### PR TITLE
Enable sitemap.xml generation & reintroduce robots.txt

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,4 +3,7 @@ description: You are being watched! Knowledge, encryption and privacy tools to p
 url: "https://privacytools.io"
 sass:
   style: compressed
-
+plugins:
+  - jekyll-sitemap
+sitemap:
+file: "/sitemap.xml"

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://privacytools.io/sitemap.xml


### PR DESCRIPTION
I disagree with the decision to remove robots.txt in #668. I think it may at least remove 404 errors from logs and sitemap.xml can only help with SEO or won't be harmful.

However I am not sure if privacytools.io has more than one page and I was unable to get Jekyll working locally on this PC.
