### PR TITLE
Add Firefox Send to File Sharing "Worth Mentioning"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1346,6 +1346,11 @@ layout: default
     %}
   </div>
 
+<h3>Worth Mentioning</h3>
+  <ul>
+    <li><a href="https://send.firefox.com/">Firefox Send</a> <span class="badge badge-warning" data-toggle="tooltip" title="This software utilizes Google Analytics.">warning<i class="far fa-question-circle"></i></span> - A file sharing service created by the non-profit organization Mozilla.</li>
+  </ul>
+  
   <h1 id="cloud" class="anchor"><a href="#cloud"><i class="fas fa-link anchor-icon"></i></a> Encrypted Cloud Storage Services</h1>
 
   <div class="alert alert-warning" role="alert">


### PR DESCRIPTION
**Description**: Add Firefox Send to File Sharing "Worth Mentioning"
**Note**: Firefox Send does use Google Analytics when DNT is disabled. I made sure to add a warning label to alert the user before utilizing. Several open issues here: https://github.com/mozilla/send/issues/1027
**Firefox Send URL**: https://send.firefox.com