### PR TITLE
Removed extension that is no longer available

### DIFF
--- a/index.html
+++ b/index.html
@@ -3146,7 +3146,6 @@ Windows 10 Sends Your Data 5500 Times Every Day Even After Tweaking Privacy Sett
 					by the late Aaron Swartz and is currently managed by Freedom of the Press Foundation.</li>
 				<li><a href="https://pack.resetthenet.org/"><strong>Reset The Net - Privacy Pack</strong></a> - Help fight to end mass surveillance. Get these tools to protect yourself and your friends.</li>
 				<li><a href="http://www.secfirst.org/"><strong>Security First</strong></a> - Umbrella is an Android app that provides all the advice needed to operate safely in a hostile environment.</li>
-				<li><a href="https://addons.mozilla.org/en-US/firefox/addon/block-cloudflare-mitm-attack/"><strong>Block Cloudflare MiTM Attack</strong></a> - Firefox add-on to detect and block corporate MITM attack.
 			</ul>
 
 			<a class="anchor" name="participate"></a>


### PR DESCRIPTION
"Block Cloudflare MiTM Attack - Firefox add-on to detect and block corporate MITM attack. "

