### PR TITLE
Fix referrer policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 	<meta name="description" content="You are being watched! Knowledge, encryption and privacy tools to protect you against global mass surveillance.">
 
 	<!-- referrer policy -->
-	<meta http-equiv="Referrer-Policy" content="no-referrer">
+	<meta name="referrer" content="no-referrer">
 
 	<!-- title -->
 	<title>Privacy Tools - Encryption Against Global Mass Surveillance</title>


### PR DESCRIPTION
### Description

The syntax for the referrer policy was wrong. Therefore, the referrer policy was not actually enabled.

See also: https://webbkoll.dataskydd.net/en/results?url=http%3A%2F%2Fprivacytools.io%2F

### HTML Preview

https://htmlpreview.github.io/?https://github.com/rsnitsch/privacytools.io/blob/master/index.html
