### PR TITLE
Add Wireguard to VPN Providers

### DIFF
--- a/_includes/sections/vpn.html
+++ b/_includes/sections/vpn.html
@@ -15,6 +15,7 @@
         <th data-sortable="true" title="Number of Servers"># Servers</th>
         <th data-sortable="true">Free Trial</th>
         <th data-sortable="true">WireGuard</th>
+        <th data-sortable="true">Jurisdiction</th>
         <th data-sortable="false">Website</th>
       </tr>
     </thead>

--- a/_includes/sections/vpn.html
+++ b/_includes/sections/vpn.html
@@ -13,7 +13,6 @@
         <th data-sortable="true">Yearly Price</th>
         <th data-sortable="true">Free Trial</th>
         <th data-sortable="true" title="Number of Servers"># Servers</th>
-        <th data-sortable="true">Free Trial</th>
         <th data-sortable="true">WireGuard</th>
         <th data-sortable="true">Jurisdiction</th>
         <th data-sortable="false">Website</th>

--- a/_includes/sections/vpn.html
+++ b/_includes/sections/vpn.html
@@ -13,7 +13,8 @@
         <th data-sortable="true">Yearly Price</th>
         <th data-sortable="true">Free Trial</th>
         <th data-sortable="true" title="Number of Servers"># Servers</th>
-        <th data-sortable="true">Jurisdiction</th>
+        <th data-sortable="true">Free Trial</th>
+        <th data-sortable="true">WireGuard</th>
         <th data-sortable="false">Website</th>
       </tr>
     </thead>
@@ -24,6 +25,7 @@
         <td data-value="{{ 54 | times: eur_to_usd }}">54 €</td>
         <td><span class="label label-success">Yes</span></td>
         <td>162</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-it"></span> Italy</td>
         <td><a href="https://airvpn.org/">AirVPN.org</a></td>
       </tr>
@@ -35,6 +37,7 @@
         <td data-value="{{ 45 | times: eur_to_usd }}">45 €</td>
         <td><span class="label label-success">Yes</span></td>
         <td>22</td>
+        <td><span class="label label-success">Yes</span></td>
         <td><span class="flag-icon flag-icon-se"></span> Sweden</td>
         <td><a href="https://www.azirevpn.com/">AzireVPN.com</a></td>
       </tr>
@@ -46,6 +49,7 @@
         <td data-value="{{ 49 | times: eur_to_usd }}">49 €</td>
         <td><span class="label label-success">Yes</span></td>
         <td>31</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-hk"></span> Hong Kong</td>
         <td><a href="https://www.blackvpn.com/">blackVPN.com</a></td>
       </tr>
@@ -57,6 +61,7 @@
         <td data-value="52">$ 52</td>
         <td><span class="label label-success">Yes</span></td>
         <td>28</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-is"></span> Iceland</td>
         <td><a href="https://cryptostorm.is/">Cryptostorm.is</a></td>
       </tr>
@@ -68,6 +73,7 @@
         <td data-value="100">$ 99.95</td> <!-- USD on December 28, 2018 -->
         <td><span class="label label-success">Yes</span></td>
         <td>148</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-vg"></span> British Virgin Islands</td>
         <td><a href="https://www.expressvpn.com/">ExpressVPN.com</a></td>
       </tr>
@@ -79,6 +85,7 @@
         <td data-value="36">$ 35.88</td>
         <td><span class="label label-warning">No</span></td>
         <td>27</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-se"></span> Sweden</td>
         <td><a href="https://www.frootvpn.com/">FrootVPN.com</a></td>
       </tr>
@@ -90,6 +97,7 @@
         <td data-value="0"><a data-toggle="tooltip" data-placement="bottom" data-original-title="2 GB data transfer, 1 simultaneous connection" href="https://hide.me/pricing">Free</a></td>
         <td><span class="label label-success">Yes</span></td>
         <td>160+</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-my"></span> Malaysia</td>
         <td><a href="https://hide.me/">hide.me</a></td>
       </tr>
