### PR TITLE
Add Tor URL to VPN Provider website column

### DIFF
--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -9,7 +9,7 @@
     <thead>
       <tr>
         <th data-sortable="true">Email Service</th>
-        <th data-sortable="true">URL</th>
+        <th data-sortable="false">Website</th>
         <th data-sortable="true">Since</th>
         <th data-sortable="true">Server</th>
         <th data-sortable="true">Storage</th>

--- a/_includes/sections/vpn.html
+++ b/_includes/sections/vpn.html
@@ -10,225 +10,262 @@
     <thead>
       <tr>
         <th data-sortable="true">Sortable VPN Providers Table</th>
+        <th data-sortable="false">Website</th>
         <th data-sortable="true">Yearly Price</th>
         <th data-sortable="true">Free Trial</th>
         <th data-sortable="true" title="Number of Servers"># Servers</th>
         <th data-sortable="true">WireGuard</th>
         <th data-sortable="true">Jurisdiction</th>
-        <th data-sortable="false">Website</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td data-value="AirVPN">
           <a href="https://airvpn.org/"><img alt="AirVPN" src="/assets/img/provider/AirVPN.png" width="200" height="70"></a></td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://airvpn.org/" href="https://airvpn.org/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="{{ 54 | times: eur_to_usd }}">54 €</td>
         <td><span class="label label-success">Yes</span></td>
         <td>162</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-it"></span> Italy</td>
-        <td><a href="https://airvpn.org/">AirVPN.org</a></td>
       </tr>
 
       <tr>
         <td data-value="AzireVPN">
           <a href="https://www.azirevpn.com/"><img alt="AzireVPN" src="/assets/img/provider/AzireVPN.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.azirevpn.com/" href="https://www.azirevpn.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="{{ 45 | times: eur_to_usd }}">45 €</td>
         <td><span class="label label-success">Yes</span></td>
         <td>22</td>
         <td><span class="label label-success">Yes</span></td>
         <td><span class="flag-icon flag-icon-se"></span> Sweden</td>
-        <td><a href="https://www.azirevpn.com/">AzireVPN.com</a></td>
       </tr>
 
       <tr>
         <td data-value="blackVPN">
           <a href="https://www.blackvpn.com/"><img alt="blackVPN" src="/assets/img/provider/blackVPN.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.blackvpn.com/" href="https://www.blackvpn.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="{{ 49 | times: eur_to_usd }}">49 €</td>
         <td><span class="label label-success">Yes</span></td>
         <td>31</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-hk"></span> Hong Kong</td>
-        <td><a href="https://www.blackvpn.com/">blackVPN.com</a></td>
       </tr>
 
       <tr>
         <td data-value="Cryptostorm">
           <a href="https://cryptostorm.is/"><img alt="Cryptostorm" src="/assets/img/provider/Cryptostorm.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://cryptostorm.is/" href="https://cryptostorm.is/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="52">$ 52</td>
         <td><span class="label label-success">Yes</span></td>
         <td>28</td>
         <td><span class="label label-success">Yes</span></td>
         <td><span class="flag-icon flag-icon-is"></span> Iceland</td>
-        <td><a href="https://cryptostorm.is/">Cryptostorm.is</a></td>
       </tr>
 
       <tr>
         <td data-value="ExpressVPN">
           <a href="https://www.expressvpn.com/"><img alt="ExpressVPN" src="/assets/img/provider/ExpressVPN.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.expressvpn.com/" href="https://www.expressvpn.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="100">$ 99.95</td> <!-- USD on December 28, 2018 -->
         <td><span class="label label-success">Yes</span></td>
         <td>148</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-vg"></span> British Virgin Islands</td>
-        <td><a href="https://www.expressvpn.com/">ExpressVPN.com</a></td>
       </tr>
 
       <tr>
         <td data-value="FrootVPN">
           <a href="https://www.frootvpn.com/"><img alt="FrootVPN" src="/assets/img/provider/FrootVPN.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.frootvpn.com/" href="https://www.frootvpn.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="36">$ 35.88</td>
         <td><span class="label label-warning">No</span></td>
         <td>27</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-se"></span> Sweden</td>
-        <td><a href="https://www.frootvpn.com/">FrootVPN.com</a></td>
       </tr>
 
       <tr>
         <td data-value="hide.me">
           <a href="https://hide.me/"><img alt="hide.me" src="/assets/img/provider/hide.me.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://hide.me/" href="https://hide.me/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="0"><a data-toggle="tooltip" data-placement="bottom" data-original-title="2 GB data transfer, 1 simultaneous connection" href="https://hide.me/pricing">Free</a></td>
         <td><span class="label label-success">Yes</span></td>
         <td>160+</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-my"></span> Malaysia</td>
-        <td><a href="https://hide.me/">hide.me</a></td>
       </tr>
 
       <tr>
         <td data-value="IVPN">
           <a href="https://www.ivpn.net/"><img alt="IVPN" src="/assets/img/provider/IVPN.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.ivpn.net/" href="https://www.ivpn.net/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="100">$ 100</td>
         <td><span class="label label-success">Yes</span></td>
         <td>38</td>
         <td><span class="label label-success">Yes</span></td>
         <td><span class="flag-icon flag-icon-gi"></span> Gibraltar</td>
-        <td><a href="https://www.ivpn.net/">IVPN.net</a></td>
       </tr>
 
       <tr>
         <td data-value="Mullvad">
           <a href="https://mullvad.net/"><img alt="Mullvad" src="/assets/img/provider/Mullvad.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://mullvad.net/" href="https://mullvad.net/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="http://xcln5hkbriyklr6n.onion. Requires specific software to access: torproject.org" href="http://xcln5hkbriyklr6n.onion/"><img alt="Tor" src="/assets/img/layout/tor.png" width="35"></a>
