### PR TITLE
Add that Signal uses GCM and may require microG

### DIFF
--- a/index.html
+++ b/index.html
@@ -1466,7 +1466,7 @@
 								<button type="button" class="btn btn-success">iOS: apple.com</button>
 							</a>
 						</p>
-						<p>OS: Android, iOS.</p>
+						<p>OS: Android, iOS. (<a href="http://support.whispersystems.org/hc/en-us/articles/215843598-Why-GCM-Does-Google-see-my-messages-">Signal uses GCM for a wakeup event.</a> If your Android-device doesn't include Google Play Services, you may need to install <a href="https://microg.org/">microG</a> for Signal to function.)</p>
 					</div>
 				</div>
 			</div>
@@ -1549,7 +1549,7 @@
 								<button type="button" class="btn btn-success">iOS: apple.com</button>
 							</a>
 						</p>
-						<p>OS: iOS, Android.</p>
+						<p>OS: iOS, Android. (<a href="http://support.whispersystems.org/hc/en-us/articles/215843598-Why-GCM-Does-Google-see-my-messages-">Signal uses GCM for a wakeup event.</a> If your Android-device doesn't include Google Play Services, you may need to install <a href="https://microg.org/">microG</a> for Signal to function.)</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Signal uses GCM for a wakeup event: http://support.whispersystems.org/hc/en-us/articles/215843598-Why-GCM-Does-Google-see-my-messages-

If your Android-device doesn't include Google Play Services, you may need to install microG for Signal to function: https://microg.org/