### PR TITLE
Fix StartMail's "Own Domain" data-value

### DIFF
--- a/index.html
+++ b/index.html
@@ -1267,7 +1267,7 @@
 							<td data-value="60">$ 59.95</td>
 							<td data-value="0"><span class="label label-success">Accepted</span></td>
 							<td data-value="1"><span class="label label-success">Built-in</span></td>
-							<td data-value="0"><span class="label label-success">Yes</span></td>
+							<td data-value="1"><span class="label label-success">Yes</span></td>
 						</tr>
 
 						<tr>


### PR DESCRIPTION
### Description

I noticed the sorting for "Own Domain" in the email section was not working for StartMail. The data-value attribute was not inline with text and the actual features listed on StartMail's website.

### HTML Preview

*Replace [GITHUB_USERNAME] with your GitHub username and [BRANCH] with the branch name.*

http://htmlpreview.github.io/?https://github.com/nearwood/privacytools.io/blob/master/index.html
