### PR TITLE
Revert "browser-tweaks: remove browser.send_pings"

### DIFF
--- a/_includes/sections/browser-tweaks.html
+++ b/_includes/sections/browser-tweaks.html
@@ -37,6 +37,9 @@
   <dt>browser.safebrowsing.phishing.enabled = false</dt>
   <dd>Disable Google Safe Browsing and phishing protection. Security risk, but privacy improvement.</dd>
 
+  <dt>browser.send_pings = false</dt>
+  <dd>The attribute would be useful for letting websites track visitors' clicks.</dd>
+
   <dt>browser.sessionstore.max_tabs_undo = 0</dt>
   <dd>Even with Firefox set to not remember history, your closed tabs are stored temporarily at Menu -&gt; History -&gt; Recently Closed Tabs.</dd>
 


### PR DESCRIPTION
Reverts privacytoolsIO/privacytools.io#865

https://www.bleepingcomputer.com/news/software/mozilla-firefox-to-enable-hyperlink-ping-tracking-by-default/