### PR TITLE
Add MicroG Project to MobileOS Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2747,6 +2747,7 @@
 		<ul>
 			<li><a href="http://www.replicant.us/">Replicant</a> - An open-source operating system based on Android, aiming to replace all proprietary components with free software.</li>
 			<li><a href="http://omnirom.org/">OmniROM</a> - A free software operating system for smartphones and tablet computers, based on the Android mobile platform.</li>
+			<li><a href="https://microg.org/">MicroG</a> - A project that aims to reimplement the proprietary Google Play Services in the Android operating sytem with a FLOSS replacement.
 		</ul>
 		
 		<a class="anchor" name="firmware"></a>

--- a/index.html
+++ b/index.html
@@ -2688,7 +2688,7 @@
 		</div>
 		<!-- alert message about GApps -->
 		<div class="alert alert-warning" role="alert">
-			<strong>Even though the source code of the following OS is provided, installing Google Apps may compromise your setup.</strong>
+			<strong>Even though the source code of the following OS is provided, installing Google Apps may compromise your setup. The MicroG project can serve as a FLOSS replacement, depending on your threat model.</strong>
 		</div>
 		<div class="row">
 			<div class="col-sm-4">


### PR DESCRIPTION
### Description

The MicroG project aims to provide a replacement for the proprietary Google Apps and Services found in the Android operating system (such as Google Play Services). This project is useful because it allows functionality in applications that depend on GAPPS. I added MicroG to the Worth Mentioning section of MobileOS's and to the warning about GAPPS. 

### Pictures 
![microg-pr](https://user-images.githubusercontent.com/31498585/31857690-e0ce1d90-b699-11e7-8a13-6566c3fea736.png)

### HTML Preview

http://htmlpreview.github.io/?https://github.com/sim-s-singh/privacytools.io/blob/microg/index.html
