### PR TITLE
Update to BCH CashAddr

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -26,7 +26,7 @@ permalink: /donate/
       <div class="form-group row">
         <label for="BCH" class="col-sm-4 col-form-label"><strong>Bitcoin Cash (BCH)</strong></label>
         <div class="col-sm-8">
-          <input id="BCH" type="text" value="1FhsstXDBJqpAnSU9D2kCFN4nFY4vUnXZ3" onclick="this.focus();this.select()" class="form-control input-lg" readonly>
+          <input id="BCH" type="text" value="bitcoincash:qzs5eh484cc7gq2frw4y0ygdg33uv6ucrq48ewgqqf" onclick="this.focus();this.select()" class="form-control input-lg" readonly>
         </div>
       </div>
 


### PR DESCRIPTION
*Apparently* normal addresses [are totally *out*](https://www.bitcoinabc.org/2018-01-14-CashAddr/) for Bitcoin Cash, and CashAddrs are *in*. Converted our wallet with https://cashaddr.bitcoincash.org/