### PR TITLE
added Ubuntu Touch and e mobile OS to worth mentioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -1937,7 +1937,9 @@ layout: default
   <ul>
     <li><a href="https://www.replicant.us/">Replicant</a> - An open-source operating system based on Android, aiming to replace all proprietary components with free software.</li>
     <li><a href="https://www.omnirom.org/">OmniROM</a> - A free software operating system for smartphones and tablet computers, based on the Android mobile platform.</li>
-    <li><a href="https://microg.org/">MicroG</a> - A project that aims to reimplement the proprietary Google Play Services in the Android operating system with a FLOSS replacement.
+    <li><a href="https://microg.org/">MicroG</a> - A project that aims to reimplement the proprietary Google Play Services in the Android operating system with a FLOSS replacement.</li>
+    <li><a href="https://ubuntu-touch.io/">Ubuntu Touch</a> - An open-source operating system based on the Ubuntu desktop environment. Phone compatibility is limited.</li>
+    <li><a href="https://e.foundation/">/e/</a> - A privacy respecting alternative to Android for Android compatibile phones. Currently in beta and available for install on a wide range of phones.</li>
   </ul>
 
   <!-- Android add-ons -->


### PR DESCRIPTION
Added both Ubuntu Touch and /e/ to mobile operating systems under worth mentioning.

Device availability for Ubuntu is too low to make it a card, and /e/ is in it's first beta stages, though is available on an impressive amount of devices.

/e/ is not based on Android and is created with privacy in mind before anything else.

I also fixed a missing closing tag on the MicroG link.