### PR TITLE
Update information about Thunderbird and avoid repetition

### DIFF
--- a/_includes/cardv2.html
+++ b/_includes/cardv2.html
@@ -40,6 +40,7 @@
         {% if include.github %}<a href="{{include.github}}"><i class="fab fa-github fa-2x fa-fw"></i></a>{% endif %}
         {% if include.gitlab %}<a href="{{include.gitlab}}"><i class="fab fa-gitlab fa-2x fa-fw"></i></a>{% endif %}
         {% if include.git %}<a href="{{include.git}}"><i class="fab fa-git-square fa-2x fa-fw"></i></a>{% endif %}
+        {% if include.source %}<a href="{{include.source}}"><i class="fas fa-code-branch fa-2x fa-fw"></i></a>{% endif %}
 
     </div>
 

--- a/_includes/sections/email-clients.html
+++ b/_includes/sections/email-clients.html
@@ -3,10 +3,10 @@
 {% include cardv2.html
 title="Thunderbird"
 image="/assets/img/tools/Thunderbird.png"
-description="Mozilla Thunderbird is a free, open source, cross-platform email, news, and chat client developed by the Mozilla Foundation. Thunderbird is an email, newsgroup, news feed, and chat (XMPP, IRC, Twitter) client."
+description="Thunderbird is a free, open source, cross-platform email, newsgroup, news feed, and chat (XMPP, IRC, Twitter) client developed by community, previously by the Mozilla Foundation."
 website="https://www.thunderbird.net/"
 forum="https://forum.privacytools.io/t/discussion-thunderbird/659"
-github="https://github.com/thundernest"
+source="https://hg.mozilla.org/comm-central/"
 windows=""
 mac=""
 linux=""


### PR DESCRIPTION
Thunderbird is no longer developed by Mozilla.
https://blog.mozilla.org/thunderbird/2017/05/thunderbirds-future-home/

github.com/thundernest does not contain source code of Thunderbird client
> comm-central is the main Thunderbird repository.
> Thundernest contains the code for Thunderbird.net (this site),
as well as the Thunderbird web server setup scripts.

from https://www.thunderbird.net/en-US/get-involved/

In _includes/cardv2.html add `source`, because git is not the only
version control available (there is Mercurial, Subversion, CVS)