### PR TITLE
(Re)add Privacy Badger

### DIFF
--- a/index.html
+++ b/index.html
@@ -847,13 +847,13 @@
 			<br />
 			<a href="https://addons.mozilla.org/firefox/addon/disconnect/">https://addons.mozilla.org/firefox/addon/disconnect/</a>
 			</p>
--->
+
 		<h3>Hinder Browser Fingerprinting with "Random Agent Spoofer"</h3>
 		<img src="img/addons/Random-Agent-Spoofer.gif" class="img-responsive pull-left" alt="Random Agent Spoofer" style="margin-right:30px;">
 		<p>A privacy enhancing firefox addon which aims to hinder browser fingerprinting. It does this by changing the browser/device profile on a timer. Source code: <a href="https://github.com/dillbyrne/random-agent-spoofer">GitHub.</a>
 			<br />
 			<a href="https://addons.mozilla.org/firefox/addon/random-agent-spoofer/">https://addons.mozilla.org/firefox/addon/random-agent-spoofer/</a></p>
--->			
+		-->			
 
 		<h3>Automatically Delete Cookies with "Self-Destructing Cookies"</h3>
 		<img src="img/addons/Self-Destructing-Cookies.gif" class="img-responsive pull-left" alt="Self-Destructing Cookies" style="margin-right:30px;">

--- a/index.html
+++ b/index.html
@@ -833,22 +833,15 @@
 		</div>
 
 
-		<!--
+		
 		<h3>Stop tracking with "Disconnect"</h3>
 
 		<img src="img/addons/Privacy-Badger.gif" class="img-responsive pull-left" alt="Privacy Badger" style="margin-right:30px;">
 		<p><strong>Privacy Badger</strong> is a browser add-on that stops advertisers and other third-party trackers from secretly tracking where you go and what pages you look at on the web. Privacy Badger automatically blocks that advertiser from loading any more content in your browser.
 		<br />
-		<a href="https://addons.mozilla.org/firefox/addon/privacy-badger-firefox/">https://addons.mozilla.org/firefox/addon/privacy-badger-firefox/</a></p>
+		<a href="https://www.eff.org/privacybadger">https://www.eff.org/privacybadger</a></p>
 		<br />
 
-
-		<img src="img/addons/Disconnect.gif" class="img-responsive pull-left" alt="Disconnect" style="margin-right:30px;">
-		<p>Founded in 2011 by former Google engineers and a consumer-and privacy-rights attorney. The addon is open source and loads the pages you go to 27% faster and stops tracking by 2,000+ third-party sites. It also keeps your searches private. If you are planning to install "uBlock Origin" make sure to install "Disconnect" first. <strong>Alternative to Disconnect:</strong> <a href="https://addons.mozilla.org/firefox/addon/privacy-badger-firefox/">Privacy Badger by EFF</a>
-			<br />
-			<a href="https://addons.mozilla.org/firefox/addon/disconnect/">https://addons.mozilla.org/firefox/addon/disconnect/</a>
-			</p>
--->
 		<h3>Block Ads and Trackers with "uBlock Origin"</h3>
 		<img src="img/addons/uBlock.gif" class="img-responsive pull-left" alt="uBlock" style="margin-right:30px;">
 		<p>An efficient <a href="https://github.com/gorhill/uBlock/wiki/Blocking-mode">wide-spectrum-blocker</a> that's easy on memory, and yet can load and enforce thousands more filters than other popular blockers out there. It has no monetization strategy and

--- a/index.html
+++ b/index.html
@@ -834,23 +834,20 @@
 
 
 		
-		<h3>Stop tracking with "Disconnect"</h3>
-
+		<h3>Stop Tracking with "Privacy Badger"</h3>
 		<img src="img/addons/Privacy-Badger.gif" class="img-responsive pull-left" alt="Privacy Badger" style="margin-right:30px;">
-		<p><strong>Privacy Badger</strong> is a browser add-on that stops advertisers and other third-party trackers from secretly tracking where you go and what pages you look at on the web. Privacy Badger automatically blocks that advertiser from loading any more content in your browser.
+		<p><strong>Privacy Badger</strong> is a browser add-on that stops advertisers and other third-party trackers from secretly tracking where you go and what pages you look at on the web. Privacy Badger learns about trackers as you browse by inspecting external resources websites request.
 		<br />
-		<a href="https://www.eff.org/privacybadger">https://www.eff.org/privacybadger</a></p>
+		<a href="https://www.eff.org/privacybadger">https://www.eff.org/privacybadger/</a></p>
 		<br />
 
-		<h3>Block Ads and Trackers with "uBlock Origin"</h3>
-		<img src="img/addons/uBlock.gif" class="img-responsive pull-left" alt="uBlock" style="margin-right:30px;">
-		<p>An efficient <a href="https://github.com/gorhill/uBlock/wiki/Blocking-mode">wide-spectrum-blocker</a> that's easy on memory, and yet can load and enforce thousands more filters than other popular blockers out there. It has no monetization strategy and
-			is completely <a href="https://github.com/gorhill/uBlock/">open source</a>. We recommend Firefox but uBlock Origin also works in other browsers such as Safari, Opera, and Chromium. Unlike AdBlock Plus, uBlock does not allow so-called <a href="https://adblockplus.org/acceptable-ads">"acceptable ads"</a>.
+		<!--
+		<img src="img/addons/Disconnect.gif" class="img-responsive pull-left" alt="Disconnect" style="margin-right:30px;">
+		<p>Founded in 2011 by former Google engineers and a consumer-and privacy-rights attorney. The addon is open source and loads the pages you go to 27% faster and stops tracking by 2,000+ third-party sites. It also keeps your searches private. If you are planning to install "uBlock Origin" make sure to install "Disconnect" first. <strong>Alternative to Disconnect:</strong> <a href="https://addons.mozilla.org/firefox/addon/privacy-badger-firefox/">Privacy Badger by EFF</a>
 			<br />
-			<a href="https://addons.mozilla.org/firefox/addon/ublock-origin/">https://addons.mozilla.org/firefox/addon/ublock-origin/</a>
-		</p>
-
-<!--
+			<a href="https://addons.mozilla.org/firefox/addon/disconnect/">https://addons.mozilla.org/firefox/addon/disconnect/</a>
+			</p>
+-->
 		<h3>Hinder Browser Fingerprinting with "Random Agent Spoofer"</h3>
 		<img src="img/addons/Random-Agent-Spoofer.gif" class="img-responsive pull-left" alt="Random Agent Spoofer" style="margin-right:30px;">
 		<p>A privacy enhancing firefox addon which aims to hinder browser fingerprinting. It does this by changing the browser/device profile on a timer. Source code: <a href="https://github.com/dillbyrne/random-agent-spoofer">GitHub.</a>


### PR DESCRIPTION
I changed the link to the eff official link, giving the user the ability to choose download the correct version for his browser directly. See #244 

### HTML Preview

http://htmlpreview.github.io/?https://github.com/hugoncosta/privacytools.io/blob/patch-2/index.html
