### PR TITLE
Remove darknet mirrors

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,14 +191,6 @@
 			<span class="flag-icon flag-icon-es" style="margin-left:5px;"></span> <a href="https://victorhck.gitlab.io/privacytools-es/">Español</a>
 			
 			<span class="flag-icon flag-icon-de" style="margin-left:5px;"></span> <a href="https://privacytools.it-sec.rocks/">Deutsch</a>
-
-			<span style="margin-left:15px;">Darknet:</span>
-			
-			<a data-toggle="tooltip" data-placement="bottom" data-original-title="Requires specific software to access: torproject.org" href="http://privacyh3rsehm64.onion/">Tor</a>, 
-			
-			<a data-toggle="tooltip" data-placement="bottom" data-original-title="Requires specific software to access: geti2p.net" href="http://privacytools.i2p/?i2paddresshelper=5GOHmoHjcG3c55VitD6OZmDHFpDfetZkwsgLUsq4EgM5SgJIFYYgxeDXFLJSrrUxjgD70bC-ZUKzGZ-hf8l4RUUrM7aUGCSC3Yk~tAZMIVMni6hDCw269GQRJUYrOeGX9Ufze2ln~gWssUsH8BErV1HHJ-FS2oKQZYR-rROEGRJ3ptR5LiZmsKgfcObU3Y4pBfK~yq9s~V7XV-7YD8v8eEjiEeyBVKKddeoguj~Uq9N2NsR4rm~FclpAZi2HS50wD4Ph96di7DxgKdk96uDHFeIQJzvdK6VPuvuX6jZUA-LVbwlnLM~~mh4hv5jT7w~KaJPkTFWRRO1~lrrhiS4WLjjBnhfAty7PZ4W4GSuJKPPGhLPF65Yz7Ji--T3p2ZLLkpjPbNpgokNAKHfOkr~uR7F1rjnkcRTi3ZzYciiALCJNwNgLEOXowuAbdLyM5GO3gXm27~PZpsttxvCBlHkmD8L2xinybADaDvrAe3ReWbi9zd9WMGm5zc2sfZ1G~1E1BQAEAAEAAA%3d%3d">I2P</a>, 
-			
-			<a data-toggle="tooltip" data-placement="bottom" data-original-title="Requires specific software to access: zeronet.io" href="http://127.0.0.1:43110/14gSEpfWfF5Go7u5y7UidZQCnGa6eSBYZ9/">ZeroNet</a>
 		</p>	
 <!-- end language and darknet selection -->
 


### PR DESCRIPTION
### Description

They're currently offline.

### HTML Preview

http://htmlpreview.github.io/?https://github.com/privacytoolsIO/privacytools.io/blob/Shifterovich-remove-darknets/index.html
