### PR TITLE
List open source means to prevent WebRTC leaks in Chrome.

### DIFF
--- a/index.html
+++ b/index.html
@@ -832,7 +832,7 @@
 
 		<!-- steps to manually disable WebRTC in Chrome -->
 		<h3>How to fix the WebRTC Leak in Google Chrome?</h3>
-		<p>There is no known working solution, only a plugin that is easily circumvented. Please use Firefox instead. </p>
+		<p>WebRTC cannot be fully disabled in Chrome, however it is possible to change its routing settings (and prevent leaks) using an extension. Two open source solutions include <a href="https://chrome.google.com/webstore/detail/webrtc-leak-prevent/eiadekoaikejlgdbkbdfeijglgfdalml">WebRTC Leak Prevent</a> (options may need to be changed depending on the scenario), and <a href="https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm">uBlock Origin</a> (select "Prevent WebRTC from leaking local IP addresses" in Settings).</p>
 
 		<h3>What about other browsers?</h3>
 		<p>Chrome on iOS, Internet Explorer and Safari does not implement WebRTC yet. <a href="#browser"><span class="glyphicon glyphicon-link"></span> But we recommend using Firefox on all devices.</a></p>


### PR DESCRIPTION
### Description

Although it's not possible to disable WebRTC in Chrome, an API exists to change its routing settings.

The API can be used to prevent leaks using extensions.

*index.html* currently mentions that only a single extension exists, and that it can be easily circumvented. 

This is no longer true. 

The old extension (which has been removed by its developer) attempted to block WebRTC by injecting JavaScript into web pages (a content script). This solution is flawed because it's not possible to inject code into a sandboxed iframe.

Current extensions use an API provided by Chrome, and cannot be circumvented.

### HTML Preview

https://htmlpreview.github.io/?https://github.com/aghorler/privacytools.io/blob/master/index.html
