### PR TITLE
Add LibertyBSD to OSes

### DIFF
--- a/_includes/sections/operating-systems.html
+++ b/_includes/sections/operating-systems.html
@@ -40,7 +40,7 @@
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://www.openbsd.org/">OpenBSD</a> - A project that produces a free, multi-platform 4.4BSD-based UNIX-like operating system. Emphasizes portability, standardization, correctness, proactive security and integrated cryptography.</li>
+  <li><a href="https://www.openbsd.org/">OpenBSD</a> - A project that produces a free, multi-platform 4.4BSD-based UNIX-like operating system. Emphasizes portability, standardization, correctness, proactive security and integrated cryptography. <a href="https://libertybsd.net/">LibertyBSD</a> is a completely <a href="https://www.wikipedia.org/wiki/Free_software">free software</a> version of <a href="https://www.openbsd.org/">OpenBSD</a>.</li>
   <li><a href="https://www.archlinux.org/">Arch Linux</a> - A simple, lightweight Linux distribution. It is composed predominantly of free and open-source software, and supports community involvement. <a href="https://www.parabola.nu/">Parabola</a> is a
     completely open source version of Arch Linux.</li>
   <li><a href="https://www.whonix.org/">Whonix</a> - A Debian GNU/Linux based security-focused Linux distribution. It aims to provide privacy, security and anonymity on the internet. The operating system consists of two virtual machines, a "Workstation"

--- a/_includes/sections/router-firmware.html
+++ b/_includes/sections/router-firmware.html
@@ -28,6 +28,6 @@
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://www.openbsd.org/">OpenBSD</a> - A project that produces a free, multi-platform 4.4BSD-based UNIX-like operating system. Emphasizes portability, standardization, correctness, proactive security and integrated cryptography.</li>
+  <li><a href="https://www.openbsd.org/">OpenBSD</a> - A project that produces a free, multi-platform 4.4BSD-based UNIX-like operating system. Emphasizes portability, standardization, correctness, proactive security and integrated cryptography. <a href="https://libertybsd.net/">LibertyBSD</a> is a completely <a href="https://www.wikipedia.org/wiki/Free_software">free software</a> version of <a href="https://www.openbsd.org/">OpenBSD</a>.</li>
   <li><a href="https://dd-wrt.com/">DD-WRT</a> - A is Linux-based firmware for wireless routers and wireless access points. It is compatible with several models of routers and access points.</li>
 </ul>


### PR DESCRIPTION
**Description**: Add LibertyBSD to OSes.
**Has this been discussed before?** Yes, #929 
**How?**: I recommend changing the OpenBSD description to:

> A project that produces a free, multi-platform 4.4BSD-based UNIX-like operating system. Emphasizes portability, standardization, correctness, proactive security and integrated cryptography. [LibertyBSD](https://libertybsd.net) is a completely [free software](https://www.wikipedia.org/wiki/Free_software) version of [OpenBSD](https://openbsd.org).

This is very similar to the way [Parabola](https://www.wikipedia.org/wiki/Parabola_GNU/Linux-libre) is listed as a free'd version of [Arch](https://www.wikipedia.org/wiki/Arch_Linux).

**Does LibertyBSD remove any of the security functionality of OpenBSD?**
Although I'm unaware of any non-freedom changes this was one of the issues brought up in #929.