### PR TITLE
Change Deep Web to Dark web

### DIFF
--- a/index.html
+++ b/index.html
@@ -1973,7 +1973,7 @@
 			<h1><a href="#network" class="titleanchor"><span class="glyphicon glyphicon-link"></span></a> Self-contained Networks</h1>
 		</div>
 		<div class="alert alert-warning" role="alert">
-			<strong>If you are currently browsing the <a href="https://en.wikipedia.org/wiki/Surface_Web">Clearnet</a> and you want to access the <a href="https://en.wikipedia.org/wiki/Deep_Web">Deep Web</a> this section is for you.</strong>
+			<strong>If you are currently browsing the <a href="https://en.wikipedia.org/wiki/Surface_Web">Clearnet</a> and you want to access the <a href="https://en.wikipedia.org/wiki/Dark_web">Dark web</a> this section is for you.</strong>
 		</div>
 		<div class="row">
 			<div class="col-sm-4">


### PR DESCRIPTION
Deep web != dark web

And the capitalisation was just weird.