### PR TITLE
Add Warnings to Non-free Email Providers

### DIFF
--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -70,7 +70,7 @@
         <td data-value="1000">1 GB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
-        <td data-value="1"><span class="label label-success">Yes</span></td>
+        <td data-value="1"><span class="label label-success">Yes (backend is non-free)</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>

--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -105,7 +105,7 @@
         <td data-value="2000">2 GB</td>
         <td data-value="13">12 €</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
-        <td data-value="0"><span class="label label-warning">No</span></td>
+        <td data-value="0"><span class="label label-warning"> </span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>

--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -15,6 +15,7 @@
         <th data-sortable="true">Storage</th>
         <th data-sortable="true">Price / Year</th>
         <th data-sortable="true">Bitcoin</th>
+        <th data-sortable="true">Free Software</th>
         <th data-sortable="true">Encryption</th>
         <th data-sortable="true">Own Domain</th>
       </tr>
@@ -35,6 +36,7 @@
         <td data-value="500">500 MB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">Yes (backend is non-free)</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -51,6 +53,7 @@
         <td data-value="2000">2 GB</td>
         <td data-value="1"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">Yes</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -67,6 +70,7 @@
         <td data-value="1000">1 GB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
+        <td data-value="1"><span class="label label-success">Yes</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -83,6 +87,7 @@
         <td data-value="500">500 MB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="0"><span class="label label-warning">No</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -100,6 +105,7 @@
         <td data-value="2000">2 GB</td>
         <td data-value="13">12 €</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="0"><span class="label label-warning">No</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -116,6 +122,7 @@
         <td data-value="2000">2 GB</td>
         <td data-value="13">12 €</td>
         <td data-value="0"><span class="label label-primary">No</span></td>
+        <td data-value="1"><span class="label label-success">Yes</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
       </tr>
@@ -133,6 +140,7 @@
         <td data-value="1000">1 GB</td>
         <td data-value="20">$ 19.95</td>
         <td data-value="1"><span class="label label-primary">Yes</span></td>
+        <td data-value="0"><span class="label label-warning">No</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -149,6 +157,7 @@
         <td data-value="1000">1 GB</td>
         <td data-value="50">$ 49.95</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="0"><span class="label label-warning">No</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -165,6 +174,7 @@
         <td data-value="10000">10 GB</td>
         <td data-value="60">$ 59.95</td>
         <td data-value="0"><span class="label label-success">Accepted</span></td>
+        <td data-value="0"><span class="label label-warning">No</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -181,6 +191,7 @@
         <td data-value="2048">2 GB</td>
         <td data-value="60">$ 60</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">Yes</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>

--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -122,7 +122,7 @@
         <td data-value="2000">2 GB</td>
         <td data-value="13">12 €</td>
         <td data-value="0"><span class="label label-primary">No</span></td>
-        <td data-value="1"><span class="label label-success">Yes</span></td>
+        <td data-value="1"><span class="label label-success">Yes (excludes certain payment options).</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
       </tr>

--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -191,7 +191,7 @@
         <td data-value="2048">2 GB</td>
         <td data-value="60">$ 60</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
-        <td data-value="1"><span class="label label-success">Yes</span></td>
+        <td data-value="1"><span class="label label-success">W.I.P</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>


### PR DESCRIPTION
**Feature**: Add warnings to email providers with non-free software
**Why?**: To highlight the issue of black box providers.
**What providers**: The majority of my sources is from the FSF with the default response being set to "no". Other providers like [Posteo](https://www.fsf.org/blogs/community/fsf-javascript-guidelines-picked-up-by-posteo-webmail), [Kolab Now](https://www.wikipedia.org/wiki/Kolab_Now), and Disroot list themselves as being free software.
https://www.fsf.org/resources/webmail-systems