### PR TITLE
Grammar Correction ("an" corrected to "a")

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,18 +29,18 @@
 <meta name="msapplication-TileImage" content="https://www.privacytools.io/img/favicons/mstile-144x144.png">
 <meta name="msapplication-config" content="https://www.privacytools.io/img/favicons/browserconfig.xml">
 <meta name="theme-color" content="#ffffff">
- 
+
 <link href="css/bootstrap.min.css" rel="stylesheet">
 <link href="css/bootstrap-theme.min.css" rel="stylesheet">
 <link href="css/font-awesome.min.css" rel="stylesheet">
-<link href="css/sortable-theme-bootstrap.css" rel="stylesheet"/> 
+<link href="css/sortable-theme-bootstrap.css" rel="stylesheet"/>
 <link href="css/custom.css?v=11" rel="stylesheet">
- 
+
 <!--[if lt IE 9]>
       <script src="js/html5shiv.min.js"></script>
       <script src="js/respond.min.js"></script>
 <![endif]-->
-    
+
 <meta property="og:title" content="privacy tools - encryption against surveillance"/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://www.privacytools.io/"/>
@@ -52,8 +52,8 @@
 </head>
 
 <body>
- 
-<!-- navigation starts here --> 
+
+<!-- navigation starts here -->
 <nav class="navbar navbar-inverse navbar-fixed-top">
 <div class="container">
 <div class="navbar-header">
@@ -98,7 +98,7 @@
 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Software<span class="caret"></span></a>
 <ul class="dropdown-menu" role="menu">
 <li><a href="#clients">Email Clients</a></li>
-<li><a href="#messaging">Email Alternatives</a></li>	
+<li><a href="#messaging">Email Alternatives</a></li>
 <li><a href="#im">Instant Messenger</a></li>
 <li><a href="#voip">Video & Voice Messenger</a></li>
 <li><a href="#pw">Password Manager</a></li>
@@ -136,7 +136,7 @@
 <li><a href="https://www.privatesearch.io/" target="_blank">Search</a></li>
 <li><a href="donate.html">Donate</a></li>
 </ul>
-</div> 
+</div>
 </div>
 </nav>
 <!-- navigation ends here -->
@@ -211,7 +211,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 5. United States of America
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -224,7 +224,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 9. Norway
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-default">
 <div class="panel-heading">
@@ -238,11 +238,11 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 14. Sweden
 </div>
 </div>
-</div> 
+</div>
 </div>
 
 <a class="anchor" name="usa"></a>
-<h3>Why is it not recommended to choose an US based service?</h3>
+<h3>Why is it not recommended to choose a US based service?</h3>
 
 <img src="img/layout/USA.png" class="img-responsive pull-right" alt="USA" style="margin-left:10px;">
 
@@ -294,7 +294,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 </tr>
 </thead>
 <tbody>
-	
+
 <tr>
 <td data-value="AirVPN"><a href="https://airvpn.org/" target="_blank"><img src="img/provider/AirVPN.gif" width="200" height="70"><br />AirVPN.org</a></td>
 <td>Italy</td>
@@ -317,7 +317,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 <td><span class="label label-success">Allowed</span></td>
 <td data-value="54">99 €</td>
 <td><a data-toggle="tooltip" data-placement="top" data-original-title="Hong Kong does not have an equivalent to America’s NSLs and is unable to legally issue a gag order. Since none of the BlackVPN team are in Hong Kong it’s difficult for them to intimidate us that way. We do not have a warrant canary as we’ve never seen one used effectively. In the worst case scenario we would simply “do a Lavabit” and hit the kill switch to shutdown all our systems until the authorities or the offender went away.">Statement</a></td>
-</tr>	
+</tr>
 
 <tr>
 <td data-value="Cryptostorm"><a href="https://cryptostorm.is/" target="_blank"><img src="img/provider/Cryptostorm.gif" width="200" height="70"><br />Cryptostorm.is</a></td>
@@ -404,7 +404,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 <td data-value="150">150 €</td>
 <td><a data-toggle="tooltip" data-placement="top" data-original-title="Since we are not bound by U.S. law, gag orders like National Security Letters do not apply to us. We would outright disclose any information of a possible problem to our users. As a last resort we would shut down our service before allowing our users to be compromised (e.g. like LavaBit).">Statement</a></td>
 </tr>
