### PR TITLE
Change OS section order

### DIFF
--- a/index.html
+++ b/index.html
@@ -2390,6 +2390,23 @@
 			<div class="col-sm-4">
 				<div class="panel panel-success">
 					<div class="panel-heading">
+						<h3 class="panel-title">Qubes OS</h3>
+					</div>
+					<div class="panel-body">
+						<p><img src="img/tools/Qubes-OS.png" alt="Qubes OS" align="right" style="margin-left:5px;">Qubes is an open-source operating system designed to provide strong security for desktop computing. Qubes is based on Xen, the X Window System, and Linux, and
+							can run most Linux applications and utilize most of the Linux drivers.</p>
+						<p>
+							<a href="https://www.qubes-os.org/">
+								<button type="button" class="btn btn-success">Website: qubes-os.org</button>
+							</a>
+						</p>
+					</div>
+				</div>
+			</div>
+
+			<div class="col-sm-4">
+				<div class="panel panel-info">
+					<div class="panel-heading">
 						<h3 class="panel-title">Debian</h3>
 					</div>
 					<div class="panel-body">
@@ -2397,23 +2414,7 @@
 							General Public License, and packaged by a group of individuals known as the Debian project.</p>
 						<p>
 							<a href="https://www.debian.org/">
-								<button type="button" class="btn btn-success">Website: debian.org</button>
-							</a>
-						</p>
-					</div>
-				</div>
-			</div>
-			<div class="col-sm-4">
-				<div class="panel panel-info">
-					<div class="panel-heading">
-						<h3 class="panel-title">Trisquel</h3>
-					</div>
-					<div class="panel-body">
-						<p><img src="img/tools/Trisquel.png" alt="Trisquel" align="right" style="margin-left:5px;">Trisquel is a Linux-based operating system derived from Ubuntu. The project aims for a fully free software system without proprietary software or firmware and
-							uses Linux-libre, a version of the Linux kernel with the non-free code (binary blobs) removed.</p>
-						<p>
-							<a href="http://trisquel.info/">
-								<button type="button" class="btn btn-info">Website: trisquel.info</button>
+								<button type="button" class="btn btn-info">Website: debian.org</button>
 							</a>
 						</p>
 					</div>
@@ -2422,14 +2423,14 @@
 			<div class="col-sm-4">
 				<div class="panel panel-warning">
 					<div class="panel-heading">
-						<h3 class="panel-title">Qubes OS</h3>
+						<h3 class="panel-title">Trisquel</h3>
 					</div>
 					<div class="panel-body">
-						<p><img src="img/tools/Qubes-OS.png" alt="Qubes OS" align="right" style="margin-left:5px;">Qubes is an open-source operating system designed to provide strong security for desktop computing. Qubes is based on Xen, the X Window System, and Linux, and
-							can run most Linux applications and utilize most of the Linux drivers.</p>
+						<p><img src="img/tools/Trisquel.png" alt="Trisquel" align="right" style="margin-left:5px;">Trisquel is a Linux-based operating system derived from Ubuntu. The project aims for a fully free software system without proprietary software or firmware and
+							uses Linux-libre, a version of the Linux kernel with the non-free code (binary blobs) removed.</p>
 						<p>
-							<a href="https://www.qubes-os.org/">
-								<button type="button" class="btn btn-warning">Website: qubes-os.org</button>
+							<a href="http://trisquel.info/">
+								<button type="button" class="btn btn-warning">Website: trisquel.info</button>
 							</a>
 						</p>
 					</div>


### PR DESCRIPTION
Qubes should be first. Debian is just a generic distribution, whereas Qubes is about security. Also, [[1]](https://twitter.com/Snowden/status/781493632293605376) [[2]](https://www.qubes-os.org/experts/).