### PR TITLE
Adding Subgraph OS in the Worth Mentioning section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2574,7 +2574,9 @@
 			<li><a href="https://www.archlinux.org/">Arch Linux</a> - A simple, lightweight Linux distribution. It is composed predominantly of free and open-source software, and supports community involvement. <a href="https://www.parabola.nu/">Parabola</a> is a
 				completely open source version of Arch Linux.</li>
 			<li><a href="https://www.whonix.org/">Whonix</a> - A Debian GNU/Linux based security-focused Linux distribution. It aims to provide privacy, security and anonymity on the internet. The operating system consists of two virtual machines, a "Workstation"
-				and a Tor "Gateway". All communication are forced through the Tor network to accomplish this..</li>
+				and a Tor "Gateway". All communication are forced through the Tor network to accomplish this.</li>
+			<li><a href="https://subgraph.com/">Subgraph OS</a> - Another Debian based Linux distribution, it features security hardening which makes it more resistant to security vulnerabilities. Subgraph runs many desktop applications in a security sandbox to limit their risk in case of compromise.
+				By default, it anonymizes Internet traffic by sending it through the Tor network. Note: It is still in alpha, and much testing and bug fixing still has to be done.</li>
 		</ul>
 
 		<a class="anchor" name="live_os"></a>


### PR DESCRIPTION
Partially solves https://github.com/privacytoolsIO/privacytools.io/issues/194

That issue should be left open to track when or whether Subgraph should switch places with Trisquel.