### PR TITLE
Add Security Policy

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -2,3 +2,4 @@ Contact: admin@privacytools.io
 Encryption: https://www.jonaharagon.com/keys/
 Preferred-Languages: en
 Canonical: https://www.privacytools.io/.well-known/security.txt
+Policy: https://github.com/privacytoolsIO/privacytools.io/security/policy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and policies for the `privacytools.io` repository/code and all services hosted by privacytools.io, such as Mastodon, Matrix, Riot, et cetera.
+
+## Reporting a Bug
+
+We take all security bugs related to our code and our infrastructure very seriously. Thank you for improving the security of our projects and services. We appreciate your efforts and responsible disclosure, and will make every effort to acknowledge your contributions.
+
+Report any security bugs by emailing the services administrator at [admin@privacytools.io](mailto:admin@privacytools.io).
+
+The administrative team will acknowledge your message within 48 hours, and will provide a detailed response within 72 hours detailing the next steps for handling your report. After our initial reply we will make every effort to keep you informed of the progress towards a fix and announcement, and we may ask for additional information or guidance.
+
+Please report any security bugs in third-party projects to the person or team maintaining that project.
+
+The following are out of scope and should **not** be performed:
+
+* Excessive Automated Scans
+* Denial of Service Attacks
+* Social Engineering Attacks
+* Reports against infrastructure outside our control
+
+## Disclosure Policy
+
+When we receive a security report, that report will be assigned to an administrative team member. That person will coordinate the fix, release, and announcement process, involving the following steps:
+
+1. Confirm the problem and determine affected services.
+2. Audit infrastructure and/or code to find any potential similar problems.
+3. Prepare fixes for all releases currently in production, which will be implemented as quickly as possible.
+
+## Comments on this Policy
+
+Please open a Pull Request or Issue if you would like to discuss any changes to this policy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,12 +12,13 @@ The administrative team will acknowledge your message within 48 hours, and will 
 
 Please report any security bugs in third-party projects to the person or team maintaining that project.
 
-The following are out of scope and should **not** be performed:
+The following are out of scope and should **not** be attacked/performed:
 
 * Excessive Automated Scans
 * Denial of Service Attacks
 * Social Engineering Attacks
 * Reports against infrastructure outside our control
+* User or admin accounts not owned by the tester
 
 ## Disclosure Policy
 
@@ -26,6 +27,8 @@ When we receive a security report, that report will be assigned to an administra
 1. Confirm the problem and determine affected services.
 2. Audit infrastructure and/or code to find any potential similar problems.
 3. Prepare fixes for all releases currently in production, which will be implemented as quickly as possible.
+
+Additionally, if user data was directly affected or compromised, we will inform affected users to the best of our ability via email and/or a website notification with more information about the incident.
 
 ## Comments on this Policy
 


### PR DESCRIPTION
As recommended in #988:

> Since privacytools.io has somewhat recently become a service provider, I suggest we have an official bug reporting policy.

This sounds good to me. I added some basic instructions to a security policy file, do you think this is enough or well-constructed? Let me know if anything should be added @beardog108.

---

Closes #988 