### PR TITLE
Minor edit to 'ChatSecure' description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1515,7 +1515,7 @@
 						<h3 class="panel-title">Off-the-Record: ChatSecure</h3>
 					</div>
 					<div class="panel-body">
-						<p><img src="img/tools/ChatSecure.png" style="margin-left:5px;" align="right">ChatSecure is a free and open source messaging app that features OTR encryption over XMPP. You can connect to your existing accounts on Facebook or Google, create new accounts
+						<p><img src="img/tools/ChatSecure.png" style="margin-left:5px;" align="right">ChatSecure is a free and open source messaging app that features OTR encryption over XMPP. You can connect to your existing account on Google, create new accounts
 							on public XMPP servers (including via Tor), or even connect to your own server for extra security. ChatSecure only uses well-known open source cryptographic libraries to keep your conversations private.</p>
 						<p>
 							<a href="https://www.chatsecure.org/">


### PR DESCRIPTION
Facebook is no longer an option for ChatSecure, because they discontinued their XMPP service in April 2015. I have changed the ChatSecure description to reflect this. [Source](https://developers.facebook.com/docs/chat/).

Side note: It says that one should 'post suggestions' in the subreddit, which I do use, however I take that to mean suggestions for adding or removing software/advice, not minor edits like this. I apologize if minor edits should also be discussed in the sub.