### PR TITLE
Update instant-messenger.html

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -1,12 +1,12 @@
 <h1 id="im" class="anchor"><a href="#im"><i class="fas fa-link anchor-icon"></i></a> Encrypted Instant Messenger</h1>
 
 <div class="alert alert-warning" role="alert">
-  <strong>If you are currently using an Instant Messenger like LINE, Telegram, Viber, <a href="https://www.eff.org/deeplinks/2016/10/where-whatsapp-went-wrong-effs-four-biggest-security-concerns">WhatsApp</a> or plain SMS messages you should pick an alternative here.</strong>
+  <strong>If you are currently using an Instant Messenger like LINE, Telegram, Viber, <a href="https://www.eff.org/deeplinks/2016/10/where-whatsapp-went-wrong-effs-four-biggest-security-concerns">WhatsApp</a>, or plain SMS messages you should pick an alternative here.</strong>
 </div>
 
 
 {% include cardv2.html
-title="Mobile: Signal"
+title="Signal"
 image="/assets/img/tools/Signal.png"
 description="Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling.
 All communications are end-to-end encrypted. Signal is free and open source."
@@ -24,7 +24,7 @@ linux=""
 {% include cardv2.html
 title="Wire"
 image="/assets/img/tools/wire.png"
-description='A free software End-to-End Encrypted chatting application that supports instant messaging, voice, and video calls. Full source code is available. <span class="badge badge-warning" data-toggle="tooltip" title="Wire stores metadata such as list of your connections/conversations in plaintext (= not encrypted).">experimental <i class="far fa-question-circle"></i> (<a href="https://www.vice.com/en_us/article/gvzw5x/secure-messaging-app-wire-stores-everyone-youve-ever-contacted-in-plain-text">more info</a>)</span>'
+description='A free software End-to-End Encrypted chatting application that supports instant messaging, voice, and video calls. Full source code is available. <span class="badge badge-warning" data-toggle="tooltip" title="Wire stores metadata such as list of your connections/conversations in plaintext (= not encrypted)."><a href="https://www.vice.com/en_us/article/gvzw5x/secure-messaging-app-wire-stores-everyone-youve-ever-contacted-in-plain-text">Warning</a></span>'
 website="https://wire.com/"
 forum="https://forum.privacytools.io/t/discussion-wire/750"
 github="https://github.com/wireapp/"
@@ -47,17 +47,19 @@ web=""
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://ricochet.im/">Ricochet</a> - Ricochet uses the <a href="/browsers/#browser"><i class="fas fa-link"></i> Tor network</a> to reach your contacts without relying on messaging servers. It creates a hidden service, which is used to rendezvous with your contacts without revealing your location or IP address. <span class="badge badge-warning" data-toggle="tooltip" title="This software is an experiment."><a href="https://github.com/ricochet-im/ricochet#experimental">Experimental</a></span> <span class="badge badge-danger">Danger</span> <a href="#ricochetTor">Keep Tor up to date</a></li>
+  <li><a href="https://briarproject.org/">Briar</a> - An ultra-secure peer-to-peer instant messenger that connects to contacts via Direct Wi-Fi, Bluetooth, or Tor over the internet, keeping its users protected from surveillance and censorship.
   <li><a href="https://retroshare.cc/">RetroShare</a> - An E2E encrypted instant messaging and voice/video call client. RetroShare supports both TOR and I2P. </li>
-  <li><a href="https://xmpp.org/">XMPP</a> federated clients with <a href="https://conversations.im/omemo/">OMEMO</a> support:</li>
+  <li><a href="https://xmpp.org/">XMPP</a> - Federated instant messaging protocol with <a href="https://conversations.im/omemo/">OMEMO</a>, OTR, or OpenPGP end-to-end encryption:</li>
   <ul>
-    <li><a href="https://monal.im/">Monal</a> (iOS, MacOS) - An XMPP client in active development.</li>
-    <li><a href="https://conversations.im/">Conversations</a> (Android) - An open source Jabber/XMPP client for Android 4.4+ smartphones. Supports end-to-end encryption with either OMEMO or OpenPGP.</li>
-    <li><a href="https://gajim.org/">Gajim</a> (FreeBSD, Linux, Windows) - An open source fully featured XMPP client.</li>
-    <li><a href="https://omemo.top/">List of OMEMO ready clients</a></li>
+    <li><a href="https://conversations.im/">Conversations</a> (Android) - An open source Jabber/XMPP client for Android 4.4+ smartphones. <span class="badge badge-success">OMEMO</span></li>
+    <li><a href="https://gajim.org/">Gajim</a> (FreeBSD, Linux, Windows) - An open source fully featured XMPP client. <span class="badge badge-success">OMEMO</span></li>
+    <li><a href="https://monal.im/">Monal</a> (iOS, MacOS) - An XMPP client in active development. <span class="badge badge-success">OMEMO</span></li>
+    <li><a href="https://omemo.top/">Other OMEMO ready clients</a>.</li>
   </ul>
   <li><a href="https://www.kontalk.org/">Kontalk</a> - A community-driven instant messaging network. Supports end-to-end encryption. Both client-to-server and server-to-server channels are fully encrypted.</li>
-  <li><a href="https://status.im/">Status</a> - <span class="badge badge-warning">Experimental</span> A free and open-source, peer-to-peer, encrypted instant messanger with support for DAPPs. </li>
+  <li><a href="https://keybase.io/">Keybase</a> - <span class="badge badge-warning" data-toggle="tooltip" title="This software relies on a closed-source central server.">Warning</span> End-to-end encrypted messaging with social verification.</li>
+  <li><a href="https://status.im/">Status</a> - <span class="badge badge-warning">Experimental</span> A free and open-source, peer-to-peer, encrypted instant messanger with support for DAPPs.</li>
+  <li><a href="https://ricochet.im/">Ricochet</a> - <span class="badge badge-danger" data-toggle="tooltip" title="This software is safe if you manually keep Tor up to date."><a href="#ricochetTor" class="text-white">Danger</a></span> <span class="badge badge-warning" data-toggle="tooltip" title="This software is considered safe but experimental and the client has not been updated since 2016."><a href="https://github.com/ricochet-im/ricochet#experimental">Experimental</a></span> Ricochet uses the <a href="/browsers/#browser"><i class="fas fa-link"></i> Tor network</a> to reach your contacts without relying on messaging servers. It creates a hidden service, which is used to rendezvous with your contacts without revealing your location or IP address.</li>
 </ul>
 
 

--- a/source_code.md
+++ b/source_code.md
@@ -10,158 +10,166 @@ https://github.com/privacytoolsIO/
 
 ## Browser Recommendation
  TorBrowser: https://gitweb.torproject.org/tor.git
- 
+
  Firefox: https://hg.mozilla.org/
- 
+
  Brave: https://github.com/brave/
 
 ## Excellent Firefox Privacy Add-ons
- 
+
  Privacy Badger: https://github.com/EFForg/privacybadger
- 
+
  uBlock Origin: https://github.com/gorhill/uBlock/
- 
+
  Cookie AutoDelete: https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/
- 
+
  HTTPS Everywhere: https://github.com/EFForg/https-everywhere
- 
+
  Decentraleyes: https://git.synz.io/Synzvato/decentraleyes
- 
+
  Terms of Service; Didn’t Read : https://github.com/tosdr/
- 
+
  Snowflake : https://gitweb.torproject.org/pluggable-transports/snowflake.git
- 
+
  uMatrix: https://github.com/gorhill/uMatrix/
- 
+
  NoScript: https://github.com/hackademix/noscript/
 
 ## Privacy-Conscious Email Providers
- 
+
  Posteo: https://github.com/posteo (backend & frontend)
  Note: Credit card payments may require non-free JS
- 
- ProtonMail: 
+
+ ProtonMail:
 Frontend: https://github.com/ProtonMail/WebClient
 Backend: closed-source
 
   Disroot: https://git.fosscommunity.in/disroot
  Related: https://board.disroot.org/project/disroot-disroot/issue/1138
  Website: https://git.fosscommunity.in/disroot/website + some other repositories https://git.fosscommunity.in/disroot/
- 
- Tutanota: 
+
+ Tutanota:
 Frontend: https://github.com/tutao/tutanota
 Backend: closed-source
- 
+
  Mailfence: Non-free/Proprietary Software
- 
+
  Mailbox.org: Non-free/Proprietary Software
- 
- runbox: 
+
+ runbox:
 Runbox 7: https://github.com/runbox/Runbox7
 Backend: closed-source
- 
+
  NEO MAILBOX: largely closed-source
- 
+
  Start Mail: largely closed-source
- 
+
  Kolab Now: ?
- 
- 
+
+
  Mail-in-a-Box: https://github.com/mail-in-a-box/mailinabox
 
    Interesting Email Providers Under Development
    Confidant Mail: List of components at https://www.confidantmail.org/docs/server_admin.html
-   
+
    Privacy Email Tools:
- 
+
  GPG4USB: https://github.com/gpg4usb/gpg4usb
- 
+
  Mailvelope: https://github.com/mailvelope/mailvelope
- 
+
  Enigmail: https://www.enigmail.net/index.php/en/download/source-code
- 
+
  TorBirdy: https://gitweb.torproject.org/torbirdy.git/
- 
+
  Email Privacy Tester: https://gitlab.com/mikecardwell/ept3
 
 ## Email Clients
  Thunderbird: https://github.com/thundernest/thunderbird-website
- 
+
  Claws Mail: https://git.claws-mail.org/
 
    Worth Mentioning:
- 
+
  K-9 Mail: https://github.com/k9mail/k-9/
- 
+
  GNU Privacy Guard: https://github.com/gpg/gnupg
- 
+
  Mailpile: https://github.com/mailpile/Mailpile
 
 ## Email Alternatives
  I2p Bote: https://github.com/i2p/i2p.i2p-bote
- 
+
  Bitmessage: https://github.com/Bitmessage
- 
+
  Retroshare: https://github.com/RetroShare
 
 ## Privacy Respecting Search Engines
  SearX: https://github.com/asciimoo/searx/
 
    Worth Mentioning:
- 
+
  MetaGer: https://gitlab.metager3.de/open-source/MetaGer
 
 ## Encrypted Instant Messenger
  Signal https://github.com/signalapp
- 
- Ricochet: https://github.com/ricochet-im/ricochet
+
+ Wire: https://github.com/wireapp
 
    Worth Mentioning:
- 
- ChatSecure: https://github.com/chatsecure
- 
- Cryptocat: https://github.com/cryptocat/cryptocat
- 
- Kontalk: https://github.com/kontalk/
- 
+
+ Briar: https://code.briarproject.org/briar/briar/tree/master
+
+ RetroShare: https://github.com/RetroShare/RetroShare
+
  Conversations: https://github.com/siacs/Conversations
- 
- Wire: https://github.com/wireapp
+
+ Gajim: https://dev.gajim.org/gajim/gajim
+
+ Monal: https://github.com/anurodhp/Monal
+
+ Kontalk: https://github.com/kontalk
+
+ Keybase: https://github.com/keybase/client
+
+ Status.im: https://github.com/status-im
+
+ Ricochet: https://github.com/ricochet-im/ricochet
 
 ## Encrypted Video & Voice Messenger
  Signal: https://github.com/signalapp
- 
+
  Wire: https://github.com/wireapp
- 
+
  Linphone: https://github.com/BelledonneCommunications/
 
    Worth Mentioning
- 
+
  Jitsi: https://github.com/jitsi/jitsi-meet
 
  Tox: https://github.com/TokTok/c-toxcore
 
  Ring/Jami: https://gerrit-ring.savoirfairelinux.com/#/q/status:open
- 
+
  ## File Sharing
   OnionShare: https://github.com/micahflee/onionshare
-  
+
   Magic Wormhole: https://github.com/warner/magic-wormhole
-  
+
  ## Encrypted Cloud Storage Services
   Nextcloud: https://github.com/nextcloud
-  
+
   Least Authority S4: https://leastauthority.com/how-it-works/
-  
+
    Worth Mentioning
- 
+
  Cryptomator: https://github.com/cryptomator/cryptomator
- 
+
 ## Self-Hosted Cloud Server Software
  Pydio: https://github.com/pydio
- 
+
  Tahoe-LAFS: https://github.com/tahoe-lafs/tahoe-lafs
- 
+
  Nextcloud: https://github.com/nextcloud
 
 ## Secure Hosting Provider
@@ -171,144 +179,144 @@ Backend: closed-source
  SparkleShare: https://www.github.com/hbons/SparkleShare/
 
  Syncthing: https://github.com/syncthing/syncthing
- 
+
    Worth Mentioning
 .    
     git-annex: http://source.git-annex.branchable.com/?p=source.git;a=summary
-    
+
 ## Password Manager Software
  Bitwarden: https://github.com/bitwarden
- 
+
  KeePass: https://keepass.info/download.html
- 
+
  KeePassXC: https://github.com/keepassxreboot
- 
+
  LessPass: https://github.com/lesspass/lesspass
- 
+
    Worth Mentioning
 .    
     Master Password: https://gitlab.com/lhunath/MasterPassword
 .
     Password Safe: hhttps://sourceforge.net/p/passwordsafe/git-code/ci/master/tree/
-    
+
 ## Calendar and Contacts Sync
   Nextcloud: https://github.com/nextcloud
-  
+
   EteSync: https://github.com/etesync
-  
+
    Worth Mentioning:
 .    
     fruux: https://fruux.com/opensource/
 .    
     Flock: https://github.com/signalapp/Flock
-    
+
 ## File Encryption Software
  VeraCrypt: https://www.veracrypt.fr/en/Source%20Code.html
- 
+
  GNU Privacy Guard: https://github.com/gpg/gnupg
- 
+
  PeaZip: https://github.com/giorgiotani/PeaZip/
- 
+
  Cryptomator: https://github.com/cryptomator/cryptomator
- 
+
   Worth Mentioning:
-   
+
    miniLock: https://github.com/kaepora/miniLock
-   
+
    AES Crypt: https://github.com/marcobellaccini/pyAesCrypt
-   
+
    DiskCryptor: https://github.com/smartinm/diskcryptor
-   
+
    Linux Unified Key Setup (LUKS): https://gitlab.com/cryptsetup/cryptsetup/
-   
+
 ## Self-contained Networks
  TorBrowser: https://gitweb.torproject.org/tor.git
- 
+
  I2p: https://github.com/i2p
- 
+
  Freenet: https://github.com/freenet/
- 
+
   Worth Mentioining:
-   
+
    ZeroNet: https://github.com/HelloZeroNet/ZeroNet
-   
+
    RetroShare: https://github.com/RetroShare
-   
+
    GNUnet: https://gnunet.org/
-   
+
    IPFS: https://github.com/ipfs + https://github.com/ipfs-shipyard
-   
+
 ## Decentralized Social Networks
  Mastodon: https://github.com/tootsuite/mastodon
- 
+
  diaspora*: https://github.com/diaspora/diaspora/
- 
+
  Friendica: https://github.com/friendica/
- 
+
   Worth Mentioning:
-   
+
    GNU Social: https://gnu.io/source/
-   
+
 ## Domain Name System (DNS)
  Njalla: Non-free/Proprietary Software
- 
+
  DNSCrypt: https://github.com/dnscrypt
 DNSCrypt-proxy: https://github.com/jedisct1/dnscrypt-proxy/
- 
+
  OpenNic: https://github.com/opennic/ (mostly)
 Webpage: https://github.com/opennic/opennic-web
- 
+
   Worth Mentioning
-   
+
    NoTrack: https://github.com/quidsup/notrack
-   
+
    Namecoin: https://github.com/namecoin
-   
+
    Pi-hole: https://github.com/pi-hole
-   
+
 ## Digital Notebook
  Joplin: https://github.com/laurent22/joplin
- 
+
  Standard Notes: https://github.com/standardnotes/
- 
+
  Turtl: https://github.com/turtl
- 
+
   Worth Mentioning
-   
+
    Paperwork: https://github.com/twostairs/paperwork
-   
+
    Org-mode: https://code.orgmode.org/bzg/org-mode
-   
+
 ## Paste Services
  PrivateBin: https://github.com/PrivateBin/PrivateBin/
- 
+
  ZeroBin: https://github.com/sebsauvage/ZeroBin
- 
+
  Ghostbin: https://github.com/kilgarth/ghostbin
- 
+
   Worth Mentioning:
-   
+
    Disroot: https://github.com/PrivateBin/PrivateBin via https://disroot.org/en/services/privatebin
   website: https://git.fosscommunity.in/disroot/website + some other repositories https://git.fosscommunity.in/disroot/
 
-   
+
 ## Productivity Tools
  Etherpad: https://github.com/ether/etherpad-lite
- 
+
  Write.as: https://code.as/writeas
- 
- Protected Text: 
+
+ Protected Text:
 Frontend:?
 Backend: closed-source
-  
+
   Worth Mentioning
-   
+
    Cryptee: https://github.com/cryptee
 Backend: Closed Source
-   
+
    EtherCalc: https://github.com/audreyt/ethercalc
-   
-   Disroot: 
+
+   Disroot:
   Email:
   Cloud: https://github.com/nextcloud/server
   Diaspora/Social-Network: https://github.com/diaspora/
@@ -316,57 +324,57 @@ Backend: Closed Source
   Chat: http://hg.prosody.im/
   Pads: https://github.com/ether/etherpad-lite
   Pastebin: https://github.com/PrivateBin/PrivateBin via https://disroot.org/en/services/privatebin
-  Upload: 
+  Upload:
  Lufi: https://framagit.org/fiat-tux/hat-softwares/lufi
-  Search: 
+  Search:
  Searx: https://github.com/asciimoo/searx
-  Polls: 
+  Polls:
  Framadate: https://git.framasoft.org/framasoft/framadate
-  Project Board: 
+  Project Board:
  Taiga: https://github.com/taigaio/
  Website: https://git.fosscommunity.in/disroot/website + some other repositories https://git.fosscommunity.in/disroot/
 
-   
+
    Dudle: https://github.com/kellerben/dudle/
-   
+
    LibreOffice: https://gerrit.libreoffice.org/
-   
+
 ## PC Operating Systems
  QubesOS: https://github.com/QubesOS
- 
+
  Debian: https://codesearch.debian.net/
- 
+
  Trisquel: https://devel.trisquel.info/groups/trisquel
- 
+
   Worth Mentioning:
-   
+
    OpenBSD: https://github.com/openbsd
-   
+
    Arch Linux: https://git.archlinux.org/
-   
+
    Parabola: https://projects.parabola.nu/
-   
+
    Whonix: https://github.com/Whonix/Whonix
-   
+
    Subgraph OS: https://github.com/subgraph
-   
+
 ## Live CD Operating Systems
    Tails: https://tails.boum.org/contribute/git/
-   
+
    KNOPPIX: Unknown (More info https://knopper.net/knoppix-info/index-en.html)
   LXDE: https://github.com/lxde
   MPlayer: svn://svn.mplayerhq.hu/mplayer/trunk
   WvDial: https://github.com/wlach/wvdial
   Gimp: https://gitlab.gnome.org/GNOME/gimp
   LibreOffice: https://git.libreoffice.org/core
-   
+
    PuppyLinux: http://puppylinux.com/woof-ce.html
-   
+
    Worth Mentioing
 .    
-    Tiny Core Linux: 
+    Tiny Core Linux:
     https://www.openhub.net/p/tinycorelinux/enlistments
-   
+
 ## Live CD Operating Systems
    LineageOS: https://github.com/lineageos
 .   
@@ -377,23 +385,22 @@ Backend: Closed Source
      OmniROM: https://www.omnirom.org/source
 .     
      MicroG: https://github.com/microg
-     
+
 ## Android Privacy Add-ons
    NetGuard: https://github.com/M66B/NetGuard/
-   
+
    XPrivacyLua: https://github.com/M66B/XPrivacyLua/
-   
+
 ## Open Source Router Firmware
    OpenWRT: https://git.openwrt.org/?p=openwrt/openwrt.git;a=shortlog;h=refs/tags/v18.06.1
-   
+
    pfSense: http://github.com/pfsense
-   
+
    libreCMC: https://gogs.librecmc.org/libreCMC/libreCMC
 .   
     Worth Mentioning:
-    
-   
+
+
    OpenBSD: https://github.com/openbsd
-   
+
    DD-WRT: https://svn.dd-wrt.com//
-   


### PR DESCRIPTION
# Description

Update some of the Instant Messenger recommendations for 2019 and make some of the descriptions sound better.

## Notable Changes 

- Moves Ricochet to the bottom of Worth Mentioning list, with emphasis on security notices regarding keeping Tor up to date manually.
- Adds Briar to top of Worth Mentioning list.
- Adds Keybase as Worth Mentioning, with warning about centralized server.
- Reorders XMPP list, add badges for OMEMO support.
- Adds description to XMPP.
- Removes experimental tag from Wire, replaces with Warning tag.

Resolves #948, resolves #740, resolves #483 

Adding Keybase here should not affect its listing in #1065 or #1067 as Keybase supports both functionalities in different forms.