### PR TITLE
Mention that Wire stores metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -1501,7 +1501,9 @@
 					</div>
 					<div class="panel-body">
 						<p><img src="img/tools/wire.png" alt="WIRE SWISS GmbH" align="right" style="margin-left:5px;">Wire is an app developed by Wire Swiss GmbH.
-       The Wire app allows users to exchange end-to-end encrypted instant messages, as well as make voice and video calls. Wire is free and open source, enabling anyone to verify its security by auditing the code. The development team is backed by Iconical and they will monetize in the future with premium features/services.</p>
+							The Wire app allows users to exchange end-to-end encrypted instant messages, as well as make voice and video calls. Wire is free and open source, enabling anyone to verify its security by auditing the code. 
+							The development team is backed by Iconical and they will monetize in the future with premium features/services. 
+							Caution: The company keeps a list of all the users you contact until you delete your account.</p>
 						<p>
 							<a href="https://get.wire.com">
 								<button type="button" class="btn btn-info">Download: get.wire.com</button>
@@ -1585,7 +1587,9 @@
 					</div>
 					<div class="panel-body">
 						<p><img src="img/tools/wire.png" alt="WIRE SWISS GmbH" align="right" style="margin-left:5px;">Wire is a app developed by Wire Swiss GmbH.
-       The Wire app allows users to exchange end-to-end encrypted instant messages, as well as make voice and video calls. Wire is free and open source, enabling anyone to verify its security by auditing the code. The development team is backed by Iconical and they will monetize in the future with premium features/services.</p>
+							The Wire app allows users to exchange end-to-end encrypted instant messages, as well as make voice and video calls. Wire is free and open source, enabling anyone to verify its security by auditing the code. 
+							The development team is backed by Iconical and they will monetize in the future with premium features/services. 
+							Caution: The company keeps a list of all the users you contact until you delete your account.</p>
 						<p>
 							<a href="https://get.wire.com">
 								<button type="button" class="btn btn-info">Download: get.wire.com</button>

--- a/index.html
+++ b/index.html
@@ -1502,7 +1502,7 @@
 					<div class="panel-body">
 						<p><img src="img/tools/wire.png" alt="WIRE SWISS GmbH" align="right" style="margin-left:5px;">Wire is an app developed by Wire Swiss GmbH.
 							The Wire app allows users to exchange end-to-end encrypted instant messages, as well as make voice and video calls. Wire is free and open source, enabling anyone to verify its security by auditing the code. 
-							The development team is backed by Iconical and they will monetize in the future with premium features/services. 
+							The development team is backed by Iconical and they will monetize in the future with premium features/services.<br> 
 							Caution: The company keeps a list of all the users you contact until you delete your account.</p>
 						<p>
 							<a href="https://get.wire.com">
@@ -1588,7 +1588,7 @@
 					<div class="panel-body">
 						<p><img src="img/tools/wire.png" alt="WIRE SWISS GmbH" align="right" style="margin-left:5px;">Wire is a app developed by Wire Swiss GmbH.
 							The Wire app allows users to exchange end-to-end encrypted instant messages, as well as make voice and video calls. Wire is free and open source, enabling anyone to verify its security by auditing the code. 
-							The development team is backed by Iconical and they will monetize in the future with premium features/services. 
+							The development team is backed by Iconical and they will monetize in the future with premium features/services.<br> 
 							Caution: The company keeps a list of all the users you contact until you delete your account.</p>
 						<p>
 							<a href="https://get.wire.com">

--- a/index.html
+++ b/index.html
@@ -1500,7 +1500,7 @@
 						<h3 class="panel-title">Wire</h3>
 					</div>
 					<div class="panel-body">
-						<p><img src="img/tools/wire.png" alt="WIRE SWISS GmbH" align="right" style="margin-left:5px;">Wire is an app developed by <a href="https://wire.com">WIRE SWISS GmbH</a>.
+						<p><img src="img/tools/wire.png" alt="WIRE SWISS GmbH" align="right" style="margin-left:5px;">Wire is an app developed by Wire Swiss GmbH.
        The Wire app allows users to exchange end-to-end encrypted instant messages, as well as make voice and video calls. Wire is free and open source, enabling anyone to verify its security by auditing the code. The development team is backed by Iconical and they will monetize in the future with premium features/services.</p>
 						<p>
 							<a href="https://get.wire.com">
