### PR TITLE
temporary dnscrypt stop

### DIFF
--- a/index.html
+++ b/index.html
@@ -2367,7 +2367,7 @@
 						<p><img src="img/tools/DNSCrypt.png" alt="DNSCrypt" align="right" style="margin-left:5px;">A protocol for securing communications between a client and a DNS resolver. The DNSCrypt protocol uses high-speed high-security elliptic-curve cryptography and
 							is very similar to DNSCurve, but focuses on securing communications between a client and its first-level resolver.</p>
 						<p>
-							<b> PAUSED due to DNSCrypt v2 being developed, waiting for a more stable environment before providing download links. </b>
+							<b> Please refrain from using DNSCrypt until further notice (DNSCrypt v2 in development, no official website yet). </b>
 						</p>
 						<p>OS: Windows, Mac, Linux, iOS with Jailbreak.</p>
 					</div>

--- a/index.html
+++ b/index.html
@@ -2367,9 +2367,7 @@
 						<p><img src="img/tools/DNSCrypt.png" alt="DNSCrypt" align="right" style="margin-left:5px;">A protocol for securing communications between a client and a DNS resolver. The DNSCrypt protocol uses high-speed high-security elliptic-curve cryptography and
 							is very similar to DNSCurve, but focuses on securing communications between a client and its first-level resolver.</p>
 						<p>
-							<a href="http://dnscrypt.org/">
-								<button type="button" class="btn btn-info">Website: dnscrypt.org</button>
-							</a>
+							<b> PAUSED due to DNSCrypt v2 being developed, waiting for a more stable environment before providing download links. </b>
 						</p>
 						<p>OS: Windows, Mac, Linux, iOS with Jailbreak.</p>
 					</div>


### PR DESCRIPTION
Someone sniped the domain https://dnscrypt.org/
Might redirect to malware in the future

### Description

#384 

### HTML Preview

*Replace [GITHUB_USERNAME] with your GitHub username and [BRANCH] with the branch name.*

http://htmlpreview.github.io/?https://github.com/privacytoolsIO/privacytools.io/blob/dnscrypt/index.html
