### PR TITLE
Remove Riot beta warning badge

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -24,7 +24,7 @@ linux=""
 {% include cardv2.html
 title="Riot.im"
 image="/assets/img/tools/Riot.png"
-description="Riot.im is a decentralized free-software chatting application based on the <a href\"https://matrix.org/\">Matrix</a> protocol, a recent open protocol for real-time communication offering E2E encryption. It can bridge other communications via others protocols such as IRC too. <span class=\"badge badge-warning\" data-toggle=\"tooltip\" title=\"The software is currently in beta and the mobile client states 'End-to-end encryption is in beta and may not be reliable. You should not yet trust it to secure data.'\">beta <i class=\"far fa-question-circle\"></i></span>"
+description="Riot.im is a decentralized free-software chatting application based on the <a href\"https://matrix.org/\">Matrix</a> protocol, a recent open protocol for real-time communication offering E2E encryption. It can bridge other communications via others protocols such as IRC too."
 website="https://riot.im/"
 forum="https://forum.privacytools.io/t/discussion-riot-im/665"
 github="https://github.com/vector-im"


### PR DESCRIPTION
## Description

Resolves: #none

Riot is no longer considered in beta:
https://matrix.org/blog/2019/06/11/introducing-matrix-1-0-and-the-matrix-org-foundation

> We are very excited to announce the first fully stable release of the Matrix protocol and specification across all APIs - as well as the Synapse 1.0 reference implementation which implements the full Matrix 1.0 API surface.
> 
> This means that after just over 5 years since the initial work on Matrix began, we are proud to have finally exited beta!! This is the conclusion of the work which we announced at FOSDEM 2019 when we cut the first stable release of the Server-Server API and began the Synapse 0.99 release series in anticipation of releasing a 1.0.
