### PR TITLE
Changing the extensions.blocklist.url flag

### DIFF
--- a/index.html
+++ b/index.html
@@ -846,7 +846,7 @@ layout: default
                 </ul>
             </li>
             
-            <li>extensions.blocklist.url = https://blocklists.settings.services.mozilla.com/v1/blocklist/3/%APP_ID%/%APP_VERSION%/
+            <li>extensions.blocklist.url = https://blocklists.settings.services.mozilla.com/v1/blocklist/3/%20/%20/
                 <ul>
                     <li>Limit the amount of identifiable information sent when requesting the Mozilla harmful extension blocklist.</li>
                     <li>Optionally, the blocklist can be disabled entirely by setting <code>extensions.blocklist.enabled</code> to false for increased privacy, but decreased security. <a href="https://old.reddit.com/r/privacytoolsIO/comments/9uqeew/firefox_tip_sanitize_firefox_blocklist_url_so_it/">Source</a></li>

--- a/index.html
+++ b/index.html
@@ -845,6 +845,13 @@ layout: default
                     <li>Not rendering IDNs as their Punycode equivalent leaves you open to phishing attacks that can be very difficult to notice. <a href="https://krebsonsecurity.com/2018/03/look-alike-domains-and-visual-confusion/#more-42636">Source</a></li>
                 </ul>
             </li>
+            
+            <li>extensions.blocklist.url = https://blocklists.settings.services.mozilla.com/v1/blocklist/3/%APP_ID%/%APP_VERSION%/
+                <ul>
+                    <li>Limit the amount of identifiable information sent when requesting the Mozilla harmful extension blocklist.</li>
+                    <li>Optionally, the blocklist can be disabled entirely by setting <code>extensions.blocklist.enabled</code> to false for increased privacy, but decreased security. <a href="https://old.reddit.com/r/privacytoolsIO/comments/9uqeew/firefox_tip_sanitize_firefox_blocklist_url_so_it/">Source</a></li>
+                </ul>
+            </li>
         </ol>
 
 <!-- related information -->


### PR DESCRIPTION
Limit the amount of identifiable information sent when requesting the Mozilla harmful extensions blocklist.

### Description

From Reddit user /u/LocalFigurez at https://old.reddit.com/r/privacytoolsIO/comments/9uqeew/firefox_tip_sanitize_firefox_blocklist_url_so_it/

Firefox includes feature that connects in regular time intervals (every 24 hour) to the Mozilla's servers to download blocklist of harmful extensions, vulnerable plugins and crash-prone graphic drivers. This request includes following information:

    APP_ID
    APP_VERSION
    PRODUCT
    VERSION
    BUILD_ID
    BUILD_TARGET
    OS_VERSION
    LOCALE
    CHANNEL
    PLATFORM_VERSION
    DISTRIBUTION
    DISTRIBUTION_VERSION
    PING_COUNT
    TOTAL_PING_COUNT
    DAYS_SINCE_LAST_PING

By changing `extensions.blocklist.url` from 

    https://blocklists.settings.services.mozilla.com/v1/blocklist/3/%APP_ID%/%APP_VERSION%/%PRODUCT%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/%PING_COUNT%/%TOTAL_PING_COUNT%/%DAYS_SINCE_LAST_PING%/
to 

    https://blocklists.settings.services.mozilla.com/v1/blocklist/3/%APP_ID%/%APP_VERSION%/

Firefox won't send identifiable information in the blocklist request and you will still get all the security features from it.



### HTML Preview

https://htmlpreview.github.io/?https://github.com/HxxxxxS/privacytools.io/blob/patch-1/index.html
