### PR TITLE
Add Experimental note to Ricochet

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -39,7 +39,7 @@ web=""
 {% include cardv2.html
 title="Desktop: Ricochet"
 image="/assets/img/tools/Ricochet.png"
-description='Ricochet uses the <a href="/browsers/#browser"><i class="fas fa-link"></i> Tor network</a> to reach your contacts without relying on messaging servers. It creates a hidden service, which is used to rendezvous with your contacts without revealing your location or IP address. <span class="badge badge-danger">Danger</span> <a href="#ricochetTor">Keep Tor up to date</a>'
+description='Ricochet uses the <a href="/browsers/#browser"><i class="fas fa-link"></i> Tor network</a> to reach your contacts without relying on messaging servers. It creates a hidden service, which is used to rendezvous with your contacts without revealing your location or IP address. <span class="badge badge-warning" data-toggle="tooltip" title="This software is an experiment."><a href="https://github.com/ricochet-im/ricochet#experimental">Experimental</a></span> <span class="badge badge-danger">Danger</span> <a href="#ricochetTor">Keep Tor up to date</a>'
 website="https://ricochet.im/"
 forum="https://forum.privacytools.io/t/discussion-ricochet/666"
 github="https://github.com/ricochet-im/ricochet"


### PR DESCRIPTION
## Description
Other messengers have the Experimental tag so Ricochet should as well since it is considered as such by the author and is documented right in the readme and on the website.

Resolves: #none

