### PR TITLE
Mention desktop platforms in the Signal entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -1542,7 +1542,7 @@
 								<button type="button" class="btn btn-success">Download: signal.org</button>
 							</a>
 						</p>
-						<p>OS: Android, iOS.</p>
+						<p>OS: Android, iOS, macOS, Windows, Debian-based Linux</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
### Description

This was requested on Reddit: https://www.reddit.com/r/privacytoolsIO/comments/7fz9fj/update_needed_signal_app_now_have_desktop/

Signal Desktop does not support voice and video calling yet. I think we can wait until it does before we add mentions of the desktop platforms to that section.

### HTML Preview

http://htmlpreview.github.io/?https://github.com/NinebitX/privacytools.io/blob/patch-2/index.html
