### PR TITLE
Adding CSP and RP to donate.html

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Donate - privacytools.io</title>
-<link href="css/bootstrap.min.css" rel="stylesheet">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-<link rel="shortcut icon" href="favicon.ico" type="image/ico">
+	<title>Donate - privacytools.io</title>
+	<link href="css/bootstrap.min.css" rel="stylesheet">
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+	<link rel="shortcut icon" href="favicon.ico" type="image/ico">
+	<!-- content security policy -->
+	<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
 </head>
 <body>
 

--- a/donate.html
+++ b/donate.html
@@ -8,6 +8,8 @@
 	<link rel="shortcut icon" href="favicon.ico" type="image/ico">
 	<!-- content security policy -->
 	<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
+	<!-- referrer policy -->
+	<meta http-equiv="Referrer-Policy" content="no-referrer">
 </head>
 <body>
 

--- a/donate.html
+++ b/donate.html
@@ -7,7 +7,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 	<link rel="shortcut icon" href="favicon.ico" type="image/ico">
 	<!-- content security policy -->
-	<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
+	<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src https:; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
 	<!-- referrer policy -->
 	<meta http-equiv="Referrer-Policy" content="no-referrer">
 </head>


### PR DESCRIPTION
### Description

Adding a Content Security Policy, which you can read about [here](https://scotthelme.co.uk/content-security-policy-an-introduction/), and for implementing it on [GitHub pages](https://qszhuan.github.io/technology/2015/08/12/add_csp_to_github_blog).

```
<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
```


Referrer policy (see [here](https://wiki.mozilla.org/Security/Guidelines/Web_Security#Referrer_Policy)):

```
<meta http-equiv="Referrer-Policy" content="no-referrer">
```

### HTML Preview

http://htmlpreview.github.io/?https://github.com/C-O-M-P-A-R-T-M-E-N-T-A-L-I-Z-A-T-I-O-N/privacytools.io/blob/master/donate.html
