### PR TITLE
browser-recommendation: suggest Firefox ESR instead of Firefox

### DIFF
--- a/_includes/sections/browser-recommendation.html
+++ b/_includes/sections/browser-recommendation.html
@@ -12,12 +12,13 @@
   %}
 
   {% include card.html color="primary"
-  title="Mozilla Firefox"
+  title="Mozilla Firefox ESR"
   image="/assets/img/tools/Firefox.png"
-  url="https://www.firefox.com/"
+  website="mozilla.org"
+  url="https://www.mozilla.org/en-US/firefox/organizations/all/"
   footer="OS: Windows, macOS, Linux, Android, iOS, BSD."
   description='Firefox is fast, reliable, open source and respects your privacy. Don\'t forget to adjust the settings according to our
-  recommendations: <a href="#webrtc"><i class="fas fa-link"></i> WebRTC</a> and <a href="#about_config"><i class="fas fa-link"></i> about:config</a> and get the <a href="#addons"><i class="fas fa-link"></i> privacy add-ons</a>.'
+  recommendations: <a href="#webrtc"><i class="fas fa-link"></i> WebRTC</a> and <a href="#about_config"><i class="fas fa-link"></i> about:config</a> and get the <a href="#addons"><i class="fas fa-link"></i> privacy add-ons</a>. The extended support release (ESR) gets new features more slowly, while still receiving backported security updates promptly.'
   %}
 
   {% include card.html color="warning"


### PR DESCRIPTION
I wonder if this could be a compromise suggestion to #856 as with ESR the potentially privacy invasive updates also come more slowly and may in some cases be cancelled before they reach the ESR branch.

Problem: I don't think ESR exists on mobile Android and iOS.

Solution: Having different browser recommendations for those platforms such as Tor Browser (Alpha), Firefox Klar or DuckDuckGo (give me issue number please) and Brave?