@@ -101,6 +109,7 @@
         <td data-value="100">$ 100</td>
         <td><span class="label label-success">Yes</span></td>
         <td>38</td>
+        <td><span class="label label-success">Yes</span></td>
         <td><span class="flag-icon flag-icon-gi"></span> Gibraltar</td>
         <td><a href="https://www.ivpn.net/">IVPN.net</a></td>
       </tr>
@@ -112,6 +121,7 @@
         <td data-value="{{ 60 | times: eur_to_usd }}">60 €</td>
         <td><span class="label label-success">Yes</span></td>
         <td>281</td>
+        <td><span class="label label-success">Yes</span></td>
         <td><span class="flag-icon flag-icon-se"></span> Sweden</td>
         <td><a href="https://mullvad.net/">Mullvad.net</a></td>
       </tr>
@@ -123,6 +133,7 @@
         <td data-value="84">$ 83.88</td>
         <td><span class="label label-success">Yes</span></td>
         <td>5200+</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-pa"></span> Panama</td>
         <td><a href="https://nordvpn.com/">NordVPN.com</a></td>
       </tr>
@@ -134,6 +145,7 @@
         <td data-value="{{ 84 | times: eur_to_usd }}">84 €</td>
         <td><span class="label label-success">Yes</span></td>
         <td>67</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-se"></span> Sweden</td>
         <td><a href="https://www.ovpn.com/">OVPN.com</a></td>
       </tr>
@@ -145,6 +157,7 @@
         <td data-value="{{ 119.99 | times: eur_to_usd }}">119.99 €</td>
         <td><span class="label label-warning">No</span></td>
         <td>54</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-ch"></span> Switzerland</td>
         <td><a href="https://www.perfect-privacy.com/">Perfect-Privacy.com</a></td>
       </tr>
@@ -156,6 +169,7 @@
         <td data-value="0"><a data-toggle="tooltip" data-placement="bottom" data-original-title="3 countries, 1 device, speed: low" href="https://protonvpn.com/pricing">Free</a></td>
         <td><span class="label label-success">Yes</span></td>
         <td>396</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-ch"></span> Switzerland</td>
         <td><a href="https://protonvpn.com/">ProtonVPN.com</a></td>
       </tr>
@@ -167,6 +181,7 @@
         <td data-value="40">$ 40</td>
         <td><span class="label label-warning">No</span></td>
         <td>300+</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>
         <td><a href="https://proxy.sh/">Proxy.sh</a></td>
       </tr>
@@ -178,6 +193,7 @@
         <td data-value="40">$ 39.95</td>
         <td><span class="label label-success">Yes</span></td>
         <td>164</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>
         <td><a href="https://trust.zone/">Trust.Zone</a></td>
       </tr>
@@ -188,6 +204,7 @@
         <td data-value="40">$ 39.99</td>
         <td><span class="label label-warning">No</span></td>
         <td>128</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-hk"></span> Hong Kong</td>
         <td><a href="https://vpn.ht/">VPN.ht</a></td>
       </tr>
@@ -198,6 +215,7 @@
         <td data-value="59">$ 59</td>
         <td><span class="label label-success">Yes</span></td>
         <td>204</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-bg"></span> Bulgaria</td>
         <td><a href="https://vpnarea.com/">VPNArea.com</a></td>
       </tr>
@@ -208,6 +226,7 @@
         <td data-value="{{ 35.88 | times: eur_to_usd }}">35.88 €</td>
         <td><span class="label label-warning">No</span></td>
         <td>800+</td>
+        <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>
         <td><a href="https://vpntunnel.com/">VPNTunnel.com</a></td>
       </tr>


### PR DESCRIPTION
**Description**: Add WireGuard support to VPN provider table/comparison.
**Why?**: Personally, I couldn't run a VPN without WireGuard, OpenVPN was too taxing on my already slow speeds. This helps show users that OpenVPN isn't the only way to utilize a VPN.
**But isn't WireGuard beta?** Yes, but this PR isn't about recommending WireGuard. Instead it is about making it easier for users to choose for themselves. 
**Has this been discussed before?** Yes, #633 .