### PR TITLE
Update 5Eyes formatting to be consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,11 +65,12 @@ layout: default
     {% include panel.html color="danger"
     title="Five Eyes"
     body='
-    <li>1. Australia <div class="float-right"><span class="flag-icon flag-icon-au"></span></div></li>
-    <li>Canada <div class="float-right"><span class="flag-icon flag-icon-ca"></span></div></li>
-    <li>New Zealand <div class="float-right"><span class="flag-icon flag-icon-nz"></span></div></li>
-    <li>United Kingdom <div class="float-right"><span class="flag-icon flag-icon-gb"></span></div></li>
-    <li>United States of America <div class="float-right"><span class="flag-icon flag-icon-us"></span></div></li>
+        1. Australia <div class="float-right"><span class="flag-icon flag-icon-au"></span></div>
+        <br /> 2. Canada <div class="float-right"><span class="flag-icon flag-icon-ca"></span></div>
+        <br /> 3. New Zealand <div class="float-right"><span class="flag-icon flag-icon-nz"></span></div>
+        <br /> 4. United Kingdom <div class="float-right"><span class="flag-icon flag-icon-gb"></span></div>
+        <br /> 5. United States of America <div class="float-right"><span class="flag-icon flag-icon-us"></span></div>
+        <br /><br /> 
     '
     %}
 


### PR DESCRIPTION
Was 5-Eyes countries to be bullet points, with AUS showing as ( • 1. Australia) and the rest without numbers.

## Description

Resolves: #none 


## Screenshots

Before: https://i.imgur.com/rrgUYn6.png

After: https://i.imgur.com/TW6uQJ6.png  (EDIT: Just realized I did this with the Dev console open, so the elements are moved. This is not a byproduct of my change, which is just the text, and the layout is still unchanged)
