### PR TITLE
Prep for move off CloudFlare

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.privacytools.io


### PR DESCRIPTION
We are going to move off of CloudFlare to an Nginx server we control that will reverse proxy to the GitHub Pages host. Essentially we will be acting in the exact same way CloudFlare currently does for us, but under our control.

We need to start by serving this site on `privacytoolsio.github.io/privacytools.io` instead of `www.privacytools.io` so we can actually implement this server side (which is what this commit accomplishes). Once we move to the new DNS infrastructure we will point the main domain to our Nginx server and get Let's Encrypt installed. Hopefully this will be accomplished with minimal downtime.

Obviously, don't merge this until the backend is ready.

---

Resolves: #374 