### PR TITLE
Remove foreign link

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,8 +319,8 @@
 		<div class="alert alert-success" role="alert">
 			<strong>All providers listed here are outside the US, use encryption, accept Bitcoin, support OpenVPN and have a no logging policy.</strong>
 		</div>
-		
-<br>		
+
+<br>
 
 		<!-- START VPN TABLE -->
 
@@ -329,9 +329,9 @@
 							<tr>
 								<th data-sortable="true">Sortable VPN Providers Table</th>
 								<th data-sortable="true">Yearly Price</th>
-								<th data-sortable="true">Free Trial</th>										
+								<th data-sortable="true">Free Trial</th>
 								<th data-sortable="true" title="Number of Servers"># Servers</th>
-								<th data-sortable="true">Jurisdiction</th>								
+								<th data-sortable="true">Jurisdiction</th>
 								<th data-sortable="false">Website</th>
 							</tr>
 						</thead>
@@ -340,8 +340,8 @@
 							<tr>
 								<td data-value="AirVPN">
 									<a href="https://airvpn.org/"><img src="img/provider/AirVPN.gif" width="200" height="70"></a></td>
-								<td data-value="54">54 €</td>								
-								<td><span class="label label-success">Yes</span></td>													
+								<td data-value="54">54 €</td>
+								<td><span class="label label-success">Yes</span></td>
 								<td>162</td>
 								<td><span class="flag-icon flag-icon-it"></span> Italy</td>
 								<td><a href="https://airvpn.org/">AirVPN.org</a></td>
@@ -354,7 +354,7 @@
 								<td data-value="45">45 €</td>
 								<td><span class="label label-warning">No</span></td>
 								<td>5</td>
-								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>								
+								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>
 								<td><a href="https://www.azirevpn.com/">AzireVPN.com</a></td>
 							</tr>
 
@@ -365,7 +365,7 @@
 								<td data-value="99">99 €</td>
 								<td><span class="label label-warning">No</span></td>
 								<td>27</td>
-								<td><span class="flag-icon flag-icon-hk"></span> Hong Kong</td>								
+								<td><span class="flag-icon flag-icon-hk"></span> Hong Kong</td>
 								<td><a href="https://www.blackvpn.com/">blackVPN.com</a></td>
 							</tr>
 
@@ -374,53 +374,53 @@
 									<a href="https://cryptostorm.is/"><img src="img/provider/Cryptostorm.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="52">$ 52</td>
-								<td><span class="label label-success">Yes</span></td>								
+								<td><span class="label label-success">Yes</span></td>
 								<td>18</td>
-								<td><span class="flag-icon flag-icon-is"></span> Iceland</td>								
-								<td><a href="https://cryptostorm.is/">Cryptostorm.is</a></td>								
+								<td><span class="flag-icon flag-icon-is"></span> Iceland</td>
+								<td><a href="https://cryptostorm.is/">Cryptostorm.is</a></td>
 							</tr>
-							
+
 							<tr>
 								<td data-value="CyberGhost">
 									<a href="http://www.cyberghostvpn.com/"><img src="img/provider/CyberGhost.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="50">49,92 €</td>
-								<td><span class="label label-warning">No</span></td>								
+								<td><span class="label label-warning">No</span></td>
 								<td>691</td>
-								<td><span class="flag-icon flag-icon-ro"></span> Romania</td>								
+								<td><span class="flag-icon flag-icon-ro"></span> Romania</td>
 								<td><a href="http://www.cyberghostvpn.com/">CyberGhostVPN.com</a></td>
 							</tr>
-							
+
 							<tr>
 								<td data-value="Doublehop.me">
 									<a href="https://doublehop.me/"><img src="img/provider/Doublehop.me.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="33">$ 33</td>
-								<td><span class="label label-warning">No</span></td>								
+								<td><span class="label label-warning">No</span></td>
 								<td>6</td>
-								<td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>								
+								<td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>
 								<td><a href="https://doublehop.me/">Doublehop.me</a></td>
