### PR TITLE
Replace youtube links with PeerTube counterpart

### DIFF
--- a/index.html
+++ b/index.html
@@ -1500,7 +1500,7 @@ layout: default
 
 <h3>Related Information</h3>
 <ul>
-    <li><a href="https://www.youtube.com/watch?v=yzGzB-yYKcc">Edward Snowden on Passwords - YouTube</a></li>
+    <li><a href="https://peertube.mastodon.host/videos/watch/4cdedd90-a5b4-4022-b93d-828e85ed58cd">Edward Snowden on Passwords - PeerTube</a></li>
 </ul>
 
 <h1 id="calendar_contacts" class="anchor"><a href="#calendar_contacts"><i class="fas fa-link anchor-icon"></i></a> Calendar and Contacts Sync</h1>
@@ -1612,7 +1612,7 @@ layout: default
 <ul>
     <li><a href="https://en.wikipedia.org/wiki/Key_disclosure_law">Wikipedia page on key disclosure law</a></li>
     <li><a href="https://law.stackexchange.com/questions/1523/can-a-us-citizen-be-required-to-provide-the-authentication-key-for-encrypted-dat">law.stackexchange.com question about key disclosure law in US</a></li>
-    <li><a href="https://www.youtube.com/watch?v=Jt7D4AIfqlQ">DEFCON 20: Crypto and the Cops: the Law of Key Disclosure and Forced Decryption</a></li>
+    <li><a href="https://peertube.mastodon.host/videos/watch/e09915eb-5962-4830-a02f-8da5c2b59e71">DEFCON 20: Crypto and the Cops: the Law of Key Disclosure and Forced Decryption - PeerTube</a></li>
 </ul>
 
 <h1 id="encrypt" class="anchor"><a href="#encrypt"><i class="fas fa-link anchor-icon"></i></a> File Encryption Software</h1>


### PR DESCRIPTION
<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io#contributing-guidelines) BEFORE SUBMITTING -->

## Description
Replaced YouTube links in sources by their PeerTube counterpart.

Issue: #579
