### PR TITLE
Updated URL link for NoTrack

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -30,7 +30,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://github.com/quidsup/notrack">NoTrack</a> - A network-wide DNS server which blocks Tracking sites. Currently works in Debian and Ubuntu.</li>
+  <li><a href="https://gitlab.com/quidsup/notrack">NoTrack</a> - A network-wide DNS server which blocks Tracking sites. Currently works in Debian and Ubuntu.</li>
   <li><a href="https://namecoin.info/">Namecoin</a> - A decentralized DNS open source information registration and transfer system based on the Bitcoin cryptocurrency.</li>
   <li><a href="https://pi-hole.net/">Pi-hole</a> - A network-wide DNS server for the Raspberry Pi.  Blocks advertising and tracking domains for all devices on your network.</li>
 </ul>


### PR DESCRIPTION
NoTrack Has Moved To GitLab - changed URL link

<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #none <!-- The number of the issue that is resolved by this pull request. If there is none, feel free to delete this line -->

<!--
## Screenshots

Please add screenshots if applicable
-->
