### PR TITLE
Discussion | Update Software Criteria

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,7 +48,7 @@ This criteria applies to all of privacytools.io
 - Must be free software
 
 ### Encryption
-- Only Free Software is encryption is to be trusted
+- Only verifiable encryption is to be trusted
 
 ### OSes
 - Must state if recommends, depends on, or offers non-free software (contrib)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,9 +21,9 @@ We're trying to keep it simple and promote the best tools, not all of them.
 - Prioritize Products without Vendor Lock-in (decentralized/self-hostable).
 
 There can be exceptions if no software is available that meet the criteria.
-This criteria applies to all of privacytools.io
+NOte: This criteria applies to all of privacytools.io
 ### Proividers
-- Prioritize Products by privacy respecying nationality.
+- Prioritize Products by privacy respecting nationality.
 
 ### VPN
 - Prioritize Products by privacy respecying nationality.
@@ -39,12 +39,12 @@ This criteria applies to all of privacytools.io
 - Accessable Using Free Software (i.e IMAP)
 
 ### Hardware
-- Must be H-Node Class A or Equivlant (if applicable)
-- Must prioritize hardware certifications like RYF, OSHWA, and OSI when avalible.
+- Must be [H-Node Class A](https://h-node.org/wiki/page/en/compatibility-classes) or Equivlant (if applicable)
+- Must prioritize hardware certifications like [RYF](https://ryf.fsf.org/), [OSHWA](https://certification.oshwa.org/), and OSI when avalible.
 - Cannot lock users to a particular platform.
 
 ### Software
-- Must be able to download over encryted network (including mirrors)
+- Must be able to download over encryted network (can be a mirror)
 - Must be free software
 
 ### Encryption

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We're trying to keep it simple and promote the best tools, not all of them.
 - Cross-platform / Accessible.
 - Privacy respecting.
 - Open Source / free software is preferred but not required.
-- Prioritize Products without Vendor Lock-in (decentralized/self-hostable) or products that enable users with an easily way export to and use other platforms.
+- Prioritize Products without Vendor Lock-in (decentralized/self-hostable) or data interoperability.
 
 There can be exceptions if no software is available that meet the criteria.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We're trying to keep it simple and promote the best tools, not all of them.
 - Cross-platform / Accessible.
 - Privacy respecting.
 - Open Source / free software is preferred but not required.
-- Prioritize Products without Vendor Lock-in (decentralized/self-hostable).
+- Prioritize Products without Vendor Lock-in (decentralized/self-hostable) or products that enable users with an easily way export to and use other platforms.
 
 There can be exceptions if no software is available that meet the criteria.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,6 +18,7 @@ We're trying to keep it simple and promote the best tools, not all of them.
 - Cross-platform / Accessible.
 - Privacy respecting.
 - Open Source / free software is preferred but not required.
+- Must list source code in [source_code.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md) (if applicable)
 - Prioritize Products without Vendor Lock-in (decentralized/self-hostable) or data interoperability.
 
 There can be exceptions if no software is available that meet the criteria.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Note: This criteria applies to all of privacytools.io
 - Prioritize Products by privacy respecting nationality.
 
 ### VPN
-- Prioritize Products by privacy respecying nationality.
+- Prioritize Products by privacy respecting nationality.
 - Cannot be based in USA or UK.
 - Must be acessable via free software (i.e OpenVPN, WireGuard)
 - Use Encryption

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,8 @@ We're trying to keep it simple and promote the best tools, not all of them.
 - Prioritize Products without Vendor Lock-in (decentralized/self-hostable).
 
 There can be exceptions if no software is available that meet the criteria.
-NOte: This criteria applies to all of privacytools.io
+
+Note: This criteria applies to all of privacytools.io
 ### Proividers
 - Prioritize Products by privacy respecting nationality.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Note: This criteria applies to all of privacytools.io
 - Cannot lock users to a particular platform.
 
 ### Software
-- Must be able to download over encryted network (can be a mirror)
+- Must be able to download over encrypted network (can be a mirror)
 - Must be free software
 
 ### Encryption

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,13 +13,46 @@ Please read this before contributing.
 We're trying to keep it simple and promote the best tools, not all of them.
 
 ## Software Criteria
-
+### Main
 - Easy to use. Could your mother use that tool or service? Usability is most important.
 - Cross-platform / Accessible.
 - Privacy respecting.
 - Open Source / free software is preferred but not required.
+- Prioritize Products without Vendor Lock-in (decentralized/self-hostable).
 
 There can be exceptions if no software is available that meet the criteria.
+This criteria applies to all of privacytools.io
+### Proividers
+- Prioritize Products by privacy respecying nationality.
+
+### VPN
+- Prioritize Products by privacy respecying nationality.
+- Cannot be based in USA or UK.
+- Must be acessable via free software (i.e OpenVPN, WireGuard)
+- Use Encryption
+- Accept Cryptocurrency
+- No logging policy
+
+### Email
+- Outside of USA
+- Support SMTP SSL
+- Accessable Using Free Software (i.e IMAP)
+
+### Hardware
+- Must be H-Node Class A or Equivlant (if applicable)
+- Must prioritize hardware certifications like RYF, OSHWA, and OSI when avalible.
+- Cannot lock users to a particular platform.
+
+### Software
+- Must be able to download over encryted network (including mirrors)
+- Must be free software
+
+### Encryption
+- Only Free Software is encryption is to be trusted
+
+### OSes
+- Must state if recommends, depends on, or offers non-free software (contrib)
+- No Tracking Policy (opt-in analytics is ok)
 
 ## Images
 


### PR DESCRIPTION
**The Issue**: As privacytools.io has grown more criteria for products has been added,
For instance VPNs must be "outside the US, use encryption, accept Bitcoin, support OpenVPN and have a no logging policy."

The software criteria in the contributing guidelines has not updated with this.

**What do you propose?**
> ### Main
> - Easy to use. Could your mother use that tool or service? Usability is most important.
> - Cross-platform / Accessible.
> - Privacy respecting.
> - Open Source / free software is preferred but not required.
> - Must list source code in [source_code.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md) (if applicable)
> - Prioritize Products without Vendor Lock-in (decentralized/self-hostable) or data interoperability.
> 
> There can be exceptions if no software is available that meet the criteria.
> Note: This criteria applies to all of privacytools.io

Basically the same, just renamed to "main" and added prioritize decentralization.
For instance, privacytools.io doesn't recommend `social media` it recommends `Decentralized Social Networks.`

I also added [source_code.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md) (if applicable) line(s).

> ### Proividers
> - Prioritize Products by privacy respecting nationality.

Example: https://www.privacytools.io/classic/#ukusa

> ### VPN
> - Prioritize Products by privacy respecying nationality.
> - Cannot be based in USA or UK.
> - Must be acessable via free software (i.e OpenVPN, WireGuard)
> - Use Encryption
> - Accept Cryptocurrency
> - No logging policy

Basically the same as listed on the website.

> ### Email
> - Outside of USA
> - Support SMTP SSL
> - Accessable Using Free Software (i.e IMAP)

Basically the same as listed on the website.

> ### Hardware
> - Must be H-Node Class A or Equivlant (if applicable)
> - Must prioritize hardware certifications like RYF, OSHWA, and OSI when avalible.
> - Cannot lock users to a particular platform.

Hardware, sections aren't yet in use but there are many discussions for it.
Basically, it must work with any Linux-OS (+most BSD distros) and prioritize certified hardware.

> ### Software
> - Must be able to download over encryted network (including mirrors)
> - Must be free software

Wasn't sure what privacytools.io stance on freedom is, but I assumed you follow the GNU Foundation.
Either way, basically all of the listed software is free software.

I also added must have a safe way to get stuff, users should be able to trust the connection.

> ### Encryption
> - Only verifiable is encryption is to be trusted

I kinda added this one, but basically encryption should be verifiable.

> ### OSes
> - Must state if recommends, depends on, or offers non-free software (contrib)
> - No Tracking Policy (opt-in analytics is ok)

Just kinda followed the website.

**But what about____?**
I take the belief that software can never be complete, feel free to throw ideas or debate my code.
Edits from maintainers are always welcome.

Edit: Edited main to add line for [source_code.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md).