### PR TITLE
Update information about Tor in Self-Contained Networks

### DIFF
--- a/_includes/sections/self-contained-networks.html
+++ b/_includes/sections/self-contained-networks.html
@@ -7,11 +7,11 @@
 <div class="row mb-2">
 
   {% include card.html color="success"
-  title="Tor Browser"
+  title="Tor"
   image="/assets/img/tools/Tor-Project.png"
   url="https://www.torproject.org/"
   tor="http://expyuzz4wqqyqhjn.onion"
-  footer='OS: Windows, macOS, Linux, <a href="https://mike.tig.as/onionbrowser/">iOS</a>, <a href="https://www.torproject.org/docs/android.html.en">Android</a>, <a href="https://github.com/torbsd/openbsd-ports">OpenBSD.</a>'
+  footer='OS: Windows, macOS, Linux, <a href="https://mike.tig.as/onionbrowser/">iOS</a>, Android (<a href="https://www.torproject.org/download/#android">Tor Browser</a>, <a href="https://guardianproject.info/apps/orbot/">Proxy other apps with Orbot</a>), <a href="https://github.com/torbsd/openbsd-ports">OpenBSD.</a>'
   description="The Tor network is a group of volunteer-operated servers that allows people to improve their privacy and security on the Internet. Tor's users employ this network by connecting through a series of virtual tunnels rather than making a direct connection, thus allowing both organizations and individuals to share information over public networks without compromising their privacy. Tor is an effective censorship circumvention tool."
   %}
 


### PR DESCRIPTION
Change Tor Browser to Tor, as TB is not a network.
Update Android informations, we don't live in 2008!
https://2019.www.torproject.org/docs/android.html.en
has instructions for 1.X, 2.X and most of the links are broken