+        </td>
         <td data-value="{{ 60 | times: eur_to_usd }}">60 €</td>
         <td><span class="label label-success">No</span></td>
         <td>281</td>
         <td><span class="label label-success">Yes</span></td>
         <td><span class="flag-icon flag-icon-se"></span> Sweden</td>
-        <td><a href="https://mullvad.net/">Mullvad.net</a></td>
       </tr>
 
       <tr>
         <td data-value="NordVPN">
           <a href="https://nordvpn.com/"><img alt="NordVPN" src="/assets/img/provider/NordVPN.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://nordvpn.com/" href="https://nordvpn.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="84">$ 83.88</td>
         <td><span class="label label-success">Yes</span></td>
         <td>5200+</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-pa"></span> Panama</td>
-        <td><a href="https://nordvpn.com/">NordVPN.com</a></td>
       </tr>
 
       <tr>
         <td data-value="OVPN.com">
           <a href="https://www.ovpn.com/"><img alt="OVPN" src="/assets/img/provider/ovpn.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.ovpn.com/" href="https://www.ovpn.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="{{ 84 | times: eur_to_usd }}">84 €</td>
         <td><span class="label label-success">Yes</span></td>
         <td>67</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-se"></span> Sweden</td>
-        <td><a href="https://www.ovpn.com/">OVPN.com</a></td>
       </tr>
 
       <tr>
         <td data-value="Perfect Privacy">
           <a href="https://www.perfect-privacy.com/"><img alt="Perfect Privacy" src="/assets/img/provider/Perfect-Privacy.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.perfect-privacy.com/" href="https://www.perfect-privacy.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="{{ 119.99 | times: eur_to_usd }}">119.99 €</td>
         <td><span class="label label-warning">No</span></td>
         <td>54</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-ch"></span> Switzerland</td>
-        <td><a href="https://www.perfect-privacy.com/">Perfect-Privacy.com</a></td>
       </tr>
 
       <tr>
         <td data-value="ProtonVPN">
           <a href="https://protonvpn.com/"><img alt="ProtonVPN" src="/assets/img/provider/ProtonVPN.png" width="200" height="70"></a     >
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://protonvpn.com/" href="https://protonvpn.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="0"><a data-toggle="tooltip" data-placement="bottom" data-original-title="3 countries, 1 device, speed: low" href="https://protonvpn.com/pricing">Free</a></td>
         <td><span class="label label-success">Yes</span></td>
         <td>396</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-ch"></span> Switzerland</td>
-        <td><a href="https://protonvpn.com/">ProtonVPN.com</a></td>
       </tr>
 
       <tr>
         <td data-value="Proxy.sh">
           <a href="https://proxy.sh/"><img alt="Proxy.sh" src="/assets/img/provider/Proxy.sh.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://proxy.sh/" href="https://proxy.sh/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="40">$ 40</td>
         <td><span class="label label-warning">No</span></td>
         <td>300+</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>
-        <td><a href="https://proxy.sh/">Proxy.sh</a></td>
       </tr>
 
       <tr>
         <td data-value="Trust.Zone">
           <a href="https://trust.zone/"><img alt="Trust.Zone" src="/assets/img/provider/Trust.Zone.png" width="200" height="70"></a>
         </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://trust.zone/" href="https://trust.zone/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
+        </td>
         <td data-value="40">$ 39.95</td>
         <td><span class="label label-success">Yes</span></td>
         <td>164</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>
-        <td><a href="https://trust.zone/">Trust.Zone</a></td>
       </tr>
       <tr>
         <td data-value="VPN.ht">
           <a href="https://vpn.ht/"><img alt="VPN.ht" src="/assets/img/provider/VPN.ht.png" width="200" height="70"></a>
+        </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://vpn.ht/" href="https://vpn.ht/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="40">$ 39.99</td>
         <td><span class="label label-warning">No</span></td>
         <td>128</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-hk"></span> Hong Kong</td>
-        <td><a href="https://vpn.ht/">VPN.ht</a></td>
       </tr>
       <tr>
         <td data-value="VPNArea">
           <a href="https://vpnarea.com/"><img alt="VPNArea" src="/assets/img/provider/vpnarea.png" width="200" height="70"></a>
+        </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://vpnarea.com/" href="https://vpnarea.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="59">$ 59</td>
         <td><span class="label label-success">Yes</span></td>
         <td>204</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-bg"></span> Bulgaria</td>
-        <td><a href="https://vpnarea.com/">VPNArea.com</a></td>
       </tr>
       <tr>
         <td data-value="VPNTunnel">
           <a href="https://vpntunnel.com/"><img alt="VPNTunnel" src="/assets/img/provider/VPNTunnel.png" width="200" height="70"></a>
+        </td>
+        <td>
+          <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://vpntunnel.com/" href="https://vpntunnel.com/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="{{ 35.88 | times: eur_to_usd }}">35.88 €</td>
         <td><span class="label label-warning">No</span></td>
         <td>800+</td>
         <td><span class="label label-warning">No</span></td>
         <td><span class="flag-icon flag-icon-sc"></span> Seychelles</td>
-        <td><a href="https://vpntunnel.com/">VPNTunnel.com</a></td>
       </tr>
 
     </tbody>


### PR DESCRIPTION
## Description

Resolves: https://github.com/privacytoolsIO/privacytools.io/issues/1058

- Updated the "Website" column for both Email and VPN providers to not be sortable (doesn't make sense?) and to say "Website" for consistency vs "URL" like it was for the Email table.
- Added Mullvad's Tor link. Not sure if I'm missing others?
