### PR TITLE
Remove Threema from explicit non-recommendation, alphabetize list, …

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -1,7 +1,7 @@
 <h1 id="im" class="anchor"><a href="#im"><i class="fas fa-link anchor-icon"></i></a> Encrypted Instant Messenger</h1>
 
 <div class="alert alert-warning" role="alert">
-  <strong>If you are currently using an Instant Messenger like WhatsApp, Viber, LINE, Telegram or Threema, you should pick an alternative here.</strong>
+  <strong>If you are currently using an Instant Messenger like LINE, Telegram, Viber, <a href="https://www.eff.org/deeplinks/2016/10/where-whatsapp-went-wrong-effs-four-biggest-security-concerns">WhatsApp</a> or plain SMS messages you should pick an alternative here.</strong>
 </div>
 
 


### PR DESCRIPTION
…add WhatsApp EFF article link, add SMS messages mention

## Description

Resolves: #948 

-Remove Threema from explicit non-recommendation
I don't think Threema should be categorized along with WhatsApp, Line, etc as being explicitly not recommended.  The only reasons I have encountered in discussions for others not liking it is that it is not fully open source and costs money (the price of a coffee).  Threema uses the open source NaCl box encryption model using elliptical curve DH 25519 key exchange and XSalsa20 encryption with all messages encrypted end to end.

-Alphabetize the remaining list of not recommended apps.

-Add a link for WhatsApp to an EFF article expressing their concerns with it.

-Add regular SMS messages to the list.  This may not really fit, as it is almost impossible to completely eliminate using SMS.