### PR TITLE
Remove the Secure Hardware section

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,6 @@
 							<li><a href="#live_os">Live CD OS</a></li>
 							<li><a href="#mobile_os">Mobile OS</a></li>
 							<li><a href="#firmware">Router Firmware</a></li>
-							<li><a href="#hardware">Secure Hardware</a></li>
 						</ul>
 					</li>
 
@@ -2778,62 +2777,6 @@
 			<li><a href="http://www.openbsd.org/">OpenBSD</a> - A project that produces a free, multi-platform 4.4BSD-based UNIX-like operating system. Emphasizes portability, standardization, correctness, proactive security and integrated cryptography.</li>
 			<li><a href="http://www.dd-wrt.com/">DD-WRT</a> - A is Linux-based firmware for wireless routers and wireless access points. It is compatible with several models of routers and access points.</li>
 		</ul>
-
-
-<a class="anchor" name="hardware"></a>    
-      <div class="page-header">
-        <h1><a href="#hardware" class="titleanchor"><span class="glyphicon glyphicon-link"></span></a> Secure Hardware</h1> 
-      </div>
-
-      <div class="row">
-	      
-        <div class="col-sm-4">
-          <div class="panel panel-success">
-            <div class="panel-heading">
-              <h3 class="panel-title">Purism - Laptop</h3>
-            </div>
-            <div class="panel-body">
-              <p><img src="img/tools/Purism.png" alt="Purism" align="right" style="margin-left:5px;">High-quality privacy, security, and freedom focused computers and software. A convenient hardware and software product.</p>
-              <p><a href="https://puri.sm/"><button type="button" class="btn btn-success">Website: puri.sm</button></a></p>         
-            </div>
-          </div>
-        </div><!-- /.col-sm-4 -->  
-        <div class="col-sm-4">
-          <div class="panel panel-info">
-            <div class="panel-heading">
-              <h3 class="panel-title">ORWL - Desktop</h3>
-            </div>
-            <div class="panel-body">
-              <p><img src="img/tools/ORWL.png" alt="ORWL" align="right" style="margin-left:5px;">The only open source consumer device using secure NFC protection and requiring two factors of authentication, a key and password.</p>
-              <p><a href="https://orwl.org/"><button type="button" class="btn btn-info">Website: orwl.org</button></a></p>
-            </div>
-          </div>
-        </div><!-- /.col-sm-4 -->            
-        <div class="col-sm-4">
-          <div class="panel panel-warning">
-            <div class="panel-heading">
-              <h3 class="panel-title">USB armory - USB</h3>
-            </div>
-            <div class="panel-body">
-              <p><img src="img/tools/USB-armory.png" alt="USB armory" align="right" style="margin-left:5px;">An open source USB stick computer for security applications. Usage ideas: OpenSSH client, VPN tunneling, Tor bridge, electronic wallet.</p>
-              <p><a href="https://inversepath.com/usbarmory.html"><button type="button" class="btn btn-warning">Website: inversepath.com</button></a></p>        
-            </div>
-          </div>
-        </div><!-- /.col-sm-4 -->  
-        
-      </div>      
-
-<h3>Worth Mentioning</h3>
-<ul>
-	<li>Modified ThinkPads with Libreboot and Trisquel: <a href="https://shop.libiquity.com/product/taurinus-x200">Libiquity.com</a> (US), <a href="https://tehnoetic.com/tet-x200">Technoethical</a> (Romania) and <a href="https://store.vikings.net/libre-friendly-hardware">Vikings.net</a> (Germany)</li>
-	<li><a href="https://minifree.org/">Ministry of Freedom</a> - Minifree provides secure, privacy-respecting computers with 100% free (as in freedom) software, including the Libreboot BIOS replacement and GNU+Linux operating system, certified by FSF under their Respects Your Freedom certification program. Shipping worldwide.
-</ul>
-
-<h3>Related Information</h3>
-<ul>
-	<li><a href="https://www.fsf.org/resources/hw">Free Software Foundation</a> - Hardware Devices that Support GNU/Linux.</li>
-	<li><a href="https://h-node.org/">h-node.org</a> - Collection about hardware that works with a fully free operating system.</li>
-</ul>
 
 
 		<a class="anchor" name="win10"></a>


### PR DESCRIPTION
### Description

All those options are terrible ones. 

From our modmail:
> 
> Related Reddit posts:
> 
> https://www.reddit.com/r/linux/comments/3ew6pz/libreboot_exposes_the_purism_librem_as_fraud/
> 
> https://www.reddit.com/r/linux/comments/69k4l9/purism_librem_laptops_any_feedback_from_real/

> I found some links for ORWL. Unlike Purism, I think they're genuinely trying. But their product has significant problems, are not open, and are vulnerable to a variety of attacks as bad as any mainstream lap/desktop out there.
> 
> Joanna Rutkowska (Qubes OS Goddess) wrote in her blog: https://blog.invisiblethings.org/2016/09/03/thoughts-about-orwl.html
> 
> Then ORWL replied, to their credit, agreeing with many of the points (and likewise, changing some things): https://www.crowdsupply.com/design-shift/orwl/updates/invisible-things
> 
> I'm not a Schneier, nor a Rutkowska, but I listen. If they have concerns, I have concerns (as Joanna does here). Reddit and GitHub comments are hit or miss. People like Joanna are reliable.

This section will be added to the site when we find better options.

### HTML Preview

http://htmlpreview.github.io/?https://github.com/privacytoolsIO/privacytools.io/blob/Shifterovich-remove-secure-hardware/index.html
