### PR TITLE
Small Improvements

### DIFF
--- a/_includes/cardv2.html
+++ b/_includes/cardv2.html
@@ -31,8 +31,8 @@
           {% if include.edge %}{% if include.edge != "" %}<a href="{{ include.edge }}"><i class="fab fa-edge fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-edge fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
 
           {% if include.android %}{% if include.android != "" %}<a href="{{ include.android }}"><i class="fab fa-android fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-android fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
-          {% if include.ios %}{% if include.ios != "" %}<a href="{{ include.ios }}"><i class="fab fa-ios fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-ios fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
-          {% if include.fire %}{% if include.fire != "" %}<a href="{{ include.fire }}"><i class="fab fa-fire fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-fire fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.ios %}{% if include.ios != "" %}<a href="{{ include.ios }}"><i class="fab fa-app-store-ios fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-app-store-ios fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.fire %}{% if include.fire != "" %}<a href="{{ include.fire }}"><i class="fas fa-fire fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fas fa-fire fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
 
           {% if include.web %}{% if include.web != "" %}<a href="{{ include.web }}"><i class="fas fa-desktop fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fas fa-desktop fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
 

--- a/_includes/cardv2.html
+++ b/_includes/cardv2.html
@@ -19,22 +19,22 @@
       </div>
 
       <div class="mt-2">
-          {% if include.windows %}<i class="fab fa-windows fa-2x fa-fw d-inline pr-1"></i>{% endif %}
-          {% if include.mac %}<i class="fab fa-apple fa-2x fa-fw d-inline pr-1"></i>{% endif %}
-          {% if include.linux %}<i class="fab fa-linux fa-2x fa-fw d-inline pr-1"></i>{% endif %}
-          {% if include.bsd %}<i class="fab fa-freebsd fa-2x fa-fw d-inline pr-1"></i>{% endif %}
+          {% if include.windows %}{% if include.windows != "" %}<a href="{{ include.windows }}"><i class="fab fa-windows fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-windows fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.mac %}{% if include.mac != "" %}<a href="{{ include.mac }}"><i class="fab fa-apple fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-apple fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.linux %}{% if include.linux != "" %}<a href="{{ include.linux }}"><i class="fab fa-linux fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-linux fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.bsd %}{% if include.bsd != "" %}<a href="{{ include.bsd }}"><i class="fab fa-freebsd fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-freebsd fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
 
-          {% if include.firefox %}<i class="fab fa-firefox fa-2x fa-fw d-inline pr-1"></i>{% endif %}
-          {% if include.chrome %}<i class="fab fa-chrome fa-2x fa-fw d-inline pr-1"></i>{% endif %}
-          {% if include.safari %}<i class="fab fa-safari fa-2x fa-fw d-inline pr-1"></i>{% endif %}
-          {% if include.opera %}<i class="fab fa-opera fa-2x fa-fw d-inline pr-1"></i>{% endif %}
-          {% if include.edge %}<i class="fab fa-edge fa-2x fa-fw d-inline pr-1"></i>{% endif %}
+          {% if include.firefox %}{% if include.firefox != "" %}<a href="{{ include.firefox }}"><i class="fab fa-firefox fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-firefox fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.chrome %}{% if include.chrome != "" %}<a href="{{ include.chrome }}"><i class="fab fa-chrome fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-chrome fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.safari %}{% if include.safari != "" %}<a href="{{ include.safari }}"><i class="fab fa-safari fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-safari fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.opera %}{% if include.opera != "" %}<a href="{{ include.opera }}"><i class="fab fa-opera fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-opera fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.edge %}{% if include.edge != "" %}<a href="{{ include.edge }}"><i class="fab fa-edge fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-edge fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
 
-          {% if include.android %}<i class="fab fa-android fa-2x fa-fw d-inline pr-1"></i>{% endif %}
-          {% if include.ios %}<i class="fab fa-app-store-ios fa-2x fa-fw d-inline pr-1"></i>{% endif %}
-          {% if include.fire %}<i class="fas fa-fire fa-2x fa-fw d-inline pr-1"></i>{% endif %}
+          {% if include.android %}{% if include.android != "" %}<a href="{{ include.android }}"><i class="fab fa-android fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-android fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.ios %}{% if include.ios != "" %}<a href="{{ include.ios }}"><i class="fab fa-ios fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-ios fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
+          {% if include.fire %}{% if include.fire != "" %}<a href="{{ include.fire }}"><i class="fab fa-fire fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fab fa-fire fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
 
