### PR TITLE
Switched deprecated User-Agent Switcher Firefox extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -763,7 +763,7 @@
 
 		<!-- second paragraph -->
 		<p>You need to find what <strong>most browsers</strong> are reporting, and then use those variables to bring your browser in the same population. This means having the same fonts, plugins, and extensions installed as the large installed base. You should
-			have a <a href="https://addons.mozilla.org/firefox/addon/random-agent-spoofer/">spoofed user agent string</a> to match what the large userbase has. You need have the same settings enabled and disabled, such as DNT and WebGL. You need your browser to
+			have a <a href="https://addons.mozilla.org/de/firefox/addon/uaswitcher/">spoofed user agent string</a> to match what the large userbase has. You need have the same settings enabled and disabled, such as DNT and WebGL. You need your browser to
 			look as common as everyone else. Disabling JavaScript, using Linux, or even the TBB, will make your browser stick out from the masses.</p>
 
 		<!-- third paragraph -->

--- a/index.html
+++ b/index.html
@@ -763,7 +763,7 @@
 
 		<!-- second paragraph -->
 		<p>You need to find what <strong>most browsers</strong> are reporting, and then use those variables to bring your browser in the same population. This means having the same fonts, plugins, and extensions installed as the large installed base. You should
-			have a <a href="https://addons.mozilla.org/de/firefox/addon/uaswitcher/">spoofed user agent string</a> to match what the large userbase has. You need have the same settings enabled and disabled, such as DNT and WebGL. You need your browser to
+			have a <a href="https://addons.mozilla.org/en-US/firefox/addon/uaswitcher/">spoofed user agent string</a> to match what the large userbase has. You need have the same settings enabled and disabled, such as DNT and WebGL. You need your browser to
 			look as common as everyone else. Disabling JavaScript, using Linux, or even the TBB, will make your browser stick out from the masses.</p>
 
 		<!-- third paragraph -->


### PR DESCRIPTION
### Description

As mentioned in #365, we talked about replacing the link to the deprecated Firefox extension "Random Agent Spoofer" to the new "User Agent Switcher" that works with FF57+.

### HTML Preview

http://htmlpreview.github.io/?https://github.com/stefnats/privacytools.io/blob/master/index.html
