### PR TITLE
Remove Signal until Removal of Proprietary Software

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -5,17 +5,6 @@
 </div>
 
 <div class="row mb-2">
-  {% include card.html color="success"
-  title="Mobile: Signal"
-  image="/assets/img/tools/Signal.png"
-  url="https://signal.org"
-  footer="OS: Android, iOS, macOS, Windows, Linux"
-  description="Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
-  All communications are end-to-end encrypted. Signal is free and open source, enabling anyone to verify its security by auditing the code. The development team is supported by community donations and grants. There are no advertisements,
-  and it doesn't cost anything to use."
-  %}
-
-
   {% include card.html color="primary"
   title="Riot.im"
   image="/assets/img/tools/riot.png"

--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -5,6 +5,17 @@
 </div>
 
 <div class="row mb-2">
+ <!-- Signal removed	
+  {% include card.html color="success"
+  title="Mobile: Signal"
+  image="/assets/img/tools/Signal.png"
+  url="https://signal.org"
+  footer="OS: Android, iOS, macOS, Windows, Linux"
+  description="Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
+  All communications are end-to-end encrypted. Signal is free and open source, enabling anyone to verify its security by auditing the code. The development team is supported by community donations and grants. There are no advertisements,
+  and it doesn't cost anything to use."
+  %}
+-->
   {% include card.html color="primary"
   title="Riot.im"
   image="/assets/img/tools/riot.png"

--- a/_includes/sections/voice-video-messenger.html
+++ b/_includes/sections/voice-video-messenger.html
@@ -4,6 +4,7 @@
   <strong>If you are currently using a Video & Voice Messenger like Skype, Viber or Google Hangouts, you should pick an alternative here.</strong>
 </div>
 <div class="row mb-2">
+  <!-- Signal removed
   {% include card.html color="success"
   title="Mobile: Signal"
   image="/assets/img/tools/Signal.png"
@@ -13,7 +14,7 @@
   All communications are end-to-end encrypted. Signal is free and open source, enabling anyone to verify its security by auditing the code. The development team is supported by community donations and grants. There are no advertisements,
   and it doesn't cost anything to use."
   %}
-
+-->
   {% include card.html color="primary"
   title="Wire"
   image="/assets/img/tools/wire.png"


### PR DESCRIPTION
**Description**: Signal uses non-free software. I would like to push the notion to remove them until all non-free dependencies have been resolved.

> "[Signal] currently has a proprietary dependency on Google libraries. Helping the project remove this dependency and operate the necessary infrastructure is a high priority. " - [FSF](https://www.fsf.org/campaigns/priority-projects/voicevideochat)