### PR TITLE
Removed Bitwarden

### DIFF
--- a/index.html
+++ b/index.html
@@ -1472,13 +1472,7 @@ layout: default
   </div>
   <div class="row mb-2">
 
-    {% include card.html color="success"
-    title="Bitwarden - Cloud/Self-host"
-    image="assets/img/tools/bitwarden.png"
-    url="https://bitwarden.com/"
-    footer="OS: Windows, macOS, Linux, iOS, Android, Web."
-    description="Bitwarden is a free and open source password manager. It aims to solve password management problems for individuals, teams, and business organizations. Bitwarden is among the easiest and safest solutions to store all of your logins and passwords while conveniently keeping them synced between all of your devices. If you don't want to use the Bitwarden cloud, you can easily host your own Bitwarden server."
-    %}    {% include card.html color="primary"
+    {% include card.html color="primary"
     title="KeePass / KeePassXC - Local"
     image="assets/img/tools/KeePass.png"
     url="https://keepass.info/download.html"
@@ -1504,6 +1498,10 @@ layout: default
     <li>
       <a href="https://pwsafe.org/">Password Safe</a> - Whether the answer is one or hundreds, Password Safe allows you to safely and easily create a secured and encrypted username/password list. With Password Safe all you have to do is create and remember
       a single "Master Password" of your choice in order to unlock and access your entire username/password list.
+    </li>
+    
+    <li>
+      <a href="https://bitwarden.com/">Bitwarden</a> - Open-source, encrypted, cloud password manager. Just be sure to disable Google Analytics if you decide to use it.
     </li>
   </ul>
 

--- a/index.html
+++ b/index.html
@@ -1472,7 +1472,7 @@ layout: default
   </div>
   <div class="row mb-2">
 
-    {% include card.html color="primary"
+    {% include card.html color="success"
     title="KeePass / KeePassXC - Local"
     image="assets/img/tools/KeePass.png"
     url="https://keepass.info/download.html"
@@ -1481,8 +1481,7 @@ layout: default
     description='KeePass is a free open source password manager, which helps you to manage your passwords in a secure way. All passwords in one database, which is locked with one
     master key or a key file. The databases are encrypted using the best and most secure encryption algorithms currently known: AES and Twofish. See also: <a href="https://keepassxc.org/">KeePassXC</a> with official native cross-platform support for Windows/macOS/Linux.'
     %}
-
-    {% include card.html color="warning"
+    {% include card.html color="primary"
     title="LessPass - Browser"
     image="assets/img/tools/LessPass.png"
     url="https://lesspass.com/"


### PR DESCRIPTION
As talked about in issue #719 Bitwarden has Google Analytics baked in and enabled by default. This commit removes Bitwarden from the recommended programs and relegates it to last place in the "worth mentioning" list, with the warning about disabling Google Analytics if it is used.

<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #719 <!-- The number of the issue that is resolved by this pull request. If there is none, feel free to delete this line -->

<!--
## Screenshots

Please add screenshots if applicable
-->
