### PR TITLE
Break long words on smaller devices

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -7,6 +7,10 @@
 @import 'fontawesome';
 @import 'sortable-theme-bootstrap';
 
+body {
+  word-wrap: break-word;
+}
+
 .card {
   box-shadow: $card-shadow !important;
 }


### PR DESCRIPTION
## Description

Add body { word-wrap: break-word; } to break up long strings on mobile devices. Just looks better.

Resolves: #610

## Screenshots

After:

![image](https://user-images.githubusercontent.com/3637842/55269025-5b608880-525d-11e9-94cb-815132cdde19.png)

Before:

![image](https://user-images.githubusercontent.com/3637842/55269034-69160e00-525d-11e9-99c9-afa005ed09e3.png)

