### PR TITLE
Remove Ricochet as it is already discontinued in 2016.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1596,26 +1596,6 @@
 				</div>
 			</div>
 
-
-			<div class="col-sm-4">
-				<div class="panel panel-warning">
-					<div class="panel-heading">
-						<h3 class="panel-title">Desktop: Ricochet</h3>
-					</div>
-					<div class="panel-body">
-						<p><img src="img/tools/Ricochet.png" style="margin-left:5px;" align="right">Ricochet uses the <a href="#browser"><span class="glyphicon glyphicon-link"></span> Tor network</a> to reach your contacts without relying on messaging servers. It creates a hidden service, which is used to rendezvous with
-							your contacts without revealing your location or IP address. Instead of a username, you get a unique address that looks like <em>ricochet:rs7ce36jsj24ogfw</em>. Other Ricochet users can use this address to send a contact request - asking to be
-							added to your contacts list.</p>
-						<p>
-							<a href="https://ricochet.im/">
-								<button type="button" class="btn btn-warning">Download: ricochet.im</button>
-							</a>
-						</p>
-						<p>OS: Windows, macOS, Linux.</p>
-					</div>
-				</div>
-			</div>
-
 		</div>
 		<h3>Worth Mentioning</h3>
 		<ul>


### PR DESCRIPTION
### Description

## The Tor Project said Ricochet is a "Discontinued software" thus it shall be removed.

Software listed here has become depreciated and development has ceased. They are therefore considered unsafe and it is highly recommended to avoid using them. This section is here purely for historical value.
Ricochet IM is an open-source, decentralised instant messenger project that officially ended development in November 2016. Ricochet starts a Tor onion service on the users local system and facilitates communication with other Ricochet users whom are also running their own Ricochet-created Tor onion service, providing End-to-End encryption by never allowing the connection to leave the Tor network.

### HTML Preview

*Replace [GITHUB_USERNAME] with your GitHub username and [BRANCH] with the branch name.*

http://htmlpreview.github.io/?https://github.com/ohmynameisrico/privacytools.io/blob/patch-1/index.html
