### PR TITLE
StartMail and Ixquick.eu update

### DIFF
--- a/index.html
+++ b/index.html
@@ -1175,7 +1175,7 @@
 							<td><span class="flag-icon flag-icon-nl"></span> Netherlands</td>
 							<td data-value="10000">10 GB</td>
 							<td data-value="60">$ 59.95</td>
-							<td data-value="0"><span class="label label-primary">No</span></td>
+							<td data-value="0"><span class="label label-primary">Accepted</span></td>
 							<td data-value="1"><span class="label label-success">Built-in</span></td>
 							<td data-value="0"><span class="label label-success">Yes</span></td>
 						</tr>
@@ -1455,8 +1455,7 @@
 			</li>
 
 			<li>
-				<a href="https://www.ixquick.eu/">ixquick.eu</a> - Returns the top ten results from multiple search engines. Based in the
-				USA and the Netherlands.
+				<a href="https://www.ixquick.eu/">ixquick.eu</a> - Returns the top results from multiple search engines. Based in the Netherlands.
 			</li>
 		</ul>
 


### PR DESCRIPTION
**Email section: StartMail now accepts Bitcoin. Changed to "Accepted"**

Information to support change: https://support.startmail.com/index.php?/Knowledgebase/Article/View/65/0/bitcoin

This closes privacytoolsIO/privacytools.io#226.

**Search Engine section, worth mentioning:**

Currently, Ixquick.eu is a "worth mentioning" with the following description: 

_ixquick.eu - Returns the top ten results from multiple search engines. Based in the USA and the Netherlands._ 

Updated to the following in the pull request:

ixquick.eu - Returns the top results from multiple search engines. Based in the Netherlands.

**Information to support the change:**

Ixquick.eu is based in the Netherlands only. Not the US. (Ixquick
originated in the US, but was acquired by Surfboard Holding B.V, a
privately held Dutch corporation, in 2000. It is based in the
Netherlands, outside of US jurisdiction.)