### PR TITLE
Create Privacy Policy

### DIFF
--- a/_includes/sections/footer.html
+++ b/_includes/sections/footer.html
@@ -22,6 +22,6 @@
     </div>
   </div>
 
-  <p><em>privacytools.io is a socially motivated website that provides information for protecting your data security and privacy. never trust any company with your privacy, always encrypt.</em></p>
+  <p><em>privacytools.io is a socially motivated website that provides information for protecting your data security and privacy. never trust any company with your privacy, always encrypt. <a href="/privacy-policy.html">view our privacy policy</a>.</em></p>
 
 </footer>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,95 @@
+---
+layout: default
+active_page: privacy_policy
+---
+<div class="container" role="main">
+  <div class="jumbotron p-5">
+    <h1 class="display-4">Privacy Policy</h1>
+    <p>This Privacy Policy explains what information privacytoolsIO and its related entities collect about its users,
+      what we do with that information, and how we handle the content you place in our products and services.</p>
+  </div>
+
+  <h2>Scope of Privacy Policy</h2>
+
+  <p>This Privacy Policy applies to the information that we obtain through your use of privacytoolsIO's services via a Device
+    or when you otherwise interact with privacytoolsIO's official web services.</p>
+  <p>privacytoolsIO services include our:</p>
+  <ul>
+    <li>Websites (privacytools.io and subdomains *.privacytools.io)</li>
+  </ul>
+  <p>but does not include:</p>
+  <ul>
+    <li>Products or services for which a separate privacy policy is provided.</li>
+    <li>Third Party Products. These are third party products or services that you may discover on our website or other official services we offer.
+      privacytoolsIO cannot guarantee your privacy outside of websites under our control. You should always review the policies of third party products
+      and services to make sure you are comfortable with the ways in which they collect and use your information.</li>
+  </ul>
+
+  <h2>Website Visitors</h2>
+  <p>Like most website operators, privacytoolsIO collects non-personally-identifying information of the sort that web browsers and servers typically make available,
+  such as the browser type, language preference, referring site, and the date and time of each visitor request. privacytoolsIO's purpose in collecting
+  non-personally identifying information is to better understand how its visitors use its website and related services.
+  From time to time, privacytoolsIO may release non-personally-identifying information in the aggregate, e.g.,
+  by publishing a report on trends in the usage of its website.</p>
+
+  <p>privacytoolsIO also collects potentially personally-identifying information like Internet Protocol (IP) addresses.
+    privacytoolsIO does not use such information to identify its visitors, however, and does not disclose such information,
+    other than under the same circumstances that it uses and discloses personally-identifying information, as described below.</p>
+
+  <h2>Opting Out of Website Tracking</h2>
+
+  <p>privacytoolsIO uses a self-hosted Matomo install to track visitor data. You can opt out entirely using the form below. This form may not function correctly with
+  an ad blocker enabled.</p>
+
+  <iframe
+        style="border: 0; height: 100px; width: 100%;"
+        src="https://stats.privacytools.io/index.php?module=CoreAdminHome&action=optOut&language=en&backgroundColor=&fontColor=212529&fontSize=1rem&fontFamily=-apple-system%2CBlinkMacSystemFont%2C%22Segoe%20UI%22%2CRoboto%2C%22Helvetica%20Neue%22%2CArial%2Csans-serif%2C%22Apple%20Color%20Emoji%22%2C%22Segoe%20UI%20Emoji%22%2C%22Segoe%20UI%20Symbol%22%2C%22Noto%20Color%20Emoji%22"
+        ></iframe>
+
+  <p>privacytoolsIO respects your Do Not Track setting in your browser. Users with Do Not Track enabled will not be tracked by any of our platforms.
+  You are also free to block stats.privacytools.io using whatever method you prefer with no detrimental effects on your experience using our services.</p>
+
+  <h2>Gathering of Personally-Identifying Information</h2>
+
+  <p>Certain visitors to privacytoolsIO's websites choose to interact with privacytoolsIO in ways that require privacytoolsIO to gather personally-identifying information.
+    The amount and type of information that privacytoolsIO gathers depends on the nature of the interaction. For example, we ask visitors who use our <a href="https://social.privacytools.io/">Mastodon service</a>
+    to provide a username and email address. In each case, privacytoolsIO collects such information only as in necessary or appropriate to fulfill the purpose of the
+    visitor’s interaction with privacytoolsIO. privacytoolsIO does not disclose personally-identifying information other than as described below. And visitors can always
+    refuse to supply personally-identifying information, with the caveat that it may prevent them from engaging in certain website-related activities.</p>
+
+  <h2>Protection of Personally-Identifying Information</h2>
+
+  <p>privacytoolsIO will never rent, sell, nor give away potentially personally-identifying and personally-identifying information to any third parties.</p>
+
+  <p>If you are a registered user of a privacytoolsIO service such as Mastodon or PeerTube, privacytoolsIO may occasionally send you an email to tell you about new features,
+    solicit your feedback, or just keep you up to date with what’s going on with the service and the privacytoolsIO organization.
+    We expect to keep this type of email to a minimum.</p>
+
+  <p>privacytoolsIO takes all measures reasonably necessary to protect against the unauthorized access, use, alteration, or destruction of potentially personally-identifying and personally-identifying information.</p>
+
+  <h2>Aggregated Statistics</h2>
+
+  <p>privacytoolsIO may collect statistics about the behavior of visitors to its websites, and may reveal generalized statistics related to a variety of our services.</p>
+
+  <h2>Cookies</h2>
+
+  <p>A cookie is a string of information that a website stores on a visitor’s computer, and that the visitor’s browser provides to the website each time the visitor returns.
+    privacytoolsIO uses cookies to help privacytoolsIO track visitor statistics, a visitor's usage of the privacytoolsIO website or services, and their services preferences.
+    privacytoolsIO visitors who do not wish to have cookies placed on their computers should set their browsers to refuse cookies before using privacytoolsIO's websites,
+    with the drawback that certain features of privacytoolsIO's websites may not function properly without the aid of cookies.</p>
+
+  <h2>Privacy Policy Changes</h2>
+
+  <p>Although most changes are likely to be minor, privacytoolsIO may change its Privacy Policy from time to time, and at privacytoolsIO's sole discretion.
+    privacytoolsIO encourages visitors to frequently check this page for any changes to its Privacy Policy. Your continued use of this site
+     after any change in this Privacy Policy will constitute your acceptance of such change.</p>
+
+  <h2>Contact Us</h2>
+
+  <p>If you have any questions or concerns about this privacy policy or the data we collect, you are free to <a href="https://github.com/privacytoolsIO/privacytools.io/issues">open an issue on our issue tracker at GitHub</a>.</p>
+
+  <br /><hr /><br />
+
+  {% include sections/footer.html %}
+
+</div>


### PR DESCRIPTION
Adds a privacy policy to the site and footer for this site, our Matomo tracking, and our services. This privacy policy is based heavily off https://www.opennic.org/privacy/ -- if someone could check and make sure everything fits with this project, that would be great.

Do not merge until:

- [x] piwik.privacytools.io is moved to stats.privacytools.io (#793)
- [ ] DNS switched from CloudFlare to self-hosted (#794)

---

Related: #475