-	
+
 <tr>
 <td data-value="Proxy.sh"><a href="https://proxy.sh/" target="_blank"><img src="img/provider/Proxy.sh.gif" width="200" height="70"><br />Proxy.sh</a></td>
 <td>Seychelles</td>
@@ -430,7 +430,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 <div class="container">
 <div class="row">
 <div class="col-md-6">
-	
+
 <h3>Our VPN Provider Criteria</h3>
 <ul>
 <li>Operating outside the USA or other Five Eyes countries. <a href="https://www.bestvpn.com/the-ultimate-privacy-guide/#avoidus" target="_blank">Avoid all US and UK based services.</a></li>
@@ -439,8 +439,8 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 <li>Accepts Bitcoin, cash, debit cards or cash cards as a payment method.</li>
 <li>No personal information is required to create an account. Only username, password and <a href="#email">Email.</a></li>
 </ul>
-<p>We're not affiliated with any of the above listed VPN providers. This way can give you honest recommendations.</p>	
-	
+<p>We're not affiliated with any of the above listed VPN providers. This way can give you honest recommendations.</p>
+
 </div>
 
 <div class="col-md-6"><span class="pull-right">
@@ -455,7 +455,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 <li><a href="https://proxy.sh/panel/knowledgebase.php?action=displayarticle&id=5" target="_blank">Ethical policy - All of the reasons why Proxy.sh might enable logging</a></li>
 <li><a href="https://www.ivpn.net/privacy" target="_blank">IVPN.net will collect your email and IP address after sign up</a><br />Read the <a data-toggle="tooltip" data-placement="top" data-original-title="The IP collected at signup is only used for a few seconds by our fraud module and then discarded, it is not stored. Storing them would significantly increase our own liability and certainly would not be in our interest. You're absolutely welcome to signup using Tor or a VPN.">Email statement</a> from IVPN.</li>
 <li><a href="https://medium.com/@blackVPN/no-logs-6d65d95a3016" target="_blank">blackVPN announced to delete connection logs after disconnection</a></li>
-</ul>	
+</ul>
 </span></div>
 </div>
 </div>
@@ -500,7 +500,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 <p>OS: Windows, Mac, Linux, Android, BSD.</p>
 </div>
 </div>
-</div> 
+</div>
 
 <!-- IceCate removed
 <div class="col-sm-4">
@@ -514,7 +514,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 <p>OS: Windows, Mac, Linux, Android.</p>
 </div>
 </div>
-</div> 	
+</div>
 -->
 
 <div class="col-sm-4">
@@ -528,7 +528,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 <p>OS: Windows, Mac, Linux, <a href="https://mike.tig.as/onionbrowser/" target="_blank">iOS</a>, <a href="https://www.torproject.org/docs/android.html.en" target="_blank">Android</a>, <a href="https://github.com/torbsd/openbsd-ports" target="_blank">OpenBSD.</a></p>
 </div>
 </div>
-</div> 
+</div>
 
 </div>
 
@@ -562,7 +562,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 	<li><a href="#addons">Our Firefox privacy addons section.</a></li>
 	<li><a href="https://www.browserleaks.com/" target="_blank">BrowserLeaks.com</a> - Web browser security testing tools, that tell you what exactly personal identity data may be leaked without any permissions when you surf the Internet.</li>
 </ul>
-	
+
 
 <a class="anchor" name="webrtc"></a>
 <div class="page-header">
@@ -752,7 +752,7 @@ This is a collection of privacy related <strong>about:config</strong> tweaks. We
 </thead>
 
 <tbody>
-	
+
 <tr>
 <td data-value="OpenMailBox"><a href="https://www.openmailbox.org/" target="_blank"><img src="img/provider/OpenMailBox.gif" width="200" height="70"><br />OpenMailBox.org</a></td>
 <td data-value="2013">2013</td>
@@ -763,7 +763,7 @@ This is a collection of privacy related <strong>about:config</strong> tweaks. We
 <td><span class="label label-success">Accepted</span></td>
 <td><span class="label label-success">Built-in</span></td>
 <td><span class="label label-primary">No</span></td>
-</tr>	
+</tr>
 
 <!-- ProtonMail removed because the source was not released yet. only webmail possible at the moment.
 <tr>
