### PR TITLE
Five Eyes countries: add missing numbers in list

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,10 +66,10 @@ layout: default
     title="Five Eyes"
     body='
     <li>1. Australia <div class="float-right"><span class="flag-icon flag-icon-au"></span></div></li>
-    <li>Canada <div class="float-right"><span class="flag-icon flag-icon-ca"></span></div></li>
-    <li>New Zealand <div class="float-right"><span class="flag-icon flag-icon-nz"></span></div></li>
-    <li>United Kingdom <div class="float-right"><span class="flag-icon flag-icon-gb"></span></div></li>
-    <li>United States of America <div class="float-right"><span class="flag-icon flag-icon-us"></span></div></li>
+    <li>2. Canada <div class="float-right"><span class="flag-icon flag-icon-ca"></span></div></li>
+    <li>3. New Zealand <div class="float-right"><span class="flag-icon flag-icon-nz"></span></div></li>
+    <li>4. United Kingdom <div class="float-right"><span class="flag-icon flag-icon-gb"></span></div></li>
+    <li>5. United States of America <div class="float-right"><span class="flag-icon flag-icon-us"></span></div></li>
     '
     %}
 


### PR DESCRIPTION
Australia had a number but not the others. And the Nine Eyes and Fourteen Eyes had numbers too.

## Description

Fixes an inconsistency:
Current:
![screenshot_2018-12-04_12-02-34](https://user-images.githubusercontent.com/2678215/49437815-d38dd480-f7bc-11e8-88dc-08f03ad91157.png)

But this is still an inconsistency between the 3 lists

Do we put bullets on the 3 lists? Or no bullets at all?