### PR TITLE
Fix small typo in LessPass section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1999,7 +1999,7 @@
 						<h3 class="panel-title">LessPass - Browser</h3>
 					</div>
 					<div class="panel-body">
-						<p><img src="img/tools/LessPass.png" alt="LessPass" align="right" style="margin-left:5px;">LessPass is a free and open source password manager that generates unique passwords for websites, email accounts, or anything else based on a master password and information you know. No sync needed. Uses PBKDF2 and SHA-256. It's adviced to use the browser addons for more security.</p>
+						<p><img src="img/tools/LessPass.png" alt="LessPass" align="right" style="margin-left:5px;">LessPass is a free and open source password manager that generates unique passwords for websites, email accounts, or anything else based on a master password and information you know. No sync needed. Uses PBKDF2 and SHA-256. It's advised to use the browser addons for more security.</p>
 						<p>
 							<a href="https://lesspass.com">
 								<button type="button" class="btn btn-warning">Website: lesspass.com</button>


### PR DESCRIPTION
"adviced" --> "advised"

Spotted a small typo in the LessPass section of index.html
 