### PR TITLE
Update Zcash description

### DIFF
--- a/index.html
+++ b/index.html
@@ -2246,7 +2246,7 @@ switch(document.readyState){case'complete':case'loaded':case'interactive':onDomC
 						<h3 class="panel-title">Zcash</h3>
 					</div>
 					<div class="panel-body">
-						<p><img src="img/tools/Zcash.png" alt="Zcash" align="right" style="margin-left:5px;">Zcash offers total payment confidentiality, while still maintaining a decentralized network using a public blockchain. Unlike Bitcoin, Zcash supports fully shielded transactions, which hide the sender, recipient, and value. <b>Caution: </b> Zcash does not provide payment anonymity by default: Zcash has two types of addresses, users need to generate a "z-addr" to enable the privacy feature, t-addresses are as public as Bitcoin addresses.</p>
+						<p><img src="img/tools/Zcash.png" alt="Zcash" align="right" style="margin-left:5px;">Zcash offers total payment confidentiality, while still maintaining a decentralized network using a public blockchain. Unlike Bitcoin, Zcash supports fully shielded transactions, which hide the sender, recipient, and value. <b>Caution: </b> Zcash does not enable this feature by default: Use z-addresses for anonymity.</p>
 						<p>
 							<a href="https://www.z.cash/">
 								<button type="button" class="btn btn-info">Website: z.cash</button>

--- a/index.html
+++ b/index.html
@@ -2246,7 +2246,7 @@ switch(document.readyState){case'complete':case'loaded':case'interactive':onDomC
 						<h3 class="panel-title">Zcash</h3>
 					</div>
 					<div class="panel-body">
-						<p><img src="img/tools/Zcash.png" alt="Zcash" align="right" style="margin-left:5px;">Zcash offers total payment confidentiality, while still maintaining a decentralized network using a public blockchain. Unlike Bitcoin, Zcash supports fully shielded transactions, which hide the sender, recipient, and value.</p>
+						<p><img src="img/tools/Zcash.png" alt="Zcash" align="right" style="margin-left:5px;">Zcash offers total payment confidentiality, while still maintaining a decentralized network using a public blockchain. Unlike Bitcoin, Zcash supports fully shielded transactions, which hide the sender, recipient, and value. <b>Caution: </b> Zcash does not provide payment anonymity by default: Zcash has two types of addresses, users need to generate a "z-addr" to enable the privacy feature, t-addresses are as public as Bitcoin addresses.</p>
 						<p>
 							<a href="https://www.z.cash/">
 								<button type="button" class="btn btn-info">Website: z.cash</button>


### PR DESCRIPTION
### Description

Updated Zcash description to include a caution to highlight the fact that the privacy feature of Zcash is not automatic and requires users to generate a z-addr. Although some service providers like Shapeshift [support z-addr](https://twitter.com/ShapeShift_io/status/857639222487994368), the majority of pools, light wallets, and exchanges only use t-addr, so new users should be warned of the difference.

### [HTML Preview](https://htmlpreview.github.io/?https://github.com/alvinjoelsantos/privacytools.io/blob/zcash-caution/index.html)
