### PR TITLE
Remove Non-Free Search Engines | Against Software Criteria

### DIFF
--- a/index.html
+++ b/index.html
@@ -1204,9 +1204,6 @@ layout: default
   <h3>Worth Mentioning</h3>
   <ul>
     <li>
-      <a href="https://www.qwant.com/">Qwant</a> - Qwant's philosophy is based on two principles: no user tracking and no filter bubble. Qwant was launched in France in February 2013. <a href="https://www.qwant.com/privacy">Privacy Policy.</a>
-    </li>
-    <li>
       <a href="https://metager.de/en/">MetaGer</a> - An open source metasearch engine, which is based in Germany. It focuses on protecting the user's privacy.
     </li>
   </ul>  <h1 id="im" class="anchor"><a href="#im"><i class="fas fa-link anchor-icon"></i></a> Encrypted Instant Messenger</h1>

--- a/index.html
+++ b/index.html
@@ -1191,20 +1191,6 @@ layout: default
     description='An <a href="https://github.com/asciimoo/searx">open source</a> metasearch engine, aggregating the results of other search engines while not storing information about its users. No logs, no ads and no tracking.'
     %}
 
-    {% include card.html color="primary"
-    title="StartPage"
-    image="assets/img/provider/StartPage.png"
-    url="https://www.startpage.com/"
-    description="Google search results, with complete privacy protection. Behind StartPage is a european company that has been obsessive about privacy since 2006."
-    %}
-
-    {% include card.html color="warning"
-    title="DuckDuckGo"
-    image="assets/img/provider/DuckDuckGo.jpg"
-    url="https://duckduckgo.com/"
-    tor="http://3g2upl4pq6kufc4m.onion"
-    description='The search engine that doesn\'t track you. Some of DuckDuckGo\'s code is free software hosted at <a href="https://github.com/duckduckgo">GitHub</a>, but the core is proprietary. <span class="flag-icon flag-icon-us"></span> <a href="#ukusa">The company is based in the USA.</a>'
-    %}
   </div>
 
   <h3>Firefox Addon</h3>


### PR DESCRIPTION
**Description**: Remove DuckDuckGo, QWANT, and Startpage
**Why**? The software criteria clearly states "**Open Source** but, DuckDuckGo, QWANT, and Startpage are anything but that. It also states "**there can be exceptions if no software is available that meet the criteria.**, this is for good reasons. Please remove these non-free services. 