-          {% if include.web %}<i class="fas fa-desktop fa-2x fa-fw d-inline pr-1"></i>{% endif %}
+          {% if include.web %}{% if include.web != "" %}<a href="{{ include.web }}"><i class="fas fa-desktop fa-2x fa-fw d-inline pr-1"></i></a>{% else %}<i class="fas fa-desktop fa-2x fa-fw d-inline pr-1"></i>{% endif %}{% endif %}
 
           {{include.icon1}}
           {{include.icon2}}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -34,7 +34,7 @@
             <a class="dropdown-item" href="/browsers/#browser"><i class="fas fa-check fa-fw"></i> Recommendations</a>
             <a class="dropdown-item" href="/browsers/#fingerprint"><i class="fas fa-fingerprint fa-fw"></i> Fingerprinting Info</a>
             <a class="dropdown-item" href="/browsers/#webrtc"><i class="far fa-eye fa-fw"></i> WebRTC IP Leak Test</a>
-            <a class="dropdown-item" href="/browsers/#addons"><i class="far fa-list-alt fa-fw"></i> Firefox Add-ons</a>
+            <a class="dropdown-item" href="/browsers/#addons"><i class="far fa-list-alt fa-fw"></i> Browser Add-ons</a>
             <a class="dropdown-item" href="/browsers/#about_config"><i class="fas fa-wrench fa-fw"></i> Firefox Tweaks</a>
           </div>
         </li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -31,11 +31,11 @@
             Browser
           </a>
           <div class="dropdown-menu" aria-labelledby="browserDropdown">
-            <a class="dropdown-item" href="/browsers/#fingerprint"><i class="fas fa-fingerprint fa-fw"></i> Fingerprint</a>
-            <a class="dropdown-item" href="/browsers/#addons"><i class="far fa-list-alt fa-fw"></i> Firefox Privacy Add-ons</a>
-            <a class="dropdown-item" href="/browsers/#about_config"><i class="fas fa-wrench fa-fw"></i> Privacy Related Tweaks</a>
-            <a class="dropdown-item" href="/browsers/#browser"><i class="fas fa-check fa-fw"></i> Recommendation</a>
-            <a class="dropdown-item" href="/browsers/#webrtc"><i class="far fa-eye fa-fw"></i> WebRTC IP Leak</a>
+            <a class="dropdown-item" href="/browsers/#browser"><i class="fas fa-check fa-fw"></i> Recommendations</a>
+            <a class="dropdown-item" href="/browsers/#fingerprint"><i class="fas fa-fingerprint fa-fw"></i> Fingerprinting Info</a>
+            <a class="dropdown-item" href="/browsers/#webrtc"><i class="far fa-eye fa-fw"></i> WebRTC IP Leak Test</a>
+            <a class="dropdown-item" href="/browsers/#addons"><i class="far fa-list-alt fa-fw"></i> Firefox Add-ons</a>
+            <a class="dropdown-item" href="/browsers/#about_config"><i class="fas fa-wrench fa-fw"></i> Firefox Tweaks</a>
           </div>
         </li>
         <li class="nav-item dropdown">
@@ -62,12 +62,12 @@
             OS
           </a>
           <div class="dropdown-menu" aria-labelledby="osDropdown">
+            <a class="dropdown-item" href="/operating-systems/#os"><i class="fas fa-th-large fa-fw"></i> PC OS Recommendations</a>
+            <a class="dropdown-item" href="/operating-systems/#live_os"><i class="fas fa-compact-disc fa-fw"></i> Live CD Operating Systems</a>
+            <a class="dropdown-item" href="/operating-systems/#mobile_os"><i class="fas fa-mobile-alt fa-fw"></i> Mobile Operating Systems</a>
             <a class="dropdown-item" href="/operating-systems/#aaddons"><i class="fas fa-th fa-fw"></i> Android Privacy Add-ons</a>
-            <a class="dropdown-item" href="/operating-systems/#win10"><i class="far fa-thumbs-down fa-fw"></i> Don't use Windows 10</a>
-            <a class="dropdown-item" href="/operating-systems/#live_os"><i class="fas fa-compact-disc fa-fw"></i> Live CD OS</a>
-            <a class="dropdown-item" href="/operating-systems/#mobile_os"><i class="fas fa-mobile-alt fa-fw"></i> Mobile OS</a>
-            <a class="dropdown-item" href="/operating-systems/#os"><i class="fas fa-th-large fa-fw"></i> PC OS</a>
             <a class="dropdown-item" href="/operating-systems/#firmware"><i class="fas fa-signal fa-fw"></i> Router Firmware</a>
