### PR TITLE
instant-messenger: add warning to Signal [Discussion]

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -9,7 +9,7 @@
 title="Mobile: Signal"
 image="/assets/img/tools/Signal.png"
 description="Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
-All communications are end-to-end encrypted. Signal is free and open source."
+All communications are end-to-end encrypted. <span class="badge badge-warning" data-toggle="tooltip" title="Signal has non-free dependecies for Android. Is it strongly un-advised to use on Android until fixed.">warning <i class="far fa-question-circle"></i> (<a href="https://github.com/signalapp/Signal-Android/issues/8927">more info</a> ."
 website="https://signal.org"
 forum="https://forum.privacytools.io/t/discussion-signal/664"
 github="https://github.com/signalapp"

--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -9,7 +9,7 @@
 title="Mobile: Signal"
 image="/assets/img/tools/Signal.png"
 description='Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
-All communications are end-to-end encrypted. <span class="badge badge-warning" data-toggle="tooltip" title="Signal has non-free dependecies for Android. Is it strongly un-advised to use on Android until fixed.">warning <i class="far fa-question-circle"></i> (<a href="https://github.com/signalapp/Signal-Android/issues/8927">more info</a>)'
+All communications are end-to-end encrypted. <span class="badge badge-warning" data-toggle="tooltip" title="Signal has non-free dependencies for Android. Is it strongly un-advised to use on Android until fixed.">warning <i class="far fa-question-circle"></i> (<a href="https://forum.privacytools.io/t/signal-has-non-free-dependencies-android/1115">more info</a>)'
 website="https://signal.org"
 forum="https://forum.privacytools.io/t/discussion-signal/664"
 github="https://github.com/signalapp"

--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -9,7 +9,7 @@
 title="Mobile: Signal"
 image="/assets/img/tools/Signal.png"
 description='Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
-All communications are end-to-end encrypted. <span class="badge badge-warning" data-toggle="tooltip" title="Signal has non-free dependecies for Android. Is it strongly un-advised to use on Android until fixed.">warning <i class="far fa-question-circle"></i> (<a href="https://github.com/signalapp/Signal-Android/issues/8927">more info</a> .'
+All communications are end-to-end encrypted. <span class="badge badge-warning" data-toggle="tooltip" title="Signal has non-free dependecies for Android. Is it strongly un-advised to use on Android until fixed.">warning <i class="far fa-question-circle"></i> (<a href="https://github.com/signalapp/Signal-Android/issues/8927">more info</a>)'
 website="https://signal.org"
 forum="https://forum.privacytools.io/t/discussion-signal/664"
 github="https://github.com/signalapp"

--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -8,8 +8,8 @@
 {% include cardv2.html
 title="Mobile: Signal"
 image="/assets/img/tools/Signal.png"
-description="Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
-All communications are end-to-end encrypted. <span class="badge badge-warning" data-toggle="tooltip" title="Signal has non-free dependecies for Android. Is it strongly un-advised to use on Android until fixed.">warning <i class="far fa-question-circle"></i> (<a href="https://github.com/signalapp/Signal-Android/issues/8927">more info</a> ."
+description='Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
+All communications are end-to-end encrypted. <span class="badge badge-warning" data-toggle="tooltip" title="Signal has non-free dependecies for Android. Is it strongly un-advised to use on Android until fixed.">warning <i class="far fa-question-circle"></i> (<a href="https://github.com/signalapp/Signal-Android/issues/8927">more info</a> .'
 website="https://signal.org"
 forum="https://forum.privacytools.io/t/discussion-signal/664"
 github="https://github.com/signalapp"


### PR DESCRIPTION
**Description**: Elaborate more for Signals Description + Warning
**What is wrong with Signal?**: Signal depends on proprietary software for its Android application. Therefore, is not "[free software](https://www.wikipedia.org/wiki/Free_software_movement)" as listed before.
**Why does freedom matter?**: Users cannot fully audit Signal's Android application. This is particularly worrisome if it plans to replace modern SMS. 
More Info: https://www.gnu.org/philosophy/right-to-read.html