### PR TITLE
Update Wire entries to reflect Linux support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1514,7 +1514,7 @@
 								<button type="button" class="btn btn-info">Download: get.wire.com</button>
 							</a>
 						</p>
-						<p>OS: Android, iOS, macOS, Windows, Web</p>
+						<p>OS: Android, iOS, macOS, Windows, Linux, Web</p>
 					</div>
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -1597,7 +1597,7 @@
 								<button type="button" class="btn btn-info">Download: get.wire.com</button>
 							</a>
 						</p>
-						<p>OS: Android, iOS, macOS, Windows, Web</p>
+						<p>OS: Android, iOS, macOS, Windows, Linux, Web</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
### Description
Hi there,

I was scrolling through and I noticed that the entry for Wire (the encrypted messenger) only listed macOS and Windows for desktop OSes. However, per their [download](https://wire.com/en/download/) page, they have source code and binaries available for Linux. I've been using the Linux app (on Arch) for several months now and it works as intended.

TL;DR: Wire does in fact support Linux.


### HTML Preview

http://htmlpreview.github.io/?https://github.com/mpcsh/privacytools.io/blob/master/index.html