### PR TITLE
Swap Ricochet and Wire

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -36,16 +36,20 @@ linux=""
 web=""
 %}
 
+
 {% include cardv2.html
-title="Desktop: Ricochet"
-image="/assets/img/tools/Ricochet.png"
-description='Ricochet uses the <a href="/browsers/#browser"><i class="fas fa-link"></i> Tor network</a> to reach your contacts without relying on messaging servers. It creates a hidden service, which is used to rendezvous with your contacts without revealing your location or IP address. <span class="badge badge-warning" data-toggle="tooltip" title="This software is an experiment."><a href="https://github.com/ricochet-im/ricochet#experimental">Experimental</a></span> <span class="badge badge-danger">Danger</span> <a href="#ricochetTor">Keep Tor up to date</a>'
-website="https://ricochet.im/"
-forum="https://forum.privacytools.io/t/discussion-ricochet/666"
-github="https://github.com/ricochet-im/ricochet"
+title="Wire"
+image="/assets/img/tools/wire.png"
+description='A free software End-to-End Encrypted chatting application that supports instant messaging, voice, and video calls. Full source code is available. <span class="badge badge-warning" data-toggle="tooltip" title="Wire stores metadata such as your contacts in plaintext (= not encrypted)."><a href="https://www.vice.com/en_us/article/gvzw5x/secure-messaging-app-wire-stores-everyone-youve-ever-contacted-in-plain-text">meta-data concerns</a> <i class="far fa-question-circle"></i></span>'
+website="https://get.wire.com/"
+forum="https://forum.privacytools.io/t/discussion-wire/750"
+github="https://github.com/wireapp/"
+android=""
+ios=""
 mac=""
 windows=""
 linux=""
+web=""
 %}
 
 <h3>Complete Comparison</h3>
@@ -59,11 +63,11 @@ linux=""
 <h3>Worth Mentioning</h3>
 
 <ul>
+  <li><a href="https://ricochet.im/">Ricochet</a> - Ricochet uses the <a href="/browsers/#browser"><i class="fas fa-link"></i> Tor network</a> to reach your contacts without relying on messaging servers. It creates a hidden service, which is used to rendezvous with your contacts without revealing your location or IP address. <span class="badge badge-warning" data-toggle="tooltip" title="This software is an experiment."><a href="https://github.com/ricochet-im/ricochet#experimental">Experimental</a></span> <span class="badge badge-danger">Danger</span> <a href="#ricochetTor">Keep Tor up to date</a></li>
   <li><a href="https://retroshare.cc/">RetroShare</a> - An E2E encrypted instant messaging and voice/video call client. RetroShare supports both TOR and I2P. </li>
   <li><a href="https://www.chatsecure.org">ChatSecure</a> - ChatSecure is a free and open source messaging app that features OTR encryption over XMPP. </li>
   <li><a href="https://kontalk.org/">Kontalk</a> - A community-driven instant messaging network. Supports end-to-end encryption. Both client-to-server and server-to-server channels are fully encrypted.</li>
   <li><a href="https://play.google.com/store/apps/details?id=eu.siacs.conversations">Conversations</a> - An open source Jabber/XMPP client for Android 4.4+ smartphones. Supports end-to-end encryption with either OMEMO or openPGP. There is also <a href="https://play.google.com/store/apps/details?id=eu.siacs.conversations.legacy">Conversations Legacy</a> which still supports OTR.</li>
-  <li><a href="https://get.wire.com/">Wire</a> <span class="badge badge-warning" data-toggle="tooltip" title="Wire stores metadata such as list of your connections/conversations in plaintext (= not encrypted).">experimental <i class="far fa-question-circle"></i> (<a href="https://www.vice.com/en_us/article/gvzw5x/secure-messaging-app-wire-stores-everyone-youve-ever-contacted-in-plain-text">more info</a>)</span> - A free software End-to-End Encrypted chatting application that supports instant messaging, voice, and video calls.</li>
   <li><a href="https://status.im/">Status</a> - <span class="badge badge-warning">Experimental</span> A free and open-source, peer-to-peer, encrypted instant messanger with support for DAPPs. </li>    
   <li><a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging#Client_support">List of OTR Clients - Wikipedia</a></li>
 </ul>

--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -40,7 +40,7 @@ web=""
 {% include cardv2.html
 title="Wire"
 image="/assets/img/tools/wire.png"
-description='A free software End-to-End Encrypted chatting application that supports instant messaging, voice, and video calls. Full source code is available. <span class="badge badge-warning" data-toggle="tooltip" title="Wire stores metadata such as your contacts in plaintext (= not encrypted)."><a href="https://www.vice.com/en_us/article/gvzw5x/secure-messaging-app-wire-stores-everyone-youve-ever-contacted-in-plain-text">meta-data concerns</a> <i class="far fa-question-circle"></i></span>'
+description='A free software End-to-End Encrypted chatting application that supports instant messaging, voice, and video calls. Full source code is available. <span class="badge badge-warning" data-toggle="tooltip" title="Wire stores metadata such as list of your connections/conversations in plaintext (= not encrypted).">experimental <i class="far fa-question-circle"></i> (<a href="https://www.vice.com/en_us/article/gvzw5x/secure-messaging-app-wire-stores-everyone-youve-ever-contacted-in-plain-text">more info</a>)</span>'
 website="https://get.wire.com/"
 forum="https://forum.privacytools.io/t/discussion-wire/750"
 github="https://github.com/wireapp/"


### PR DESCRIPTION
## Description

Resolves: #948 

Ricochet is considered experimental, not easy to use and is no longer actively maintained.  See discussions #948  #840 

The latest commit on https://github.com/ricochet-im/ricochet was almost 2 years ago.
Also see:
https://github.com/ricochet-im/ricochet/issues/578
One of the lead developers is now focusing on another project:
https://openprivacy.ca/

That does not mean Ricochet is flawed, but it was always considered experimental and it is for advanced users only who need to setup and keep Tor up to date.

Wire was originally an IM recommendation, but then replaced with Riot.  Riot is not easy to make entirely private, but it is still a good option for advanced users.  So with one easy recommendation (Signal) which is primarily for mobile device use, that leaves currently two recommendations that are for advanced users (Riot and Ricochet). Since ease of use is supposed to be one of the primary considerations one of the advanced recommendations should be replaced with any easy to use option so that we have:
1 easy to use mobile only option (desktop client cannot be standalone, is tethered to a mobile)- Signal
1 easy to use mobile or desktop option- Wire
1 advanced option for mobile or desktop- Riot/Matrix.

Also Riot/Matrix has just been released out of beta and considered by the developers fully ready to use (though the encryption library may still be beta), so this puts Riot above the experimental status of Ricochet.

Up for discussion could be whether to mention Cwtch (still in alpha) as the probably replacement to Ricochet.