### PR TITLE
Add Pi-hole as worth mentioning under DNS

### DIFF
--- a/index.html
+++ b/index.html
@@ -2510,6 +2510,7 @@
 		<ul>
 			<li><a href="https://github.com/quidsup/notrack">NoTrack</a> - A network-wide DNS server which blocks Tracking sites. Currently works in Debian and Ubuntu.</li>
 			<li><a href="https://namecoin.info/">Namecoin</a> - A decentralized DNS open source information registration and transfer system based on the Bitcoin cryptocurrency.</li>
+			<li><a href="https://pi-hole.net/">Pi-hole</a> - A network-wide DNS server for the Raspberry Pi.  Blocks advertising and tracking domains for all devices on your network.</li>
 		</ul>
 
 		<a class="anchor" name="notebook"></a>


### PR DESCRIPTION
### Description
Add Pi-hole (https://pi-hole.net/) to the suggestions for DNS.  Works quite well as a network DNS server, blocking ad and tracker domains (and anything else you feel like blocking).


### HTML Preview

http://htmlpreview.github.io/?https://github.com/sjlehn/privacytools.io/blob/master/index.html
