### PR TITLE
Remove findx.com and ixquick.eu from Search Engines

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,10 +1214,6 @@ layout: default
     <li>
         <a href="https://metager.de/en/">MetaGer</a> - An open source metasearch engine, which is based in Germany. It focuses on protecting the user's privacy.
     </li>
-
-    <li>
-        <a href="https://www.ixquick.eu/">ixquick.eu</a> - Returns the top results from multiple search engines. Based in the Netherlands.
-    </li>
 </ul>
 
 

--- a/index.html
+++ b/index.html
@@ -1209,9 +1209,6 @@ layout: default
 <h3>Worth Mentioning</h3>
 <ul>
     <li>
-        <a href="https://www.findx.com/">findx</a> - Open Source. No logging. No tracking. Transparent algorithms. Hosted in Europe.
-    </li>
-    <li>
         <a href="https://www.qwant.com/">Qwant</a> - Qwant's philosophy is based on two principles: no user tracking and no filter bubble. Qwant was launched in France in February 2013. <a href="https://www.qwant.com/privacy">Privacy Policy.</a>
     </li>
     <li>


### PR DESCRIPTION
<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io#contributing-guidelines) BEFORE SUBMITTING -->

## Description
findx.com and ixquick.eu have both shut down.

Issue: #none

<!--
## Screenshots

Please add screenshots if applicable
-->
