### PR TITLE
Fix european to European

### DIFF
--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -19,7 +19,7 @@
   title="StartPage"
   image="assets/img/provider/StartPage.png"
   url="https://www.startpage.com/"
-  description="Google search results, with complete privacy protection. Behind StartPage is a european company that has been obsessive about privacy since 2006."
+  description="Google search results, with complete privacy protection. Behind StartPage is a European company that has been obsessive about privacy since 2006."
   %}
 
   {% include card.html color="warning"


### PR DESCRIPTION
## Description

We always capitalize proper nouns and adjectives derived from them.