### PR TITLE
fix disroot.org mail storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1147,7 +1147,7 @@
 					</td>
 					<td data-value="2015">2015</td>
 					<td><span class="flag-icon flag-icon-nl"></span> Netherlands</td>
-					<td data-value="4000">4 GB</td>
+					<td data-value="2000">2 GB</td>
 					<td data-value="1"><span class="label label-warning">Free</span></td>
 					<td data-value="1"><span class="label label-success">Accepted</span></td>
 					<td data-value="1"><span class="label label-success">Built-in</span></td>


### PR DESCRIPTION
### Description
[Their website says](https://disroot.org/en/services/email):
> Mailbox size limit: 2GB

### HTML Preview

http://htmlpreview.github.io/?https://github.com/wi24rd/privacytools.io/blob/patch-1/index.html
