### PR TITLE
Add Sarchy to Search Engines

### DIFF
--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -55,6 +55,7 @@ github="https://github.com/Qwant/"
 
 <ul>
   <li><a href="https://yacy.net/">YaCy</a> - A free software P2P search engine powered by its users.</a></li>  
+  <li><a href="http://sarchy.condense.press/">Sarchy</a> - Distributed Peer-to-Peer Web Search Engine (Fork of YaCy).</a></li>  
   <li><a href="https://jivesearch.com/">Jive Search</a> - A free software search engine with a similar look and feel to Google.</a></li>  
   <li><a href="https://metager.de/en/">MetaGer</a> - An open source metasearch engine, which is based in Germany. It focuses on protecting the user's privacy.</li>
 </ul>

--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -55,7 +55,7 @@ github="https://github.com/Qwant/"
 
 <ul>
   <li><a href="https://yacy.net/">YaCy</a> - A free software P2P search engine powered by its users.</a></li>  
-  <li><a href="http://sarchy.condense.press/">Sarchy</a> - Distributed Peer-to-Peer Web Search Engine (Fork of YaCy).</a></li>  
+  <li><a href="https://sarchy.condense.press/">Sarchy</a> - Distributed Peer-to-Peer Web Search Engine (Fork of YaCy).</a></li>  
   <li><a href="https://jivesearch.com/">Jive Search</a> - A free software search engine with a similar look and feel to Google.</a></li>  
   <li><a href="https://metager.de/en/">MetaGer</a> - An open source metasearch engine, which is based in Germany. It focuses on protecting the user's privacy.</li>
 </ul>


### PR DESCRIPTION
**Description**: Add Sarchy to Search Engines
**What is Sarchy?** Sarchy is a FLOSS privacy-eccentric Yacy reboot/fork/based.
https://github.com/agnelvishal/yacy_search_server