@@ -1535,7 +1535,7 @@
 		</div>
 		<h3>Worth Mentioning</h3>
 		<ul>
-   <li><a href="https://www.chatsecure.org">ChatSecure</a> - ChatSecure is a free and open source messaging app that features OTR encryption over XMPP. </li>
+   			<li><a href="https://www.chatsecure.org">ChatSecure</a> - ChatSecure is a free and open source messaging app that features OTR encryption over XMPP. </li>
 			<li><a href="https://crypto.cat/">Cryptocat</a> - Encrypted open source messenger. Supports file sharing and multiple devices. Available for Windows, Linux and Mac.</li>
 			<li><a href="http://kontalk.org/">Kontalk</a> - A community-driven instant messaging network. Supports end-to-end encryption. Both client-to-server and server-to-server channels are fully encrypted.</li>
 			<li><a href="https://play.google.com/store/apps/details?id=eu.siacs.conversations">Conversations</a> - An open source Jabber/XMPP client for Android 4.0+ smart phones. Supports end-to-end encryption with either OMEMO, OTR or openPGP.</li>
@@ -1547,6 +1547,7 @@
 			<li><a href="https://motherboard.vice.com/read/ricochet-encrypted-messenger-tackles-metadata-problem-head-on">Ricochet, the Messenger That Beats Metadata, Passes Security Audit | Motherboard</a></li>
 			<li><a href="https://firstlook.org/theintercept/2015/07/14/communicating-secret-watched/">Chatting in Secret While We're All Being Watched - firstlook.org</a></li>
 			<li><a href="https://signal.org/android/apk/">Advanced users with special needs can download the Signal APK directly. Most users should not do this under normal circumstances.</a></li>
+			<li><a href="https://motherboard.vice.com/en_us/article/secure-messaging-app-wire-stores-everyone-youve-ever-contacted-in-plain-text">Secure Messaging App Wire Stores Everyone You've Ever Contacted in Plain Text | Motherboard</a></li>
 		</ul>
 
 		<a class="anchor" name="voip"></a>
@@ -1583,7 +1584,7 @@
 						<h3 class="panel-title">Wire</h3>
 					</div>
 					<div class="panel-body">
-						<p><img src="img/tools/wire.png" alt="WIRE SWISS GmbH" align="right" style="margin-left:5px;">Wire is a app developed by <a href="https://wire.com">WIRE SWISS GmbH</a>.
+						<p><img src="img/tools/wire.png" alt="WIRE SWISS GmbH" align="right" style="margin-left:5px;">Wire is a app developed by Wire Swiss GmbH.
        The Wire app allows users to exchange end-to-end encrypted instant messages, as well as make voice and video calls. Wire is free and open source, enabling anyone to verify its security by auditing the code. The development team is backed by Iconical and they will monetize in the future with premium features/services.</p>
 						<p>
 							<a href="https://get.wire.com">
@@ -1626,6 +1627,7 @@
 		<h3>Related Information</h3>
 		<ul>
 			<li><a href="https://signal.org/android/apk/">Advanced users with special needs can download the Signal APK directly. Most users should not do this under normal circumstances.</a></li>
+			<li><a href="https://motherboard.vice.com/en_us/article/secure-messaging-app-wire-stores-everyone-youve-ever-contacted-in-plain-text">Secure Messaging App Wire Stores Everyone You've Ever Contacted in Plain Text | Motherboard</a></li>
 		</ul>
 
 		<a class="anchor" name="cloud"></a>


### PR DESCRIPTION
### Description

Added links to a Motherboard article to the Related Information sections under Encrypted Instant Messengers and  Encrypted Video & Voice. Adding a disclaimer was also proposed by [a user on Reddit](https://www.reddit.com/r/privacytoolsIO/comments/6auj04/secure_messaging_app_wire_stores_everyone_youve/dhhldfw/?context=3
): "I'd just put a disclaimer ln the site. It really depends on your threat model, but I do think that Wire should find a way to encrypt that data."

I also made some minor aesthetic improvements, like indenting the line about ChatSecure and removing an unnecessary link from Wire's description.

### HTML Preview

http://htmlpreview.github.io/?https://github.com/NinebitX/privacytools.io/blob/patch-1/index.html
