### PR TITLE
Adding a CSP and RP to password.html

### DIFF
--- a/password.html
+++ b/password.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <!-- content security policy -->
   <meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
-	<!-- referrer policy -->
-	<meta http-equiv="Referrer-Policy" content="no-referrer">
+  <!-- referrer policy -->
+  <meta http-equiv="Referrer-Policy" content="no-referrer">
   <link href="css/bootstrap.min.css" rel="stylesheet">
   <style>
     .container {

--- a/password.html
+++ b/password.html
@@ -5,6 +5,8 @@
   <meta charset="UTF-8">
   <title>Secure Password Generator | Privacy Tools</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <!-- content security policy -->
+  <meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
   <link href="css/bootstrap.min.css" rel="stylesheet">
   <style>
     .container {

--- a/password.html
+++ b/password.html
@@ -7,6 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <!-- content security policy -->
   <meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
+	<!-- referrer policy -->
+	<meta http-equiv="Referrer-Policy" content="no-referrer">
   <link href="css/bootstrap.min.css" rel="stylesheet">
   <style>
     .container {

--- a/password.html
+++ b/password.html
@@ -6,7 +6,7 @@
   <title>Secure Password Generator | Privacy Tools</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <!-- content security policy -->
-  <meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
+  <meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src https:; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
   <!-- referrer policy -->
   <meta http-equiv="Referrer-Policy" content="no-referrer">
   <link href="css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
### Description

Adding a Content Security Policy, which you can read about [here](https://scotthelme.co.uk/content-security-policy-an-introduction/), and for implementing it on [GitHub pages](https://qszhuan.github.io/technology/2015/08/12/add_csp_to_github_blog).

```
<meta http-equiv='Content-Security-Policy' content="Content-Security-Policy: default-src 'none'; script-src https://privacytoolsio.github.io"; style-src 'unsafe-inline'>
```

Referrer policy (see [here](https://wiki.mozilla.org/Security/Guidelines/Web_Security#Referrer_Policy)):

```
<meta http-equiv="Referrer-Policy" content="no-referrer">
```

### HTML Preview

http://htmlpreview.github.io/?https://github.com/C-O-M-P-A-R-T-M-E-N-T-A-L-I-Z-A-T-I-O-N/privacytools.io/blob/patch-4/password.html
