### PR TITLE
Fixing I2P jump link

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
 			
 			<a data-toggle="tooltip" data-placement="bottom" data-original-title="Requires specific software to access: torproject.org" href="http://privacygnk5vuzea.onion/ ">Tor</a>, 
 			
-			<a data-toggle="tooltip" data-placement="bottom" data-original-title="Requires specific software to access: geti2p.net" href="http://privacytools.i2p/?i2paddresshelper=?i2paddresshelper=wfewiqkdt5bvowfp3igmkaksjvcvwj7bag2smqpqyu5x4hges2qa.b32.i2p">I2P</a>, 
+			<a data-toggle="tooltip" data-placement="bottom" data-original-title="Requires specific software to access: geti2p.net" href="http://privacytools.i2p/?i2paddresshelper=wfewiqkdt5bvowfp3igmkaksjvcvwj7bag2smqpqyu5x4hges2qa.b32.i2p">I2P</a>, 
 			
 			<a data-toggle="tooltip" data-placement="bottom" data-original-title="Requires specific software to access: zeronet.io" href="http://127.0.0.1:43110/14gSEpfWfF5Go7u5y7UidZQCnGa6eSBYZ9/">ZeroNet</a>
 		</p>	


### PR DESCRIPTION
My comment the other day had a typo, i2paddresshelper was pasted twice somehow.

Thank you for having an i2p site :+1: 