### PR TITLE
Update uBlock Origin description

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,7 +689,7 @@ Over the last 16 months, as I've debated this issue around the world, every sing
 
 <h3>Block Ads with "uBlock Origin"</h3>
 <img src="img/addons/uBlock.gif" class="img-responsive pull-left" alt="uBlock" style="margin-right:30px;">
-<p>An lightweight and efficient blocker: easy on memory and CPU footprint. The extension has no monetization strategy and development is volunteered. OS: Firefox, Safari, Opera, Chromium. AdBlock Plus is not recommended because they show "acceptable ads". The system behind that white list is lacking transparency.
+<p>An efficient <a href="https://github.com/gorhill/uBlock/wiki/Blocking-mode">wide-spectrum-blocker</a> that's easy on memory, and yet can load and enforce thousands more filters than other popular blockers out there. It has no monetization strategy and is completely <a href="https://github.com/gorhill/uBlock/">open source</a>. We recommend FireFox but uBlock Origin also works in Opera and Chromium. Unlike AdBlock Plus, uBlock does not allow so-called <a href="https://adblockplus.org/acceptable-ads">"acceptable ads"</a>.
 <br />
 <a href="https://addons.mozilla.org/firefox/addon/ublock-origin/" target="_blank">https://addons.mozilla.org/firefox/addon/ublock-origin/</a>
 </p>


### PR DESCRIPTION
In response to #44 

Before:

> An lightweight and efficient blocker: easy on memory and CPU footprint. The extension has no monetization strategy and development is volunteered. OS: Firefox, Safari, Opera, Chromium. AdBlock Plus is not recommended because they show "acceptable ads". The system behind that white list is lacking transparency. 

After:

> An efficient wide-spectrum-blocker that's easy on memory, and yet can load and enforce thousands more filters than other popular blockers out there. It has no monetization strategy and is completely open source. We recommend FireFox but uBlock Origin also works in Opera and Chromium. Unlike AdBlock Plus, uBlock does not allow so-called "acceptable ads".


Differences:

- Do not refer to browsers as _OSs_ (see #44)
- [uBlock Origin](https://github.com/gorhill/uBlock/) does not support Safari?
- AdBlock Plus is open source and they seem quite [transparent](https://adblockplus.org/acceptable-ads) (also see [this](https://adblockplus.org/blog/acceptable-ads-evolves-transparency-too)).
- I made the paragraph read more naturally

