### PR TITLE
Remove "Web" from the Signal entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -1228,7 +1228,7 @@ layout: default
     title="Mobile: Signal"
     image="assets/img/tools/Signal.png"
     url="https://signal.org"
-    footer="OS: Android, iOS, macOS, Windows, Linux, Web"
+    footer="OS: Android, iOS, macOS, Windows, Linux"
     description="Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
                 All communications are end-to-end encrypted. Signal is free and open source, enabling anyone to verify its security by auditing the code. The development team is supported by community donations and grants. There are no advertisements,
                 and it doesn't cost anything to use."
@@ -1285,7 +1285,7 @@ layout: default
     title="Mobile: Signal"
     image="assets/img/tools/Signal.png"
     url="https://signal.org"
-    footer="OS: Android, iOS, macOS, Windows, Linux, Web"
+    footer="OS: Android, iOS, macOS, Windows, Linux"
     description="Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
                 All communications are end-to-end encrypted. Signal is free and open source, enabling anyone to verify its security by auditing the code. The development team is supported by community donations and grants. There are no advertisements,
                 and it doesn't cost anything to use."


### PR DESCRIPTION
## Description

The legacy Chrome version of Signal Desktop was officially deprecated on October 31, 2017, and has now officially expired:

https://github.com/signalapp/Signal-Desktop/commit/6c8cff56bba165ad4addfde8db0c923283b11ebb#diff-2650fb3e14b7f42d68a8766269c54434R130


