### PR TITLE
Add links to GPG and PGP tutorials

### DIFF
--- a/index.html
+++ b/index.html
@@ -2130,7 +2130,7 @@
 								<button type="button" class="btn btn-info">Website: gnupg.org</button>
 							</a>
 							<a href="https://theprivacyguide.org/tutorials/gpg.html">
-								<button type="button" class="btn btn-info">Tutorial</button>
+								<button type="button" class="btn btn-default">Tutorial</button>
 							</a>
 						</p>
 						<p>OS: Windows, Mac, Linux, Android, BSD.</p>

--- a/index.html
+++ b/index.html
@@ -1271,7 +1271,7 @@
 		<h3>Interesting Email Providers Under Development</h3>
 		<ul>
 			<li><a href="https://www.confidantmail.org/">Confidant Mail</a> - An open-source non-SMTP cryptographic email system optimized for large file attachments. It is a secure and spam-resistant alternative to regular email and online file drop services. It
-				uses GNU Privacy Guard (GPG) for content encryption and authentication, and TLS 1.2 with ephemeral keys for transport encryption.</li>
+				uses <a href="https://theprivacyguide.org/tutorials/gpg.html">GNU Privacy Guard (GPG)</a> for content encryption and authentication, and TLS 1.2 with ephemeral keys for transport encryption.</li>
 		</ul>
 
 
@@ -1282,9 +1282,9 @@
 
 		<h3>Privacy Email Tools</h3>
 		<ul>
-			<li><a href="http://www.gpg4usb.org/">gpg4usb</a> - A very easy to use and small portable editor to encrypt and decrypt any text-message or -file. For Windows and Linux.</li>
-			<li><a href="https://www.mailvelope.com/">Mailvelope</a> - A browser extension that enables the exchange of encrypted emails following the OpenPGP encryption standard.</li>
-			<li><a href="https://www.enigmail.net/">Enigmail</a> - A security extension to Thunderbird and Seamonkey. It enables you to write and receive email messages signed and/or encrypted with the OpenPGP standard.</li>
+			<li><a href="http://www.gpg4usb.org/">gpg4usb</a> - A very easy to use and small portable editor to encrypt and decrypt any text-message or -file. For Windows and Linux. <a href="https://theprivacyguide.org/tutorials/gpg.html">GPG tutorial</a>.</li>
+			<li><a href="https://www.mailvelope.com/">Mailvelope</a> - A browser extension that enables the exchange of encrypted emails following the <a href="https://theprivacyguide.org/tutorials/pgp.html">OpenPGP encryption standard</a>.</li>
+			<li><a href="https://www.enigmail.net/">Enigmail</a> - A security extension to Thunderbird and Seamonkey. It enables you to write and receive email messages signed and/or encrypted with the <a href="https://theprivacyguide.org/tutorials/pgp.html">OpenPGP standard</a>.</li>
 			<li><a href="https://addons.mozilla.org/thunderbird/addon/torbirdy/">TorBirdy</a> - This extension configures Thunderbird to make connections over the Tor anonymity network.</li>
 			<li><a href="https://emailprivacytester.com/">Email Privacy Tester</a> - This tool will send an Email to your address and perform privacy related tests.</li>
 		</ul>
@@ -1362,7 +1362,7 @@
 		<h3>Worth Mentioning</h3>
 		<ul>
 			<li><a href="https://github.com/k9mail/k-9/releases">K-9 Mail</a> - An independent mail application for Android. It supports both POP3 and IMAP mailboxes, but only supports push mail for IMAP.</li>
-			<li><a href="https://www.gnupg.org/">GNU Privacy Guard</a> - Email Encryption. GnuPG is a GPL Licensed alternative to the PGP suite of cryptographic software. Use <a href="https://gpgtools.org/">GPGTools for Mac OS X.</a></li>
+			<li><a href="https://www.gnupg.org/">GNU Privacy Guard</a> - Email Encryption. GnuPG is a GPL Licensed alternative to the PGP suite of cryptographic software. <a href="https://theprivacyguide.org/tutorials/gpg.html">Tutorial.</a> Use <a href="https://gpgtools.org/">GPGTools for Mac OS X.</a></li>
 			<li><a href="https://www.mailpile.is/">Mailpile (Beta)</a> - A modern, fast web-mail client with user-friendly encryption and privacy features.</li>
 		</ul>
 
@@ -2128,6 +2128,9 @@
 						<p>
 							<a href="https://www.gnupg.org/">
 								<button type="button" class="btn btn-info">Website: gnupg.org</button>
+							</a>
+							<a href="https://theprivacyguide.org/tutorials/gpg.html">
+								<button type="button" class="btn btn-info">Tutorial</button>
 							</a>
 						</p>
 						<p>OS: Windows, Mac, Linux, Android, BSD.</p>


### PR DESCRIPTION
### Description

#347 

### HTML Preview

http://htmlpreview.github.io/?https://github.com/shifterovich2/privacytools.io/blob/tutorial-buttons/index.html
