### PR TITLE
Conditionally add top padding to Android addons icons

### DIFF
--- a/_includes/sections/android-addons.html
+++ b/_includes/sections/android-addons.html
@@ -44,7 +44,7 @@
 
 <div class="container-fluid">
   <div class="row mb-2">
-    <div class="col-lg-3 col-sm-12">
+    <div class="col-lg-3 col-sm-12 pt-lg-5">
       <img src="/assets/img/addons/xprivacylua.png" class="img-fluid d-block mr-auto ml-auto align-middle" alt="XPrivacyLua">
     </div>
     <div class="col">

--- a/_includes/sections/android-addons.html
+++ b/_includes/sections/android-addons.html
@@ -7,7 +7,7 @@
 <div class="container-fluid">
 
   <div class="row mb-2">
-    <div class="col-lg-3 col-sm-12">
+    <div class="col-lg-3 col-sm-12 pad-top-on-lg">
       <img src="/assets/img/addons/Blokada.png" height="70" width="200" class="img-fluid d-block mr-auto ml-auto align-middle" alt="Blokada">
     </div>
     <div class="col">
@@ -17,7 +17,7 @@
   </div>
 
   <div class="row mb-2">
-    <div class="col-lg-3 col-sm-12">
+    <div class="col-lg-3 col-sm-12 pad-top-on-lg">
       <img src="/assets/img/addons/netguard.png" height="70" width="200" class="img-fluid d-block mr-auto ml-auto align-middle" alt="NetGuard">
     </div>
     <div class="col">
@@ -27,7 +27,7 @@
   </div>
 
   <div class="row mb-2">
-    <div class="col-lg-3 col-sm-12">
+    <div class="col-lg-3 col-sm-12 pad-top-on-lg">
       <img src="/assets/img/addons/Orbot.png" height="70" width="200" class="img-fluid d-block mr-auto ml-auto align-middle" alt="Orbot">
     </div>
     <div class="col">

--- a/_includes/sections/android-addons.html
+++ b/_includes/sections/android-addons.html
@@ -7,7 +7,7 @@
 <div class="container-fluid">
 
   <div class="row mb-2">
-    <div class="col-lg-3 col-sm-12 pad-top-on-lg">
+    <div class="col-lg-3 col-sm-12 pt-lg-5">
       <img src="/assets/img/addons/Blokada.png" height="70" width="200" class="img-fluid d-block mr-auto ml-auto align-middle" alt="Blokada">
     </div>
     <div class="col">
@@ -17,7 +17,7 @@
   </div>
 
   <div class="row mb-2">
-    <div class="col-lg-3 col-sm-12 pad-top-on-lg">
+    <div class="col-lg-3 col-sm-12 pt-lg-5">
       <img src="/assets/img/addons/netguard.png" height="70" width="200" class="img-fluid d-block mr-auto ml-auto align-middle" alt="NetGuard">
     </div>
     <div class="col">
@@ -27,7 +27,7 @@
   </div>
 
   <div class="row mb-2">
-    <div class="col-lg-3 col-sm-12 pad-top-on-lg">
+    <div class="col-lg-3 col-sm-12 pt-lg-5">
       <img src="/assets/img/addons/Orbot.png" height="70" width="200" class="img-fluid d-block mr-auto ml-auto align-middle" alt="Orbot">
     </div>
     <div class="col">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -183,3 +183,13 @@ footer {
     margin-right: 1rem;
   }
 }
+
+.pad-top-on-lg {
+  padding-top: 0px;
+}
+
+@media only screen and (min-width: 992px) {
+  .pad-top-on-lg {
+    padding-top: 50px;
+  }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -183,13 +183,3 @@ footer {
     margin-right: 1rem;
   }
 }
-
-.pad-top-on-lg {
-  padding-top: 0px;
-}
-
-@media only screen and (min-width: 992px) {
-  .pad-top-on-lg {
-    padding-top: 50px;
-  }
-}


### PR DESCRIPTION
<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

This PR hopefully increases the UX on the [Android Addons page](https://www.privacytools.io/operating-systems/#aaddons) by adding 50 pixels of top padding to the icons conditionally (using a [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)) on the "large" Bootstrap layout until the layout collapses for smaller screens.

### Before

![addons-before](https://user-images.githubusercontent.com/1514352/62818026-398ee080-bb30-11e9-94d8-7a66eaeef54e.png)

### After

![addons-after](https://user-images.githubusercontent.com/1514352/62818028-3dbafe00-bb30-11e9-8586-e4826d78ff38.png)

### Not modified (small screen layout)

![addons-sm](https://user-images.githubusercontent.com/1514352/62818034-778c0480-bb30-11e9-8d12-c85bdf34aae9.png)

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [CONTRIBUTING.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- ~~[ ] I have listed the source code for this project in [source_code.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md).~~

- ~~[ ] This project is [free/libre software](https://www.wikipedia.org/wiki/Free_software).~~

- ~~[ ] This project has an [associated discussion](https://github.com/privacytoolsIO/privacytools.io/issues).~~

Code Repository (if applicable): N/A
