### PR TITLE
Add a Firefox tweak to disable autocomplete URL preloading

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,6 +980,11 @@
 				<li>Even with Firefox set to not remember history, your closed tabs are stored temporarily at Menu -&gt; History -&gt; Recently Closed Tabs.</li>
 			</ul>
 
+			<li>browser.urlbar.speculativeConnect.enabled = false</li>
+			<ul>
+				<li>Disable preloading of autocomplete URLs. Firefox preloads URLs that autocomplete when a user types into the address bar, which is a concern if URLs are suggested that the user does not want to connect to. <a href="https://www.ghacks.net/2017/07/24/disable-preloading-firefox-autocomplete-urls/">Source</a></li>
+			</ul>
+
 			<li>dom.battery.enabled = false</li>
 			<ul>
 				<li>Website owners can track the battery status of your device. <a href="https://www.reddit.com/r/privacytoolsIO/comments/3fzbgy/you_may_be_tracked_by_your_battery_status_of_your/">Source</a></li>


### PR DESCRIPTION
### Description

Firefox 56 will introduce a new feature called "Speculative Connect" which attempts to preload URLs that are autocompleted in the awesome bar. Firefox says it will only do the server DNS lookup and TCP and TLS handshake but not start sending or receiving HTTP data. This could indeed be a performance boost, but it could also be a privacy concern.

Note that this should not be merged until Firefox 56 is released, scheduled for 2017-09-26.

Inspiration: https://www.ghacks.net/2017/07/24/disable-preloading-firefox-autocomplete-urls/
More Technical Details: https://bugzilla.mozilla.org/show_bug.cgi?id=1348275

### HTML Preview

http://htmlpreview.github.io/?https://github.com/sbennett1990/privacytools.io/blob/master/index.html
