### PR TITLE
Change Etherpad URL to Etherpad.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -1811,7 +1811,7 @@ layout: default
     {% include card.html color="success"
     title="Etherpad"
     image="assets/img/tools/Etherpad.png"
-    url="http://etherpad.org/"
+    url="http://etherpad.net/"
     footer="OS: Windows, macOS, Linux."
     description="Etherpad is a highly customizable Open Source online editor providing collaborative editing in really real-time. Etherpad allows you to edit documents collaboratively in real-time, much like a live multi-player editor that runs in your browser. Write articles, press releases, to-do lists, etc."
     %}

--- a/index.html
+++ b/index.html
@@ -1811,9 +1811,9 @@ layout: default
     {% include card.html color="success"
     title="Etherpad"
     image="assets/img/tools/Etherpad.png"
-    url="https://etherpad.net/"
+    url="https://etherpad.org"
     footer="OS: Windows, macOS, Linux."
-    description="Etherpad is a highly customizable Open Source online editor providing collaborative editing in really real-time. Etherpad allows you to edit documents collaboratively in real-time, much like a live multi-player editor that runs in your browser. Write articles, press releases, to-do lists, etc."
+    description="Etherpad is a highly customizable Open Source online editor providing collaborative editing in really real-time. Etherpad allows you to edit documents collaboratively in real-time, much like a live multi-player editor that runs in your browser. Write articles, press releases, to-do lists, etc. To  view the live version go to <a href="https://etherpad.net/">Etherpad.net</a>"
     %}
 
     {% include card.html color="primary"

--- a/index.html
+++ b/index.html
@@ -1811,7 +1811,7 @@ layout: default
     {% include card.html color="success"
     title="Etherpad"
     image="assets/img/tools/Etherpad.png"
-    url="https://etherpad.org"
+    url="http://etherpad.org"
     footer="OS: Windows, macOS, Linux."
     description="Etherpad is a highly customizable Open Source online editor providing collaborative editing in really real-time. Etherpad allows you to edit documents collaboratively in real-time, much like a live multi-player editor that runs in your browser. Write articles, press releases, to-do lists, etc. To  view the live version go to <a href="https://etherpad.net/">Etherpad.net</a>"
     %}

--- a/index.html
+++ b/index.html
@@ -1811,7 +1811,7 @@ layout: default
     {% include card.html color="success"
     title="Etherpad"
     image="assets/img/tools/Etherpad.png"
-    url="http://etherpad.net/"
+    url="https://etherpad.net/"
     footer="OS: Windows, macOS, Linux."
     description="Etherpad is a highly customizable Open Source online editor providing collaborative editing in really real-time. Etherpad allows you to edit documents collaboratively in real-time, much like a live multi-player editor that runs in your browser. Write articles, press releases, to-do lists, etc."
     %}

--- a/index.html
+++ b/index.html
@@ -1813,7 +1813,7 @@ layout: default
     image="assets/img/tools/Etherpad.png"
     url="http://etherpad.org"
     footer="OS: Windows, macOS, Linux."
-    description="Etherpad is a highly customizable Open Source online editor providing collaborative editing in really real-time. Etherpad allows you to edit documents collaboratively in real-time, much like a live multi-player editor that runs in your browser. Write articles, press releases, to-do lists, etc. To  view the live version go to <a href="https://etherpad.net/">Etherpad.net</a>"
+    description="Etherpad is a highly customizable Open Source online editor providing collaborative editing in really real-time. Etherpad allows you to edit documents collaboratively in real-time, much like a live multi-player editor that runs in your browser. Write articles, press releases, to-do lists, etc. To  view the live version go to <a href=\"https://etherpad.net/\">Etherpad.net</a>"
     %}
 
     {% include card.html color="primary"


### PR DESCRIPTION
**Description**: Change Etherpad URL to [Etherpad.net](https://etherpad.net)
**Why**? Ease of use, Etherpad.net is plug-n-play while Etherpad is hard to set up.