### PR TITLE
Fix numbering of Five Eyes countries

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,10 +66,10 @@ layout: default
     title="Five Eyes"
     body='
     <li>1. Australia <div class="float-right"><span class="flag-icon flag-icon-au"></span></div></li>
-    <li>Canada <div class="float-right"><span class="flag-icon flag-icon-ca"></span></div></li>
-    <li>New Zealand <div class="float-right"><span class="flag-icon flag-icon-nz"></span></div></li>
-    <li>United Kingdom <div class="float-right"><span class="flag-icon flag-icon-gb"></span></div></li>
-    <li>United States of America <div class="float-right"><span class="flag-icon flag-icon-us"></span></div></li>
+    <li>2. Canada <div class="float-right"><span class="flag-icon flag-icon-ca"></span></div></li>
+    <li>3. New Zealand <div class="float-right"><span class="flag-icon flag-icon-nz"></span></div></li>
+    <li>4. United Kingdom <div class="float-right"><span class="flag-icon flag-icon-gb"></span></div></li>
+    <li>5. United States of America <div class="float-right"><span class="flag-icon flag-icon-us"></span></div></li>
     '
     %}
 


### PR DESCRIPTION
<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Australia was the only country in the column to have a number. This change makes the other 4 countries match the formatting of all Fourteen Eyes columns.

<!--
## Screenshots

Please add screenshots if applicable
-->
