### PR TITLE
Fixing link to keka file archiver

### DIFF
--- a/index.html
+++ b/index.html
@@ -1648,7 +1648,7 @@ layout: default
     footer="OS: Windows, Linux, BSD."
     description="PeaZip is a free and open-source file manager and file archiver made by Giorgio Tani. It supports its native PEA archive format (featuring compression, multi volume
                 split and flexible authenticated encryption and integrity check schemes) and other mainstream formats, with special focus on handling open formats. It supports 181 file extensions (as of version 5.5.1).</p>
-                <p><strong>macOS alternative:</strong> <a href=\"http://www.kekaosx.com/\">Keka</a> is a free file archiver."
+                <p><strong>macOS alternative:</strong> <a href=\"http://www.keka.io/\">Keka</a> is a free file archiver."
     %}
 </div>
 


### PR DESCRIPTION
## Description

This will remove a redirection hop.
Also, `https://[www.]kekaosx.com` gives ERR_SSL_PROTOCOL_ERROR.