### PR TITLE
Add CryptPad to the Worth Mentioning list of Productivity Tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -2690,6 +2690,7 @@
 			<li><a href="https://ethercalc.net/">EtherCalc</a> - EtherCalc is a web spreadsheet. Data is saved on the web, and people can edit the same document at the same time. Changes are instantly reflected on all screens. Work together on inventories, survey forms, list management, brainstorming sessions.</li>
 			<li><a href="https://disroot.org/">disroot.org</a> - Free privacy friendly service that offers Etherpad, EtherCalc and PrivateBin.</li>
 			<li><a href="https://dudle.inf.tu-dresden.de/privacy/">dudle</a> - An online scheduling application, which is free and OpenSource. Schedule meetings or make small online polls. No email collection or the need of registration.</li>
+			<li><a href="https://cryptpad.fr">CryptPad</a> - CryptPad is an EU-based zero knowledge realtime collaborative editor, whose <a href="https://github.com/xwiki-labs/cryptpad">source code</a> is public and licensed under the AGPL-3.0. You can work on documents, code, presentations and even store files.</li>
 		</ul>
 
 


### PR DESCRIPTION
The people from https://cryptpad.fr describe their service as a "zero knowledge realtime collaborative editor" and the source code is licensed under the AGPL-3.0 and located at https://github.com/xwiki-labs/cryptpad.

HTML Preview:
http://htmlpreview.github.io/?https://github.com/Grammost/privacytools.io/blob/patch-1/index.html
