### PR TITLE
remove CloudNS #80

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,7 +806,7 @@
 		<img src="img/addons/Disconnect.gif" class="img-responsive pull-left" alt="Disconnect" style="margin-right:30px;">
 		<p>Founded in 2011 by former Google engineers and a consumer-and privacy-rights attorney. The addon is open source and loads the pages you go to 27% faster and stops tracking by 2,000+ third-party sites. It also keeps your searches private. If you are planning to install "uBlock Origin" make sure to install "Disconnect" first. <strong>Alternative to Disconnect:</strong> <a href="https://addons.mozilla.org/firefox/addon/privacy-badger-firefox/">Privacy Badger by EFF</a>
 			<br />
-			<a href="https://addons.mozilla.org/firefox/addon/disconnect/">https://addons.mozilla.org/firefox/addon/disconnect/</a> 
+			<a href="https://addons.mozilla.org/firefox/addon/disconnect/">https://addons.mozilla.org/firefox/addon/disconnect/</a>
 			</p>
 
 		<h3>Block Ads with "uBlock Origin"</h3>
@@ -1417,7 +1417,7 @@
 				</div>
 			</div>
 		</div>
-		
+
 		<h3>Firefox Addon</h3>
 		<ul>
 						<li>
@@ -1891,15 +1891,15 @@
 		<ul>
 			<li><a href="https://www.youtube.com/watch?v=yzGzB-yYKcc">Edward Snowden on Passwords - YouTube</a></li>
 		</ul>
-		
+
 		<a class="anchor" name="kdl"></a>
 		<h3>Key disclosure law - Who is required to hand over the encryption keys to authorities?</h3>
 		<p>Mandatory key disclosure laws require individuals to turn over encryption keys to law enforcement conducting a criminal investigation. How these laws are implemented (who may be legally compelled to assist) vary from nation to nation, but a warrant
 			is generally required. Defenses against key disclosure laws include steganography and encrypting data in a way that provides plausible deniability.</p>
 
 		<p>Steganography involves hiding sensitive information (which may be encrypted) inside of ordinary data (for example, encrypting an image file and then hiding it in an audio file). With plausible deniability, data is encrypted in a way that prevents an
-			adversary from being able to prove that the information they are after exists (for example, one password may decrypt benign data and another password, used on the same file, could decrypt sensitive data).</p>		
-		
+			adversary from being able to prove that the information they are after exists (for example, one password may decrypt benign data and another password, used on the same file, could decrypt sensitive data).</p>
+
 		<a class="anchor" name="encrypt"></a>
 		<div class="page-header">
 			<h1><a href="#encrypt" class="titleanchor"><span class="glyphicon glyphicon-link"></span></a> File Encryption Software</h1>
@@ -2118,23 +2118,6 @@
 			<div class="col-sm-4">
 				<div class="panel panel-success">
 					<div class="panel-heading">
-						<h3 class="panel-title">CloudNS - Service</h3>
-					</div>
-					<div class="panel-body">
-						<p>An australian based security focused DNS provider. Features: DNSCrypt Support to provide confidentially and message integrity, complete trust validation of DNSSEC enabled names, namecoin resolution of .bit domain names and no domain manipulation
-							or logging.</p>
-						<p>
-							<a href="https://cloudns.com.au/">
-								<button type="button" class="btn btn-success">Website: cloudns.com.au</button>
-							</a>
-						</p>
-						<p>OS: Cross-platform.</p>
-					</div>
-				</div>
-			</div>
-			<div class="col-sm-4">
-				<div class="panel panel-info">
-					<div class="panel-heading">
 						<h3 class="panel-title">DNSCrypt - Tool</h3>
 					</div>
 					<div class="panel-body">
@@ -2150,7 +2133,7 @@
 				</div>
 			</div>
 			<div class="col-sm-4">
-				<div class="panel panel-warning">
+				<div class="panel panel-info">
 					<div class="panel-heading">
 						<h3 class="panel-title">OpenNIC - Service</h3>
 					</div>


### PR DESCRIPTION
re #80
re: https://www.privacytools.io/#dns

A couple issues here. First, they are an Australian company (Five Eyes)! Second, if you've tried to hit up their homepage since June, you were presented with an expired SSL certificate (https://cloudns.com.au/). Rookie.

How did they become the recommendation? Can we get that recommendation removed? There are plenty of other DNS and DNSCrypt providers out there.
