### PR TITLE
Switch Riot Beta tag to Experimental

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -24,7 +24,7 @@ linux=""
 {% include cardv2.html
 title="Riot.im"
 image="/assets/img/tools/Riot.png"
-description="Riot.im is a decentralized free-software chatting application based on the <a href\"https://matrix.org/\">Matrix</a> protocol, a recent open protocol for real-time communication offering E2E encryption. It can bridge other communications via others protocols such as IRC too. <span class=\"badge badge-warning\" data-toggle=\"tooltip\" title=\"The software is currently in beta and the mobile client states 'End-to-end encryption is in beta and may not be reliable. You should not yet trust it to secure data.'\">beta <i class=\"far fa-question-circle\"></i></span>"
+description="Riot.im is a decentralized free-software chatting application based on the <a href\"https://matrix.org/\">Matrix</a> protocol, a recent open protocol for real-time communication offering E2E encryption. It can bridge other communications via others protocols such as IRC too. <span class=\"badge badge-warning\" data-toggle=\"tooltip\" title=\"End-to-End encryption is not enabled by default and there are some concerns about metadata storage in Matrix, but it is generally acceptable for encrypting message content.\">experimental <i class=\"far fa-question-circle\"></i> (<a href=\"https://github.com/privacytoolsIO/privacytools.io/pull/562#issuecomment-502681069\">more info</a>)</span>"
 website="https://riot.im/"
 forum="https://forum.privacytools.io/t/discussion-riot-im/665"
 github="https://github.com/vector-im"


### PR DESCRIPTION
Closes #1004 (this PR is an alternative modification): Riot is out of beta. Replaces beta tag with experimental tag:

![image](https://user-images.githubusercontent.com/3637842/59980777-04e6ba00-95c0-11e9-9418-675e969283d9.png)

More info links to this comment: https://github.com/privacytoolsIO/privacytools.io/pull/562#issuecomment-502681069