### PR TITLE
Replace Android with BSD / Solaris under i2p

### DIFF
--- a/index.html
+++ b/index.html
@@ -1389,7 +1389,7 @@
 								<button type="button" class="btn btn-success">Website: i2pbote.xyz</button>
 							</a>
 						</p>
-						<p>OS: Windows, Mac, Linux, Android.</p>
+						<p>OS: Windows, Mac, Linux, Android, BSD / Solaris.</p>
 					</div>
 				</div>
 			</div>
@@ -2311,7 +2311,7 @@
 								<button type="button" class="btn btn-info">Website: geti2p.net</button>
 							</a>
 						</p>
-						<p>OS: Windows, Mac, Linux, Android.</p>
+						<p>OS: Windows, Mac, Linux, Android, BSD / Solaris.</p>
 					</div>
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -1389,7 +1389,7 @@
 								<button type="button" class="btn btn-success">Website: i2pbote.xyz</button>
 							</a>
 						</p>
-						<p>OS: Windows, Mac, Linux, Android, F-Droid.</p>
+						<p>OS: Windows, Mac, Linux, Android.</p>
 					</div>
 				</div>
 			</div>
@@ -2311,7 +2311,7 @@
 								<button type="button" class="btn btn-info">Website: geti2p.net</button>
 							</a>
 						</p>
-						<p>OS: Windows, Mac, Linux, Android, F-Droid.</p>
+						<p>OS: Windows, Mac, Linux, Android.</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
### Description
This PR removes F-Droid in OS line under i2p. Check commits for better understanding.

F-Droid is not an OS, it will be confusing for new users. Instead can we add another line saying, "Available on F-Droid"?

### HTML Preview
http://htmlpreview.github.io/?https://github.com/avizini/privacytools.io/blob/master/index.html
