### PR TITLE
instant-messengers: delist Riot

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -22,22 +22,6 @@ linux=""
 
 
 {% include cardv2.html
-title="Riot.im"
-image="/assets/img/tools/Riot.png"
-description="Riot.im is a decentralized free-software chatting application based on the <a href\"https://matrix.org/\">Matrix</a> protocol, a recent open protocol for real-time communication offering E2E encryption. It can bridge other communications via others protocols such as IRC too. <a href=\"https://github.com/vector-im/riot-web/issues/6779\"><span class=\"badge badge-warning\" data-toggle=\"tooltip\" title=\"The end-to-end encryption is currently in beta and the mobile client states 'End-to-end encryption is in beta and may not be reliable. You should not yet trust it to secure data.'\">Experimental <i class=\"far fa-question-circle\"></i></a></span> <a href=\"https://gist.github.com/maxidorius/5736fd09c9194b7a6dc03b6b8d7220d0\"<span class=\"badge badge-danger\" data-toggle=\"tooltip\" title=\"Riot sends a lot of data to matrix.org and vector.im with default settings that aren't trivial to change, also with selfhosted homeservers\">Privacy concerns</span></a>"
-website="https://riot.im/"
-forum="https://forum.privacytools.io/t/discussion-riot-im/665"
-github="https://github.com/vector-im"
-android=""
-ios=""
-mac=""
-windows=""
-linux=""
-web=""
-%}
-
-
-{% include cardv2.html
 title="Wire"
 image="/assets/img/tools/wire.png"
 description='A free software End-to-End Encrypted chatting application that supports instant messaging, voice, and video calls. Full source code is available. <span class="badge badge-warning" data-toggle="tooltip" title="Wire stores metadata such as list of your connections/conversations in plaintext (= not encrypted).">experimental <i class="far fa-question-circle"></i> (<a href="https://www.vice.com/en_us/article/gvzw5x/secure-messaging-app-wire-stores-everyone-youve-ever-contacted-in-plain-text">more info</a>)</span>'

--- a/source_code.md
+++ b/source_code.md
@@ -114,8 +114,6 @@ Backend: closed-source
 ## Encrypted Instant Messenger
  Signal https://github.com/signalapp
  
- Riot: https://github.com/vector-im
- 
  Ricochet: https://github.com/ricochet-im/ricochet
 
    Worth Mentioning:


### PR DESCRIPTION
We previously added a warning on privacy concerns in #1024 after
Prism-break had delisted Riot and *Notes on privacy and data collection
of Matrix.org* was released revealing concerns even with self-hosted
homeservers.

Today Libre Monde has released another part on privacy investigation on
Matrix.org [1] revealing that they aren't GDPR compliant nor privacy
friendly and behave shadily such as by announcing removal of data as a
result of GDPR request. [2]

[1]:https://github.com/libremonde-org/paper-research-privacy-matrix.org/blob/master/part2/README.md
[2]:https://github.com/libremonde-org/paper-research-privacy-matrix.org/blob/master/part2/README.md#the-request

Resolves: #840