### PR TITLE
💬 Discussion | Free Software Tag to Email Providers

### DIFF
--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -15,6 +15,7 @@
         <th data-sortable="true">Storage</th>
         <th data-sortable="true">Price / Year</th>
         <th data-sortable="true">Bitcoin</th>
+        <th data-sortable="true">Free Software</th>
         <th data-sortable="true">Encryption</th>
         <th data-sortable="true">Own Domain</th>
       </tr>
@@ -35,6 +36,7 @@
         <td data-value="500">500 MB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">Partially</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -51,6 +53,7 @@
         <td data-value="2000">2 GB</td>
         <td data-value="1"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">   </span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -66,6 +69,7 @@
         <td><span class="flag-icon flag-icon-de"></span> Germany</td>
         <td data-value="1000">1 GB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
+        <td data-value="1"><span class="label label-success">Partially</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
@@ -83,6 +87,7 @@
         <td data-value="500">500 MB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">No</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -100,6 +105,7 @@
         <td data-value="2000">2 GB</td>
         <td data-value="13">12 €</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">No</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -116,6 +122,7 @@
         <td data-value="2000">2 GB</td>
         <td data-value="13">12 €</td>
         <td data-value="0"><span class="label label-primary">No</span></td>
+        <td data-value="1"><span class="label label-success">Yes (non-free payment)</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
       </tr>
@@ -133,6 +140,7 @@
         <td data-value="1000">1 GB</td>
         <td data-value="20">$ 19.95</td>
         <td data-value="1"><span class="label label-primary">Yes</span></td>
+        <td data-value="1"><span class="label label-success">No</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -149,6 +157,7 @@
         <td data-value="1000">1 GB</td>
         <td data-value="50">$ 49.95</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">No</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -181,6 +190,7 @@
         <td data-value="2048">2 GB</td>
         <td data-value="60">$ 60</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">Yes</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>

--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -70,7 +70,7 @@
         <td data-value="1000">1 GB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Partially</span></td>
-        <td data-value="0"><span class="label label-primary">No</span></td>
+        <td data-value="1"><span class="label label-success">Partially</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
@@ -174,6 +174,7 @@
         <td data-value="10000">10 GB</td>
         <td data-value="60">$ 59.95</td>
         <td data-value="0"><span class="label label-success">Accepted</span></td>
+        <td data-value="1"><span class="label label-success">No</span></td>
         <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>


### PR DESCRIPTION
**Feature**: Add is free software (back-end and/or front-end) column to email providers.
**Why**?: You cannot trust non-free software by nature, it is not transparent.
More info: https://tutanota.com/blog/posts/open-source-email/;
Systems: https://www.fsf.org/resources/webmail-systems
**Can you verify that these are using free software?**: For front-end code it is very easy thanks to projects like LibreJS. For back-end it is illegal to mislead consumers, if they are breaking this then you may have bigger issues on your hand.
**Previous discussions**: This PR is meant to help further the discussion in #1026 

Definitions:

    Free software:
    https://www.gnu.org/philosophy/free-sw.html
