### PR TITLE
Removes Bitcoin support from Tutanota email

### DIFF
--- a/index.html
+++ b/index.html
@@ -904,7 +904,7 @@ This is a collection of privacy related <strong>about:config</strong> tweaks. We
 <td>Germany</td>
 <td data-value="1000">1 GB</td>
 <td data-value="0"><span class="label label-warning">Free</span></td>
-<td><span class="label label-success">Accepted</span></td>
+<td><span class="label label-primary">No</span></td>
 <td><span class="label label-success">Built-in</span></td>
 <td><span class="label label-success">Yes</span></td>
 </tr>


### PR DESCRIPTION
Tutanota does not accept Bitcoin as payment.