+            <a class="dropdown-item" href="/operating-systems/#win10"><i class="far fa-thumbs-down fa-fw"></i> Don't use Windows 10</a>
           </div>
         </li>
         <li class="nav-item">

--- a/_includes/sections/browser-addons.html
+++ b/_includes/sections/browser-addons.html
@@ -1,7 +1,7 @@
-<h1 id="addons" class="anchor"><a href="#addons"><i class="fas fa-link anchor-icon"></i></a> Excellent Firefox Privacy Add-ons</h1>
+<h1 id="addons" class="anchor"><a href="#addons"><i class="fas fa-link anchor-icon"></i></a> Recommended Browser Add-ons</h1>
 
 <div class="alert alert-primary" role="alert">
-  <strong>Improve your privacy with these excellent Firefox add-ons.</strong>
+  <strong>Improve your privacy with these browser add-ons.</strong>
 </div>
 
 

--- a/_includes/sections/browser-recommendation.html
+++ b/_includes/sections/browser-recommendation.html
@@ -1,4 +1,4 @@
-<h1 id="browser" class="anchor"><a href="#browser"><i class="fas fa-link anchor-icon"></i></a> Browser Recommendation</h1>
+<h1 id="browser" class="anchor"><a href="#browser"><i class="fas fa-link anchor-icon"></i></a> Browser Recommendations</h1>
 
 {% include cardv2.html
 title="Mozilla Firefox"
@@ -17,7 +17,7 @@ bsd=""
 %}
 
 {% include cardv2.html
-title="Tor Browser - for anonymity"
+title="Tor Browser - Provides Anonymity"
 image="/assets/img/tools/Tor-Browser.png"
 description='Tor Browser is your choice if you need an extra layer of anonymity. It\'s a modified version of Firefox ESR, which comes with pre-installed privacy add-ons, encryption and an advanced proxy. <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-1-myth-busting-tor">How does Tor work?</a>'
 website="https://www.torproject.org/"
@@ -32,7 +32,7 @@ bsd=""
 %}
 
 {% include cardv2.html
-title="Brave Browser - Complete but Experimental"
+title="Brave Browser - Chromium Based Runner-Up"
 image="/assets/img/tools/Brave.png"
 description="The new open source browser Brave automatically blocks ads and trackers, making it faster and safer than your current browser. Brave is based on Chromium. <span class=\"badge badge-warning\" data-toggle=\"tooltip\" title=\"Brave is a good choice if you want to use a Chromium-based browser. But at this point in Brave's development&comma; it's not as good as Firefox with privacy addons.\">experimental <i class=\"far fa-question-circle\"></i></span>"
 website="https://brave.com/"

--- a/_includes/sections/browser-recommendation.html
+++ b/_includes/sections/browser-recommendation.html
@@ -32,7 +32,7 @@ bsd=""
 %}
 
 {% include cardv2.html
-title="Brave Browser - Chromium Based Runner-Up"
+title="Brave Browser - Chromium Based"
 image="/assets/img/tools/Brave.png"
 description="The new open source browser Brave automatically blocks ads and trackers, making it faster and safer than your current browser. Brave is based on Chromium. <span class=\"badge badge-warning\" data-toggle=\"tooltip\" title=\"Brave is a good choice if you want to use a Chromium-based browser. But at this point in Brave's development&comma; it's not as good as Firefox with privacy addons.\">experimental <i class=\"far fa-question-circle\"></i></span>"
 website="https://brave.com/"


### PR DESCRIPTION
Reordered the sub-navigations for "browser" and "os" to make more logical sense, not sure why they were alphabetized with the rest.

Renamed sections to be browser-agnostic.

Added support for adding links to platform icons in cardv2.html:

Icons left blank (as they all currently are) will remain functionally the same, for example:

```
firefox=""
chrome=""
safari=""
opera=""
edge=""
android=""
```

However, adding a link to one:

```
chrome="https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm?hl=en"
```

...will add a hyperlink to that icon (the same way the Git icons are currently linked), allowing us to link to download pages for various platforms. All platform icons now support this functionality, although it will be most useful for linking browser extensions. I did not find and add links to each platform in this PR.