### PR TITLE
Update ProtonMail Storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -874,7 +874,7 @@ This is a collection of privacy related <strong>about:config</strong> tweaks. We
 <td data-value="ProtonMail"><a href="https://www.protonmail.ch/" target="_blank"><img src="img/provider/ProtonMail.ch.gif" width="200" height="70"><br />ProtonMail.ch</a></td>
 <td data-value="2013">2013</td>
 <td>Switzerland</td>
-<td data-value="1024">1 GB</td>
+<td data-value="500">500 MB</td>
 <td data-value="0"><span class="label label-warning">Free</span></td>
 <td><span class="label label-success">Accepted</span></td>
 <td><span class="label label-success">Built-in</span></td>


### PR DESCRIPTION
ProtonMail Storage is now 500 MB for new users during the Beta, with the possibility to request more if needed. (It is still 1 GB for users who registered before the change.)

More space will be available in the future as a premium option.

https://support.protonmail.ch/knowledge-base/increase-storage-space/