### PR TITLE
update VeraCrypt url

### DIFF
--- a/index.html
+++ b/index.html
@@ -1991,8 +1991,8 @@
 							or the entire storage device with pre-boot authentication. VeraCrypt is a fork of the discontinued TrueCrypt project. It was initially released on June 22, 2013. According to its developers, security improvements have been implemented and issues
 							raised by the initial TrueCrypt code audit have been addressed.</p>
 						<p>
-							<a href="https://veracrypt.codeplex.com/">
-								<button type="button" class="btn btn-success">Website: veracrypt.codeplex.com</button>
+							<a href="https://veracrypt.fr/">
+								<button type="button" class="btn btn-success">Website: veracrypt.fr</button>
 							</a>
 						</p>
 						<p>OS: Windows, Mac, Linux.</p>


### PR DESCRIPTION
### Description
CodePlex is shutting down and the VeraCrypt project is moving to veracrypt.fr.


### HTML Preview
http://htmlpreview.github.io/?https://github.com/b-harper/privacytools.io/blob/update-VeraCrypt-url/index.html
