### PR TITLE
Remove all the openmailbox URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -1327,7 +1327,6 @@
 		<ul>
 			<li><a href="http://www.wired.com/2011/10/ecpa-turns-twenty-five/">Aging ‘Privacy’ Law Leaves Cloud E-Mail Open to Cops</a> - Data stored in the cloud for longer than 6 months is considered abandoned and may be accessed by intelligence agencies without
 				a warrant. Learning: Use an external email client like Thunderbird or Enigmail, download your emails and store them locally. Never leave them on the server.</li>
-			<li><a href="https://forum.openmailbox.org/viewtopic.php?id=390">OpenMailBox keeps one year logs of meta-data</a> - Forum discussion, reply of the server admin.</li>
 			<li><a href="https://www.eff.org/deeplinks/2012/04/may-firstriseup-server-seizure-fbi-overreaches-yet-again">With May First/Riseup Server Seizure, FBI Overreaches Yet Again</a></li>
 			<li><a href="http://www.autistici.org/ai/crackdown/">Autistici/Inventati server compromised</a> - The cryptographic services offered by the Autistici/Inventati server have been compromised on 15th June 2004. It was discovered on 21st June 2005. One year
 				later. During an enquiry on a single mailbox, the Postal Police may have tapped for a whole year every user's private communication going through the server autistici.org/inventati.org.</li>


### PR DESCRIPTION
### Description

Remove all the openmailbox URL
Openmailbox has been removed since https://github.com/privacytoolsIO/privacytools.io/pull/163

### HTML Preview

https://htmlpreview.github.io/?https://github.com/Kcchouette/privacytools.io/blob/patch-1/index.html