### PR TITLE
Remove AES Crypt

### DIFF
--- a/_includes/sections/file-encryption.html
+++ b/_includes/sections/file-encryption.html
@@ -42,7 +42,6 @@
 
 <ul>
   <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.</li>
-  <li><a href="https://www.aescrypt.com/">AES Crypt</a> - Using a powerful 256-bit encryption algorithm, AES Crypt can safely secure your most sensitive files. For Windows, macOS, Linux and Android.</li>
   <li><a href="https://diskcryptor.net/">DiskCryptor</a> - A full disk and partition encryption system for Windows including the ability to encrypt the partition and disk on which the OS is installed.</li>
   <li><a href="https://gitlab.com/cryptsetup/cryptsetup/">Linux Unified Key Setup (LUKS)</a> - A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.
 </ul>


### PR DESCRIPTION
## Description

Remove AES Crypt from the "worth mentioning" section of file encryption because

- there appears to be [known issues](https://web.archive.org/web/20121029141517/https://www.aescrypt.com/wishlist.html) with the current file format they utilize. This issue allows anybody to truncate encrypted files without being detected.
- the issues [won't be fixed anytime soon](https://github.com/paulej/AESCrypt/issues/23).
- the code [doesn't appear to be under any kind of open source license](https://github.com/paulej/AESCrypt).

Resolves: #805

Related info: [Reddit thread](https://old.reddit.com/r/privacytoolsIO/comments/b7riov/aes_crypt_security_audit_1_serious_issue_found/)

<!--
## Screenshots

Please add screenshots if applicable
-->
