### PR TITLE
Key disclosure exemptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 
 <!-- set the default language as English -->
 <html lang="en">
@@ -2039,12 +2039,12 @@
 					<div class="panel-body">
 						1. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Antigua_and_Barbuda">Antigua and Barbuda</a> <div class="pull-right"><span class="flag-icon flag-icon-ag"></span></div>
 						<br /> 2. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Australia">Australia</a> <div class="pull-right"><span class="flag-icon flag-icon-au"></span></div>
-						<br /> 4. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Canada">Canada</a> <div class="pull-right"><span class="flag-icon flag-icon-ca"></span></div>
-						<br /> 6. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#France">France</a> <div class="pull-right"><span class="flag-icon flag-icon-fr"></span></div>
-						<br /> 7. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#India">India</a> <div class="pull-right"><span class="flag-icon flag-icon-in"></span></div>
-						<br /> 8. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#South_Africa">South Africa</a> <div class="pull-right"><span class="flag-icon flag-icon-za"></span></div>
-						<br /> 9. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#United_Kingdom">United Kingdom</a> <div class="pull-right"><span class="flag-icon flag-icon-gb"></span></div>
-						<br /> 10. <a href="https://edri.org/norway-introduces-forced-biometric-authentication/">Norway</a> <div class="pull-right"><span class="flag-icon flag-icon-no"></span></div>
+						<br /> 3. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Canada">Canada</a> <div class="pull-right"><span class="flag-icon flag-icon-ca"></span></div>
+						<br /> 4. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#France">France</a> <div class="pull-right"><span class="flag-icon flag-icon-fr"></span></div>
+						<br /> 5. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#India">India</a> <div class="pull-right"><span class="flag-icon flag-icon-in"></span></div>
+						<br /> 6. <a href="https://edri.org/norway-introduces-forced-biometric-authentication/">Norway</a> <div class="pull-right"><span class="flag-icon flag-icon-no"></span></div>
+						<br /> 7. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#South_Africa">South Africa</a> <div class="pull-right"><span class="flag-icon flag-icon-za"></span></div>
+						<br /> 8. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#United_Kingdom">United Kingdom</a> <div class="pull-right"><span class="flag-icon flag-icon-gb"></span></div>
 					</div>
 				</div>
 			</div>			

--- a/index.html
+++ b/index.html
@@ -2041,7 +2041,7 @@
 						<br /> 2. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Australia">Australia</a> <div class="pull-right"><span class="flag-icon flag-icon-au"></span></div>
 						<br /> 3. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Belgium">Belgium *</a> <div class="pull-right"><span class="flag-icon flag-icon-be"></span></div>
 						<br /> 4. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Canada">Canada</a> <div class="pull-right"><span class="flag-icon flag-icon-ca"></span></div>
-						<br /> 5. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Finland">Finland</a> <div class="pull-right"><span class="flag-icon flag-icon-fi"></span></div>
+						<br /> 5. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Finland">Finland *</a> <div class="pull-right"><span class="flag-icon flag-icon-fi"></span></div>
 						<br /> 6. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#France">France</a> <div class="pull-right"><span class="flag-icon flag-icon-fr"></span></div>
 						<br /> 7. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#India">India</a> <div class="pull-right"><span class="flag-icon flag-icon-in"></span></div>
 						<br /> 8. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#South_Africa">South Africa</a> <div class="pull-right"><span class="flag-icon flag-icon-za"></span></div>
@@ -2059,7 +2059,7 @@
 					<div class="panel-body">
 						1. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#New_Zealand">New Zealand</a> (unclear) <div class="pull-right"><span class="flag-icon flag-icon-nz"></span></div>
 						<br /> 2. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Sweden">Sweden</a> (proposed) <div class="pull-right"><span class="flag-icon flag-icon-se"></span></div>
-						<br /> 3. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#The_Netherlands">The Netherlands (*)</a> <div class="pull-right"><span class="flag-icon flag-icon-nl"></span></div>
+						<br /> 3. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#The_Netherlands">The Netherlands *</a> <div class="pull-right"><span class="flag-icon flag-icon-nl"></span></div>
 						<br /> 4. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#United_States">United States</a> (see related information) <div class="pull-right"><span class="flag-icon flag-icon-us"></span></div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -2039,9 +2039,7 @@
 					<div class="panel-body">
 						1. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Antigua_and_Barbuda">Antigua and Barbuda</a> <div class="pull-right"><span class="flag-icon flag-icon-ag"></span></div>
 						<br /> 2. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Australia">Australia</a> <div class="pull-right"><span class="flag-icon flag-icon-au"></span></div>
-						<br /> 3. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Belgium">Belgium *</a> <div class="pull-right"><span class="flag-icon flag-icon-be"></span></div>
 						<br /> 4. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Canada">Canada</a> <div class="pull-right"><span class="flag-icon flag-icon-ca"></span></div>
-						<br /> 5. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Finland">Finland *</a> <div class="pull-right"><span class="flag-icon flag-icon-fi"></span></div>
 						<br /> 6. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#France">France</a> <div class="pull-right"><span class="flag-icon flag-icon-fr"></span></div>
 						<br /> 7. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#India">India</a> <div class="pull-right"><span class="flag-icon flag-icon-in"></span></div>
 						<br /> 8. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#South_Africa">South Africa</a> <div class="pull-right"><span class="flag-icon flag-icon-za"></span></div>
@@ -2057,10 +2055,12 @@
 						<h3 class="panel-title">Key disclosure laws may apply</h3>
 					</div>
 					<div class="panel-body">
-						1. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#New_Zealand">New Zealand</a> (unclear) <div class="pull-right"><span class="flag-icon flag-icon-nz"></span></div>
-						<br /> 2. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Sweden">Sweden</a> (proposed) <div class="pull-right"><span class="flag-icon flag-icon-se"></span></div>
-						<br /> 3. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#The_Netherlands">The Netherlands *</a> <div class="pull-right"><span class="flag-icon flag-icon-nl"></span></div>
-						<br /> 4. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#United_States">United States</a> (see related information) <div class="pull-right"><span class="flag-icon flag-icon-us"></span></div>
+						1. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Belgium">Belgium *</a> <div class="pull-right"><span class="flag-icon flag-icon-be"></span></div>
+						<br /> 2. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Finland">Finland *</a> <div class="pull-right"><span class="flag-icon flag-icon-fi"></span></div>
+						<br /> 3. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#New_Zealand">New Zealand</a> (unclear) <div class="pull-right"><span class="flag-icon flag-icon-nz"></span></div>
+						<br /> 4. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Sweden">Sweden</a> (proposed) <div class="pull-right"><span class="flag-icon flag-icon-se"></span></div>
+						<br /> 5. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#The_Netherlands">The Netherlands *</a> <div class="pull-right"><span class="flag-icon flag-icon-nl"></span></div>
+						<br /> 6. <a href="https://en.wikipedia.org/wiki/Key_disclosure_law#United_States">United States</a> (see related information) <div class="pull-right"><span class="flag-icon flag-icon-us"></span></div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Added and unified asterisk usage.

### Description

> The suspect and some other persons who have the right or that cannot otherwise by duty be called as witnesses are exempt from this [password/key disclosure] requirement.