### PR TITLE
add a tab_undo suggestion to firefox tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -812,7 +812,7 @@ This is a collection of privacy related <strong>about:config</strong> tweaks. We
 <ul><li>Website owners can track the battery status of your device. <a href="https://www.reddit.com/r/privacytoolsIO/comments/3fzbgy/you_may_be_tracked_by_your_battery_status_of_your/" target="_blank">Source</a></li></ul>
 
 <li>browser.sessionstore.max_tabs_undo = 0</li>
-<ul><li>Even with firefox set to not remember history, your closed tabs are stored temporarily</li></ul>
+<ul><li>Even with FireFox set to not remember history, your closed tabs are stored temporarily in the History button found at Menu -> History -> Recently Closed Tabs</li></ul>
 </ol>
 
 <h3>Related Information</h3>

--- a/index.html
+++ b/index.html
@@ -810,6 +810,9 @@ This is a collection of privacy related <strong>about:config</strong> tweaks. We
 
 <li>dom.battery.enabled = false</li>
 <ul><li>Website owners can track the battery status of your device. <a href="https://www.reddit.com/r/privacytoolsIO/comments/3fzbgy/you_may_be_tracked_by_your_battery_status_of_your/" target="_blank">Source</a></li></ul>
+
+<li>browser.sessionstore.max_tabs_undo = 0</li>
+<ul><li>Even with firefox set to not remember history, your closed tabs are stored temporarily</li></ul>
 </ol>
 
 <h3>Related Information</h3>


### PR DESCRIPTION
I don't know of any way to pull this info remotely via javascript or otherwise. But it was a bit surprising to see a list of my previouslly closed tabs even while using private browsing. As seen here.

![blah](https://cloud.githubusercontent.com/assets/298426/9495224/6dc0b5d4-4bd8-11e5-8004-cc881c12c3ec.png)