-							</tr>							
-							
+							</tr>
+
 							<tr>
 								<td data-value="EarthVPN">
 									<a href="http://www.earthvpn.com/"><img src="img/provider/EarthVPN.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="40">39,99 €</td>
-								<td><span class="label label-warning">No</span></td>								
+								<td><span class="label label-warning">No</span></td>
 								<td>432</td>
-								<td><span class="flag-icon flag-icon-cy"></span> Northern Cyprus</td>								
+								<td><span class="flag-icon flag-icon-cy"></span> Northern Cyprus</td>
 								<td><a href="http://www.earthvpn.com/">EarthVPN.com</a></td>
-							</tr>														
+							</tr>
 
 							<tr>
 								<td data-value="FrootVPN">
 									<a href="https://www.frootvpn.com/"><img src="img/provider/FrootVPN.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="36">$ 36</td>
-								<td><span class="label label-warning">No</span></td>							
+								<td><span class="label label-warning">No</span></td>
 								<td>27</td>
-								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>								
+								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>
 								<td><a href="https://www.frootvpn.com/">FrootVPN.com</a></td>
 							</tr>
 
@@ -429,31 +429,31 @@
 									<a href="https://hide.me/"><img src="img/provider/hide.me.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="65">$ 65</td>
-								<td><span class="label label-success">Yes</span></td>								
+								<td><span class="label label-success">Yes</span></td>
 								<td>88</td>
-								<td><span class="flag-icon flag-icon-my"></span> Malaysia</td>								
+								<td><span class="flag-icon flag-icon-my"></span> Malaysia</td>
 								<td><a href="https://hide.me/">hide.me</a></td>
 							</tr>
-							
+
 							<tr>
 								<td data-value="IVPN">
 									<a href="https://www.ivpn.net/"><img src="img/provider/IVPN.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="100">$ 100</td>
-								<td><span class="label label-success">Yes</span></td>								
+								<td><span class="label label-success">Yes</span></td>
 								<td>21</td>
-								<td><span class="flag-icon flag-icon-gi"></span> Gibraltar</td>								
+								<td><span class="flag-icon flag-icon-gi"></span> Gibraltar</td>
 								<td><a href="https://www.ivpn.net/">IVPN.net</a></td>
-							</tr>							
+							</tr>
 
 							<tr>
 								<td data-value="Mullvad">
 									<a href="https://mullvad.net/"><img src="img/provider/Mullvad.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="60">60 €</td>
-								<td><span class="label label-success">Yes</span></td>								
+								<td><span class="label label-success">Yes</span></td>
 								<td>23</td>
-								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>								
+								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>
 								<td><a href="https://mullvad.net/">Mullvad.net</a></td>
 							</tr>
 
@@ -462,31 +462,31 @@
 									<a href="https://nordvpn.com/"><img src="img/provider/NordVPN.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="48">$ 48</td>
-								<td><span class="label label-success">Yes</span></td>								
+								<td><span class="label label-success">Yes</span></td>
 								<td>475</td>
-								<td><span class="flag-icon flag-icon-pa"></span> Panama</td>								
+								<td><span class="flag-icon flag-icon-pa"></span> Panama</td>
 								<td><a href="https://nordvpn.com/">NordVPN.com</a></td>
 							</tr>
-							
+
 							<tr>
 								<td data-value="oVPN.se">
 									<a href="https://www.ovpn.se/"><img src="img/provider/oVPN.se.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="84">84 €</td>
-								<td><span class="label label-success">Yes</span></td>								
+								<td><span class="label label-success">Yes</span></td>
 								<td>24</td>
-								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>								
+								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>
 								<td><a href="https://www.ovpn.se/">oVPN.se</a></td>
-							</tr>							
+							</tr>
 
 							<tr>
 								<td data-value="Perfect Privacy">
 									<a href="https://www.perfect-privacy.com/"><img src="img/provider/Perfect-Privacy.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="150">150 €</td>
-								<td><span class="label label-warning">No</span></td>								
+								<td><span class="label label-warning">No</span></td>
 								<td>41</td>
