### PR TITLE
Update Monero's website to include .org

### DIFF
--- a/index.html
+++ b/index.html
@@ -2143,7 +2143,7 @@
 						<p><img src="img/tools/Monero.png" alt="Monero" align="right" style="margin-left:5px;">Monero focuses strictly on protecting user's privacy and mandates all transactions are private by default. Monero is open-source, completely decentralized and has three layers of privacy through Ring Signatures, Ring Confidential Transactions and Stealth Addresses.</p>
 						<p>
 							<a href="https://getmonero.org/">
-								<button type="button" class="btn btn-success">Website: getmonero</button>
+								<button type="button" class="btn btn-success">Website: getmonero.org</button>
 							</a>
 						</p>
 						<p>OS: Windows, Mac, Linux.</p>


### PR DESCRIPTION
To be on par with the other websites' addresses, update the name on the button from "Website: getmonero" to "Website: getmonero.org"

### HTML Preview

http://htmlpreview.github.io/?https://github.com/hugoncosta/privacytools.io/blob/master/index.html
