### PR TITLE
Replace Google+ share button with Mastodon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -155,7 +155,7 @@
                 <a class="dropdown-item" href="mailto:?subject=privacytools.io%20-%20encryption%20against%20global%20mass%20surveillance&body=https://www.privacytools.io/">Email</a>
                 <a class="dropdown-item" href="https://www.facebook.com/sharer/sharer.php?u=https://www.privacytools.io">Facebook</a>
                 <a class="dropdown-item" href="https://twitter.com/share?text=Knowledge%20and%20tools%20to%20protect%20your%20privacy%20against%20global%20mass%20surveillance%20&amp;url=https://www.privacytools.io/&amp;via=privacytoolsIO">Twitter</a>
-                <a class="dropdown-item" href="https://plus.google.com/share?url=https://www.privacytools.io">Google+</a>
+                <a class="dropdown-item" href="http://sharetomastodon.github.io/?title=privacytools.io%20-%20encryption%20against%20global%20mass%20surveillance&url=https://www.privacytools.io">Mastodon</a>
                 <a class="dropdown-item" href="http://reddit.com/submit?url=https://www.privacytools.io&title=privacytools.io%20-%20encryption%20against%20global%20mass%20surveillance">reddit</a>
                 <a class="dropdown-item" href="https://www.linkedin.com/shareArticle?url=https://www.privacytools.io&title=privacytools.io%20-%20encryption%20against%20global%20mass%20surveillance">LinkedIn</a>
                 <a class="dropdown-item" href="http://www.stumbleupon.com/submit?url=https://www.privacytools.io&title=privacytools.io%20-%20encryption%20against%20global%20mass%20surveillance">StumbleUpon</a>

--- a/_sass/_vars.scss
+++ b/_sass/_vars.scss
@@ -17,7 +17,7 @@ $share-btn-active:    #e2e2e2;
 
 /* Social */
 $twitter:             #55acee;
-$google:              #dd4b39;
+$mastodon:            #3088d4;
 $facebook:            #3b5998;
 $stumbleupon:         #eb4823;
 $reddit:              #ff5700;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -111,7 +111,7 @@ a,
 }
 
 .twitter { background: $twitter; }
-.google-plus { background: $google; }
+.mastodon { background: $mastodon; }
 .facebook { background: $facebook; }
 .stumbleupon { background: $stumbleupon; }
 .reddit { background: $reddit; }

--- a/index.html
+++ b/index.html
@@ -2252,8 +2252,8 @@ This tool uses some known methods that attempt to disable major tracking feature
         <i class="fab fa-twitter"></i>
     </a>
 
-    <a href="https://plus.google.com/share?url=https://www.privacytools.io" class="share-btn google-plus" title="Google+">
-        <i class="fab fa-google-plus-g"></i>
+    <a href="http://sharetomastodon.github.io/?title=privacytools.io%20-%20encryption%20against%20global%20mass%20surveillance&url=https://www.privacytools.io" class="share-btn mastodon" title="Mastodon">
+      <i class="fab fa-mastodon"></i>
     </a>
 </div>
 <div class="col-12 col-md-6 d-flex justify-content-between">


### PR DESCRIPTION
<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io#contributing-guidelines) BEFORE SUBMITTING -->

## Description

Issue: #584 

Replace Google+ share button with Mastodon.

## Screenshots

![screenshot](https://user-images.githubusercontent.com/13933712/48679052-3eb39600-eb83-11e8-8447-f3f11c4f4ade.png)