-								<td><span class="flag-icon flag-icon-pa"></span> Panama</td>								
+								<td><span class="flag-icon flag-icon-pa"></span> Panama</td>
 								<td><a href="https://www.perfect-privacy.com/">Perfect-Privacy.com</a></td>
 							</tr>
 
@@ -495,9 +495,9 @@
 									<a href="https://privatoria.net/"><img src="img/provider/Privatoria.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="23">$ 22.8</td>
-								<td><span class="label label-success">Yes</span></td>								
+								<td><span class="label label-success">Yes</span></td>
 								<td>22</td>
-								<td><span class="flag-icon flag-icon-cz"></span> Czech Republic</td>								
+								<td><span class="flag-icon flag-icon-cz"></span> Czech Republic</td>
 								<td><a href="https://privatoria.net/">Privatoria.net</a></td>
 							</tr>
 
@@ -506,44 +506,44 @@
 									<a href="https://proxy.sh/"><img src="img/provider/Proxy.sh.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="90">$ 90</td>
-								<td><span class="label label-warning">No</span></td>								
+								<td><span class="label label-warning">No</span></td>
 								<td>300</td>
-								<td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>								
+								<td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>
 								<td><a href="https://proxy.sh/">Proxy.sh</a></td>
 							</tr>
-							
+
 							<tr>
 								<td data-value="Trust.Zone">
 									<a href="https://trust.zone/"><img src="img/provider/Trust.Zone.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="35.88">$ 35.88</td>
-								<td><span class="label label-success">Yes</span></td>								
+								<td><span class="label label-success">Yes</span></td>
 								<td>48</td>
-								<td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>								
+								<td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>
 								<td><a href="https://trust.zone/">Trust.Zone</a></td>
 							</tr>
-							
+
 							<tr>
 								<td data-value="VPN.ht">
 									<a href="https://vpn.ht/"><img src="img/provider/VPN.ht.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="40">$ 39.99</td>
-								<td><span class="label label-warning">No</span></td>								
+								<td><span class="label label-warning">No</span></td>
 								<td>122</td>
-								<td><span class="flag-icon flag-icon-hk"></span> Hong Kong</td>								
+								<td><span class="flag-icon flag-icon-hk"></span> Hong Kong</td>
 								<td><a href="https://vpn.ht/">VPN.ht</a></td>
-							</tr>	
-							
+							</tr>
+
 							<tr>
 								<td data-value="VPNTunnel">
 									<a href="https://vpntunnel.com/"><img src="img/provider/VPNTunnel.gif" width="200" height="70"></a>
 								</td>
 								<td data-value="35.88">35,88 €</td>
-								<td><span class="label label-warning">No</span></td>								
+								<td><span class="label label-warning">No</span></td>
 								<td>80</td>
-								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>								
+								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>
 								<td><a href="https://vpntunnel.com/">VPNTunnel.com</a></td>
-							</tr>																				
+							</tr>
 
 						</tbody>
 					</table>
@@ -645,7 +645,7 @@
 						<h3 class="panel-title">Mozilla Firefox</h3>
 					</div>
 					<div class="panel-body">
-						<p><img src="img/tools/Firefox.png" align="right" style="margin-left:5px;"><a href="http://www.erfahrungen.com/mit/Firefox/">Firefox</a> is fast, reliable, open source and respects your privacy. Don't forget to adjust the settings according to our
+						<p><img src="img/tools/Firefox.png" align="right" style="margin-left:5px;">Firefox is fast, reliable, open source and respects your privacy. Don't forget to adjust the settings according to our
 							recommendations: <a href="#webrtc"><span class="glyphicon glyphicon-link"></span> WebRTC</a> and <a href="#about_config"><span class="glyphicon glyphicon-link"></span> about:config</a> and get the <a href="#addons"><span class="glyphicon glyphicon-link"></span> privacy add-ons</a>.</p>
 						<p>
 							<a href="https://www.firefox.com/">


### PR DESCRIPTION
Not sure what this link was doing in the first place, but as it’s not in English (which I understand is the target audience), I think we should remove it.

Also I guess remove a tonne of white space but see line 648 for link removal.