### PR TITLE
GTK+ was renamed to GTK

### DIFF
--- a/_includes/sections/email-clients.html
+++ b/_includes/sections/email-clients.html
@@ -16,7 +16,7 @@ bsd=""
 {% include cardv2.html
 title="Claws Mail"
 image="/assets/img/tools/Claws-Mail.png"
-description="Claws Mail is a free and open source, GTK+-based email and news client. It offers easy configuration and an abundance of features. It is included with Gpg4win, an encryption suite for Windows."
+description="Claws Mail is a free and open source, GTK-based email and news client. It offers easy configuration and an abundance of features. It is included with Gpg4win, an encryption suite for Windows."
 website="https://www.claws-mail.org/"
 forum="https://forum.privacytools.io/t/discussion-claws-mail/660"
 git="https://git.claws-mail.org/"


### PR DESCRIPTION
GTK+ was renamed to just GTK, some time ago.

https://mail.gnome.org/archives/gtk-devel-list/2019-February/msg00000.html