### PR TITLE
Replace LibreWRT with LibreCMC

### DIFF
--- a/index.html
+++ b/index.html
@@ -2968,14 +2968,16 @@
 			<div class="col-sm-4">
 				<div class="panel panel-warning">
 					<div class="panel-heading">
-						<h3 class="panel-title">LibreWRT</h3>
+						<h3 class="panel-title">LibreCMC</h3>
 					</div>
 					<div class="panel-body">
-						<p><img src="img/tools/LibreWRT.png" alt="LibreWRT" align="right" style="margin-left:5px;">LibreWRT is a GNU/Linux-libre distribution for computers with minimal resources, such as the Ben Nanonote, ath9k based wifi routers, and other hardware that
-							respects your freedom with emphasis on free software. It is used by the Free Software Foundation on their access point and router which provides network connectivity to portable computers in their office.</p>
+						<p><img src="img/tools/LibreCMC.png" alt="LibreCMC" align="right" style="margin-left:5px;">
+							LibreCMC is a GNU/Linux-libre distribution for computers with minimal resources, such as the Ben Nanonote, ath9k-based Wi-Fi routers, and other hardware with emphasis on free software. 
+							The project's current goal is to aim for compliance with the GNU Free System Distribution Guidelines (GNU FSDG) and ensure that the project continues to meet these requirements set forth by the Free Software Foundation (FSF).
+						</p>
 						<p>
-							<a href="http://librewrt.org/">
-								<button type="button" class="btn btn-warning">Website: librewrt.org</button>
+							<a href="https://librecmc.org">
+								<button type="button" class="btn btn-warning">Website: librecmc.org</button>
 							</a>
 						</p>
 					</div>


### PR DESCRIPTION
### Description
As per Wikipedia, LibreWRT was merged to LibreCMC in 2015:
https://en.wikipedia.org/wiki/LibreCMC


### HTML Preview

*Replace [GITHUB_USERNAME] with your GitHub username and [BRANCH] with the branch name.*

http://htmlpreview.github.io/?https://github.com/c0rdis/privacytools.io/blob/c0rdis-patch-1/index.html
