### PR TITLE
Add More Privacy-respecting Browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,6 +532,16 @@ layout: default
     -->
 
   </div>
+  
+  
+  <h3>Worth Mentioning</h3>
+  <ul>
+    <li><a href="https://cliqz.com/">Cliqz</a> - Cliqz is a security-focused web browser.</li>
+    <li><a href="https://textbrowser.github.io/dooble//">Dooble</a> - Dooble is a next generation web browser.</li>
+    <li><a href="http://www.netsurf-browser.org/">NetSurf</a> - NetSurf is a web browser focusing on speed.</li>
+    <li><a href="https://basilisk-browser.org/">Basilisk</a> - Basilisk is an XUL-based web browser by the developers of <a href="https://www.palemoon.org/">Pale Moon</a>.</li>
+  </ul>
+
 
   <!-- Browser Fingerprint -->
   <h1 id="fingerprint" class="anchor"><a href="#fingerprint"><i class="fas fa-link anchor-icon"></i></a> Browser Fingerprint - Is your browser configuration unique?</h1>

--- a/index.html
+++ b/index.html
@@ -540,6 +540,7 @@ layout: default
     <li><a href="https://textbrowser.github.io/dooble//">Dooble</a> - Dooble is a next generation web browser.</li>
     <li><a href="http://www.netsurf-browser.org/">NetSurf</a> - NetSurf is a web browser focusing on speed.</li>
     <li><a href="https://basilisk-browser.org/">Basilisk</a> - Basilisk is an XUL-based web browser by the developers of <a href="https://www.palemoon.org/">Pale Moon</a>.</li>
+    <li><a href="https://otter-browser.org/">Otter Browser</a> - Otter Browser is a fully open source browser using the Qt Framework.</li>
   </ul>
 
 


### PR DESCRIPTION
**Description**: Add More Privacy-respecting Browsers
**Why**? Currently there are only 2 major open-source web browsers, Chromium and Firefox. Giving to much market share to a few companies can be harmful especially when there are plenty of alternatives.
**What software does this add**? The following have been added to "Worth Mentioning":

- [Cliqz](https://cliqz.com/)
- [Basilisk](https://basilisk-browser.org/)
- [NetSurf](http://www.netsurf-browser.org/)
- [Dooble](https://textbrowser.github.io/dooble//)
- [Otter Browser](https://otter-browser.org/)

All of these meet the [PrivacyTools.io Criteria](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md#software-criteria).