### PR TITLE
Adding a Content Security Policy and Referrer Policy to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
 	<meta name="keywords" content="privacy, anonymity, privacy tools, surveillance, encryption, edward snowden, nsa, tor, bitcoin">
 	<meta name="description" content="You are being watched! Knowledge, encryption and privacy tools to protect you against global mass surveillance.">
 
+	<!-- content security policy -->
+	<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
+
 	<!-- title -->
 	<title>Privacy Tools - Encryption Against Global Mass Surveillance</title>
 

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
 	<!-- content security policy -->
 	<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
 
+	<!-- referrer policy -->
+	<meta http-equiv="Referrer-Policy" content="no-referrer">
+
 	<!-- title -->
 	<title>Privacy Tools - Encryption Against Global Mass Surveillance</title>
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 	<meta name="description" content="You are being watched! Knowledge, encryption and privacy tools to protect you against global mass surveillance.">
 
 	<!-- content security policy -->
-	<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
+	<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src https:; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
 
 	<!-- referrer policy -->
 	<meta http-equiv="Referrer-Policy" content="no-referrer">


### PR DESCRIPTION
### Description

Adding a Content Security Policy, which you can read about [here](https://scotthelme.co.uk/content-security-policy-an-introduction/), and for implementing it on [GitHub pages](https://qszhuan.github.io/technology/2015/08/12/add_csp_to_github_blog).

```
<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
```

Referrer policy (see [here](https://wiki.mozilla.org/Security/Guidelines/Web_Security#Referrer_Policy)):

```
<meta http-equiv="Referrer-Policy" content="no-referrer">
```

### HTML Preview

http://htmlpreview.github.io/?https://github.com/C-O-M-P-A-R-T-M-E-N-T-A-L-I-Z-A-T-I-O-N/privacytools.io/blob/patch-2/index.html
