### PR TITLE
Remove bad email providers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1190,22 +1190,6 @@
 						</tr>
 
 						<tr>
-							<td data-value="CounterMail">
-								<img src="img/provider/CounterMail.gif" width="200" height="70">
-							</td>
-							<td>
-								<a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.countermail.com" href="https://www.countermail.com"><img src="img/layout/www.svg" width="35"></img></a>
-							</td>
-							<td data-value="2010">2010</td>
-							<td><span class="flag-icon flag-icon-se"></span> Sweden</td>
-							<td data-value="500">500 MB</td>
-							<td data-value="59">$ 59</td>
-							<td data-value="1"><span class="label label-success">Accepted</span></td>
-							<td data-value="1"><span class="label label-success">Built-in</span></td>
-							<td data-value="1"><span class="label label-success">Yes</span></td>
-						</tr>
-
-						<tr>
 							<td data-value="StartMail">
 								<img src="img/provider/StartMail.gif" width="200" height="70">
 							</td>
@@ -1234,22 +1218,6 @@
 							<td data-value="60">$ 60</td>
 							<td data-value="1"><span class="label label-success">Accepted</span></td>
 							<td data-value="0"><span class="label label-primary">No</span></td>
-							<td data-value="1"><span class="label label-success">Yes</span></td>
-						</tr>
-
-						<tr>
-							<td data-value="CryptoHeaven">
-								<img src="img/provider/CryptoHeaven.gif" width="200" height="70">
-							</td>
-							<td>
-								<a data-toggle="tooltip" data-placement="bottom" data-original-title="http://www.cryptoheaven.com" href="http://www.cryptoheaven.com"><img src="img/layout/www.svg" width="35"></img></a>
-							</td>
-							<td data-value="2001">2001</td>
-							<td><span class="flag-icon flag-icon-ca"></span> Canada</td>
-							<td data-value="200">200 MB</td>
-							<td data-value="66">$ 66</td>
-							<td data-value="0"><span class="label label-primary">No</span></td>
-							<td data-value="1"><span class="label label-success">Built-in</span></td>
 							<td data-value="1"><span class="label label-success">Yes</span></td>
 						</tr>
 			</tbody>


### PR DESCRIPTION
### Description

CryptoHeaven doesn't use HTTPS, CounterMail requires Java to even register.

### HTML Preview

http://htmlpreview.github.io/?https://github.com/privacytoolsIO/privacytools.io/blob/Shifterovich-email-patch/index.html
