### PR TITLE
[Discussion] Add Instances for Federated Services

### DIFF
--- a/_includes/sections/calendar-contacts-sync.html
+++ b/_includes/sections/calendar-contacts-sync.html
@@ -12,6 +12,7 @@
   url="https://nextcloud.com/"
   footer="Client OS: Windows, macOS, Linux, BSD, Unix, iOS, Android, Fire OS. Server: Linux."
   description="NextCloud is a suite of client-server software for creating and using file hosting services. This includes calendar sync via CalDAV and contacts sync via CardDAV. Nextcloud is free and open-source, thereby allowing anyone to install and operate it without charge on a private server."
+  extra_button='href="https://nextcloud.com/providers/">Providers</a>'
   %}
 
   {% include card.html color="primary"

--- a/_includes/sections/cloud-storage.html
+++ b/_includes/sections/cloud-storage.html
@@ -9,6 +9,7 @@ title="Nextcloud - Choose your hoster"
 image="/assets/img/provider/Nextcloud.png"
 description="Similar functionally to the widely used Dropbox, with the difference being that Nextcloud is free and open-source, and thereby allowing anyone to install and operate it without charge on a private server, with no limits on storage space or the number of connected clients."
 website="https://nextcloud.com/"
+extra_button='<a class="btn btn-success mb-1" href="https://nextcloud.com/providers/">Providers</a>'
 forum="https://forum.privacytools.io/t/discussion-nextcloud/287"
 github="https://github.com/nextcloud"
 windows=""

--- a/_includes/sections/social-networks.html
+++ b/_includes/sections/social-networks.html
@@ -14,6 +14,7 @@ github="https://github.com/tootsuite/mastodon"
 android=""
 ios=""
 web=""
+extra_button='<a class="btn btn-success mb-1" href="https://mstdn.io/">Open Instance: Mstdn.io</a>'
 %}
 
 {% include cardv2.html
@@ -25,6 +26,7 @@ forum="https://forum.privacytools.io/t/discussion-diaspora/290"
 github="https://github.com/diaspora/diaspora"
 android=""
 web=""
+extra_button='<a class="btn btn-success mb-1" href="https://diasp.org/">Open Instance: Diasp.org</a>'
 %}
 
 {% include cardv2.html
@@ -38,6 +40,7 @@ windows=""
 linux=""
 android=""
 web=""
+extra_button='<a class="btn btn-success mb-1" href="https://quitter.pl/">Open Instance: Quitter</a>'
 %}
 
 {% include cardv2.html
@@ -62,6 +65,7 @@ ios=""
 linux=""
 windows=""
 web=""
+extra_button='<a class="btn btn-success mb-1" href="https://status.fsf.org/">Open Instance: status.fsf.org</a>'
 %}
 
 <h3>Worth Mentioning</h3>

--- a/_includes/sections/social-networks.html
+++ b/_includes/sections/social-networks.html
@@ -14,7 +14,7 @@ github="https://github.com/tootsuite/mastodon"
 android=""
 ios=""
 web=""
-extra_button='<a class="btn btn-success mb-1" href="https://social.privacytools.io/">PrivacyTools.io Social</a>'
+extra_button='<a class="btn btn-success mb-1" href="https://social.privacytools.io/">Open Instance: social.privacytools.io</a>'
 %}
 
 {% include cardv2.html

--- a/_includes/sections/social-networks.html
+++ b/_includes/sections/social-networks.html
@@ -14,7 +14,7 @@ github="https://github.com/tootsuite/mastodon"
 android=""
 ios=""
 web=""
-extra_button='<a class="btn btn-success mb-1" href="https://mstdn.io/">Open Instance: Mstdn.io</a>'
+extra_button='<a class="btn btn-success mb-1" href="https://social.privacytools.io/">PrivacyTools.io Social</a>'
 %}
 
 {% include cardv2.html


### PR DESCRIPTION
**Discussion**: Add Instances For Federated/Self-Hosting Services like Mastadon or Nextcloud
**Why**? In my experience, many users won't go through the effort of choosing an instance. 
This way users will have less steps to actually start using a service.

**Some instances I recommend**:
Mastadon: [Mstdn.io](https://www.mstdn.io/)
Diaspora: [Diasp.org](https://www.diasp.org/)
Frendica: [Quitter](https://quitter.pl/)

For Nextcloud it is very easy to find and set up an instance so I just provided the provider list.

**What needs to be discussed?**
First of all, are there any major flaws with these instances?
Secondly, are there any other services that need an instance listed.

And the usual, should this PR be merged :)