### PR TITLE
Change Brave's Experimental Flag

### DIFF
--- a/index.html
+++ b/index.html
@@ -509,7 +509,7 @@ layout: default
 
     {% include card.html color="warning"
     title="Brave"
-    labels="warning:experimental:Brave is a good choice if you want to use a Chromium-based browser. But at this point in Brave's development&comma; it's not as good as Firefox with privacy addons."
+    labels="warning:experimental:Brave is still in its early development phases and may have unknown vulnerabilities."
     image="assets/img/tools/Brave.png"
     url="https://www.brave.com/"
     footer="OS: Windows, macOS, Linux, Android, iOS."


### PR DESCRIPTION
**Description**: Change Brave's Experimental Flag
**Why**? I am unaware of any know major security vulnerabilities in Brave, at lest no more than Firefox. This change would instead alert users that Brave is still in its early development phases.