@@ -790,7 +790,7 @@ This is a collection of privacy related <strong>about:config</strong> tweaks. We
 <td><span class="label label-primary">No</span></td>
 <td><span class="label label-primary">No</span></td>
 </tr>
-	
+
 <tr>
 <td data-value="Tutanota"><a href="https://www.tutanota.com/" target="_blank"><img src="img/provider/Tutanota.gif" width="200" height="70"><br />Tutanota.com</a></td>
 <td data-value="2011">2011</td>
@@ -952,7 +952,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux, BSD, Solaris, Unix.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -964,7 +964,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux, BSD.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -976,7 +976,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Chrome, Android, iOS, Web.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 
 <h3>Worth Mentioning</h3>
@@ -1002,7 +1002,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1016,7 +1016,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux, Android, F-Droid.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1028,7 +1028,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <a class="anchor" name="im"></a>
 <div class="page-header">
@@ -1049,7 +1049,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: iOS, Android, <a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging#Client_support" target="_blank">other OTR Clients.</a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1064,7 +1064,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Android, iOS.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1076,7 +1076,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Firefox, Chrome, Safari, Opera, Mac, iOS, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1113,7 +1113,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: iOS, Android.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1125,7 +1125,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: iOS, Android, Windows Phone, Linux, Windows, Mac, Browser (Web)</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1137,7 +1137,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 
 
@@ -1169,9 +1169,9 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>Client OS: Windows, Mac, Linux, iOS, Android. Server: Linux, Raspberry Pi, Windows.</p>
 </div>
 </div>
-</div> 
+</div>
 
-<!-- Cyphertite service closing: August 18th, 2015: https://blog.conformal.com/cyphertite-service-closing-august-18th-2015/ 
+<!-- Cyphertite service closing: August 18th, 2015: https://blog.conformal.com/cyphertite-service-closing-august-18th-2015/
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1183,7 +1183,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 -->
 
 <div class="col-sm-4">
@@ -1197,7 +1197,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1224,7 +1224,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>Client OS: Windows, Mac, Linux, iOS, Android. Server: Linux, Raspberry Pi, Windows.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1236,7 +1236,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux, iOS, Android.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1248,7 +1248,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1270,7 +1270,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1282,7 +1282,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1294,7 +1294,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux, Android, BSD, Solaris.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1321,7 +1321,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux, iOS, Android, BSD.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1333,9 +1333,9 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux, Android.</p>
 </div>
 </div>
-</div> 
+</div>
 
-<!-- Mitro is shutting down Aug. 31st: https://www.mitro.co/shutdown.html  
+<!-- Mitro is shutting down Aug. 31st: https://www.mitro.co/shutdown.html
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1348,7 +1348,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Firefox, Google Chrome, Safari.</p>
 </div>
 </div>
-</div> 
+</div>
 -->
 
 </div>
@@ -1384,7 +1384,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1396,7 +1396,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux, Android, BSD.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1409,7 +1409,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Linux, BSD.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1440,7 +1440,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux, Android, F-Droid.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1453,7 +1453,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: GNU/Linux, FreeBSD, NetBSD, OpenBSD, Mac, Windows.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1465,7 +1465,7 @@ Take it a step further and get control of your email with this easy-to-deploy ma
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1492,7 +1492,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="https://diasporafoundation.org/" target="_blank"><button type="button" class="btn btn-success">Website: diasporafoundation.org</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1503,7 +1503,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="http://friendica.com/" target="_blank"><button type="button" class="btn btn-info">Website: friendica.com</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1514,7 +1514,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="https://gnu.io/social/try/" target="_blank"><button type="button" class="btn btn-warning">Website: gnu.io</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 
 <h3>Worth Mentioning</h3>
@@ -1544,7 +1544,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p>OS: Cross-platform.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1556,7 +1556,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p>OS: Windows, Mac, Linux, iOS with Jailbreak.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1568,7 +1568,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p>OS: Cross-platform.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1590,7 +1590,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p>OS: Windows, Mac, Linux.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1602,7 +1602,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p>OS: Windows, Mac, GNU/Linux, FreeBSD, Browser.</p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1614,7 +1614,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p>OS: All Browsers.</p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 
 <h3>Worth Mentioning</h3>
