### PR TITLE
Add about:config rules for preventing Firefox from downloading and enabling the Widevine CDM by Google

### DIFF
--- a/index.html
+++ b/index.html
@@ -1083,7 +1083,7 @@
 
 			<li>browser.sessionstore.privacy_level = 2</li>
 			<ul>
-				<li>This preference controls when to store extra information about a session: contents of forms, scrollbar positions, cookies, and POST data. <a href="http://kb.mozillazine.org/Browser.sessionstore.privacy_level">more information</a></li>
+				<li>This preference controls when to store extra information about a session: contents of forms, scrollbar positions, cookies, and POST data. <a href="http://kb.mozillazine.org/Browser.sessionstore.privacy_level">Details</a></li>
 				<li>0 = Store extra session data for any site. (Default starting with Firefox 4.)</li>
         <li>1 = Store extra session data for unencrypted (non-HTTPS) sites only. (Default before Firefox 4.)</li>
         <li>2 = Never store extra session data.</li>

--- a/index.html
+++ b/index.html
@@ -1019,6 +1019,17 @@
 				<li>Disables geolocation.</li>
 			</ul>
 
+			<li>media.eme.enabled = false</li>
+			<ul>
+				<li>Disables playback of DRM-controlled HTML5 content, which, if enabled, automatically downloads the Widevine Content Decryption Module provided by Google Inc. <a href="https://support.mozilla.org/en-US/kb/enable-drm#w_opt-out-of-cdm-playback-uninstall-cdms-and-stop-all-cdm-downloads">Details</a></li>
+				<li>DRM-controlled content that requires the Adobe Flash or Microsoft Silverlight NPAPI plugins will still play, if installed and enabled in Firefox.</li>
+			</ul>
+
+			<li>media.gmp-widevinecdm.enabled = false</li>
+			<ul>
+				<li>Disables the Widevine Content Decryption Module provided by Google Inc., used for the playback of DRM-controlled HTML5 content. <a href="https://support.mozilla.org/en-US/kb/enable-drm#w_disable-the-google-widevine-cdm-without-uninstalling">Details</a></li>
+			</ul>
+
 			<li>media.navigator.enabled = false</li>
 			<ul>
 				<li>Websites can track the microphone and camera status of your device.</li>


### PR DESCRIPTION
### Description

Firefox automatically downloads and installs the Widevine Content Decryption Module provided by Google Inc. (the Widevine CDM for short).

![widevine](https://user-images.githubusercontent.com/6388299/44338955-f0a5ce00-a47f-11e8-8584-c9a92e8b6009.png)

There are two (apparently undocumented) **about:config** rules that deal with this plugin: `media.eme.enabled` and `media.gmp-widevinecdm.enabled`.

#### The recommended settings

* `media.eme.enabled = false`
This is equivalent to unchecking the _Play DRM-controlled content_ checkbox in the Options, and it will disable playback of DRM-controlled HTML5 content, which, if enabled, automatically downloads the Widevine CDM. This setting automatically uninstalls the Widevine CDM plugin. Setting `media.eme.enabled` to `true` again automatically reinstalls it.

![drm](https://user-images.githubusercontent.com/6388299/44339375-665e6980-a481-11e8-934d-b0f57484faae.png)

* `media.gmp-widevinecdm.enabled = false`
This is equivalent to selecting _Never Activate_ from the dropdown menu of the Widevine CDM plugin, and works whether the plugin is currently installed or not. If the plugin has been uninstalled by `media.eme.enabled = false`, and `media.eme.enabled` is set to `true` again, this setting will prevent Firefox from automatically installing and activating the plugin until `media.gmp-widevinecdm.enabled` is also set to `true` explicitly.

[More information in Firefox Help](https://support.mozilla.org/en-US/kb/enable-drm)

### HTML Preview

http://htmlpreview.github.io/?https://github.com/gaborluk/privacytools.io/blob/master/index.html