### PR TITLE
Remove Google+ mention, because it is gone

### DIFF
--- a/_includes/sections/social-networks.html
+++ b/_includes/sections/social-networks.html
@@ -1,7 +1,7 @@
 <h1 id="social" class="anchor"><a href="#social"><i class="fas fa-link anchor-icon"></i></a> Decentralized Social Networks</h1>
 
 <div class="alert alert-warning" role="alert">
-  <strong> If you are currently using Social Networks like Facebook, Twitter or Google+, you should pick an alternative here. </strong>
+  <strong> If you are currently using Social Networks like Facebook or Twitter, you should pick an alternative here. </strong>
 </div>
 
 <div class="row mb-2">


### PR DESCRIPTION
<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Related info:
https://support.google.com/plus/answer/9195133?hl=en

https://www.iol.co.za/business-report/technology/google-launches-replacement-for-google-called-google-currents-20966583

Resolves: #none <!-- The number of the issue that is resolved by this pull request. If there is none, feel free to delete this line -->

<!--
## Screenshots

Please add screenshots if applicable
-->