@@ -1643,7 +1643,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="https://www.debian.org/" target="_blank"><button type="button" class="btn btn-success">Website: debian.org</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1654,7 +1654,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="http://trisquel.info/" target="_blank"><button type="button" class="btn btn-info">Website: trisquel.info</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1665,7 +1665,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="https://www.qubes-os.org/" target="_blank"><button type="button" class="btn btn-warning">Website: qubes-os.org</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1690,7 +1690,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 </p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1701,7 +1701,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="http://www.knopper.net/knoppix/" target="_blank"><button type="button" class="btn btn-info">Website: knopper.net</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1712,7 +1712,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="http://puppylinux.org/" target="_blank"><button type="button" class="btn btn-warning">Website: puppylinux.org</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1734,7 +1734,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="http://www.cyanogenmod.org/" target="_blank"><button type="button" class="btn btn-success">Website: cyanogenmod.org</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1745,7 +1745,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="http://mozilla.org/firefox/os" target="_blank"><button type="button" class="btn btn-info">Website: mozilla.org</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1756,7 +1756,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="http://www.ubuntu.com/phone" target="_blank"><button type="button" class="btn btn-warning">Website: ubuntu.com</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1777,7 +1777,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="https://openwrt.org/" target="_blank"><button type="button" class="btn btn-success">Website: openwrt.org</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-info">
 <div class="panel-heading">
@@ -1788,7 +1788,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="https://www.pfsense.org/" target="_blank"><button type="button" class="btn btn-info">Website: pfsense.org</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 <div class="col-sm-4">
 <div class="panel panel-warning">
 <div class="panel-heading">
@@ -1799,7 +1799,7 @@ diaspora* is based on three key philosophies: Decentralization, freedom and priv
 <p><a href="http://librewrt.org/" target="_blank"><button type="button" class="btn btn-warning">Website: librewrt.org</button></a></p>
 </div>
 </div>
-</div> 
+</div>
 </div>
 <h3>Worth Mentioning</h3>
 <ul>
@@ -1834,8 +1834,8 @@ I don't want to live in a society that does these sort of things... I do not wan
 	<li><a href="https://www.ivpn.net/privacy-guides" target="_blank"><strong>IVPN Privacy Guides</strong></a> - These privacy guides explain how to obtain vastly greater freedom, privacy and anonymity through compartmentalization and isolation.</li>
 	<li><a href="http://alternativeto.net/?license=opensource&platform=self-hosted&sort=likes" target="_blank"><strong>AlternativeTo.net</strong></a> - Great collection of open source online and self-hosted software sorted by likes.</li>
 	<li><a href="https://keybase.io/" target="_blank"><strong>Keybase.io</strong></a> - Get a public key, safely, starting just with someone's social media username.</li>
-	<li><a href="https://www.grc.com/securitynow.htm" target="_blank"><strong>Security Now!</strong></a> - Weekly Internet Security Podcast by Steve Gibson and Leo Laporte.</li>					
-</ul>	
+	<li><a href="https://www.grc.com/securitynow.htm" target="_blank"><strong>Security Now!</strong></a> - Weekly Internet Security Podcast by Steve Gibson and Leo Laporte.</li>
+</ul>
 
 <a class="anchor" name="participate"></a>
 <div class="page-header">
@@ -1887,9 +1887,9 @@ It's important for a website like privacytools.io to be up-to-date. Keep an eye 
 	<br>
 	View and edit our website source code on GitHub: <a href="https://github.com/privacytoolsIO/privacytools.io" target="_blank">https://github.com/privacytoolsIO/privacytools.io</a>
 </p>
-	
+
 <p>Thank you for participating. This projects needs you.</p>
-	
+
 
 <br>
 


### PR DESCRIPTION
corrected headline text “an US” to “a US”
====
Explanation:
when using the articles “a” and “an,” usage choice is governed by
pronunciation not spelling.

If the word following the article begins ***with the sound of*** a
vowel, it should be preceded by “an.”

This is a common mistake, especially in print and text.

In this case, “US” is pronounced “You-Ess,” not “Ooo-Ess.”  The
“Y-sound” is not a vowel-sound, which means it is preceded by “a.”

Hope this helps!