### PR TITLE
Adding `privacy.resistFingerprinting` and `privacy.firstparty.isolate` documentation for about:config tweaks for FF (Issue: 272)

### DIFF
--- a/index.html
+++ b/index.html
@@ -952,6 +952,16 @@
 			<ul>
 				<li>This is Mozilla’s new built in tracking protection. It uses Disconnect.me filter list, which is redundant if you are already using uBlock Origin 3rd party filters, therefore you should set it to false if you are using the add-on functionalities.</li>
 			</ul>
+			
+			<li>privacy.resistFingerprinting = true</li>
+			<ul>
+				<li>A result of the <a href="https://wiki.mozilla.org/Security/Tor_Uplift">Tor Uplift</a> effort, this preference makes Firefox more resistant to browser fingerprinting.</li>
+			</ul>
+
+			<li>privacy.firstparty.isolate = true</li>
+			<ul>
+				<li>A result of the <a href="https://wiki.mozilla.org/Security/Tor_Uplift">Tor Uplift</a> effort, this preference isolates all browser identifier sources (e.g. cookies) to the first party domain, with the goal of preventing tracking across different domains.</li>
+			</ul>
 
 			<li>geo.enabled = false</li>
 			<ul>


### PR DESCRIPTION
### Description

Adding `privacy.resistFingerprinting` and `privacy.firstparty.isolate` documentation for about:config tweaks for Firefox. Partially addresses issue: https://github.com/privacytoolsIO/privacytools.io/issues/272

### HTML Preview

http://htmlpreview.github.io/?https://github.com/C-O-M-P-A-R-T-M-E-N-T-A-L-I-Z-A-T-I-O-N/privacytools.io/blob/patch-6/index.html

(don't be alarmed by the lack of styling, it's a result of the CSP policy.)