### PR TITLE
Update Replicant and Copperhead taglines

### DIFF
--- a/index.html
+++ b/index.html
@@ -2422,8 +2422,8 @@
 		</div>
 		<h3>Worth Mentioning</h3>
 		<ul>
-			<li><a href="http://www.replicant.us/">Replicant</a> - A free and open-source operating system based on the Android, which aims to replace all proprietary Android components with their free software counterparts.</li>
-			<li><a href="https://copperhead.co/android/downloads">Copperhead</a> - Another free and open-source mobile OS based on Linux. Currently only supports a few devices, all in the Nexus line.</li>
+			<li><a href="http://www.replicant.us/">Replicant</a> - An open-source operating system based on Android, aiming to replace all proprietary components with free software.</li>
+			<li><a href="https://copperhead.co/android/downloads">Copperhead</a> - A hardened open-source operating system based on Android, available for select Nexus devices.</li>
 			<li><a href="http://omnirom.org/">OmniROM</a> - OmniROM was created in response to the perceived commercialization of CyanogenMod. The directors of Cyanogen Inc. refuse to make signature spoofing a default feature of Cyanogen OS, making it harder to stay
 				anonymous, and in particular to hide your identity from Google. OmniROM has signature spoofing enabled as a default feature. It supports more devices than Copperhead, but fewer than CyanogenMod.</li>
 		</ul>


### PR DESCRIPTION
Replicant:
- Typo "the Android"

CopperheadOS:
- Said it was based on linux, not Android. Ultimately correct, but not relevant.

Wording was a bit verbose, so I took the liberty of rewriting them based on the taglines from each project's website.