### PR TITLE
Add Hat.sh to File Encryption page

### DIFF
--- a/_includes/sections/file-encryption.html
+++ b/_includes/sections/file-encryption.html
@@ -43,5 +43,6 @@
 <ul>
   <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.</li>
   <li><a href="https://diskcryptor.net/">DiskCryptor</a> - A full disk and partition encryption system for Windows including the ability to encrypt the partition and disk on which the OS is installed.</li>
-  <li><a href="https://gitlab.com/cryptsetup/cryptsetup/">Linux Unified Key Setup (LUKS)</a> - A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.
+  <li><a href="https://gitlab.com/cryptsetup/cryptsetup/">Linux Unified Key Setup (LUKS)</a> - A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.</li>
+  <li><a href="https://hat.sh/">Hat.sh is a cross-platform, serverless JavaScript web application that provides secure file encryption using the AES-256-GCM algorithm in your browser. It can also be downloaded and run offline.</a></li>
 </ul>

--- a/source_code.md
+++ b/source_code.md
@@ -213,23 +213,22 @@ Backend: closed-source
     Flock: https://github.com/signalapp/Flock
 
 ## File Encryption Software
- VeraCrypt: https://www.veracrypt.fr/en/Source%20Code.html
 
- GNU Privacy Guard: https://github.com/gpg/gnupg
+VeraCrypt: https://www.veracrypt.fr/en/Source%20Code.html
 
- PeaZip: https://github.com/giorgiotani/PeaZip/
+GNU Privacy Guard: https://github.com/gpg/gnupg
 
- Cryptomator: https://github.com/cryptomator/cryptomator
+PeaZip: https://github.com/giorgiotani/PeaZip/
 
-  Worth Mentioning:
 
-   miniLock: https://github.com/kaepora/miniLock
+Worth Mentioning:
+- Cryptomator: https://github.com/cryptomator/cryptomator
 
-   AES Crypt: https://github.com/marcobellaccini/pyAesCrypt
+- DiskCryptor: https://github.com/smartinm/diskcryptor
 
-   DiskCryptor: https://github.com/smartinm/diskcryptor
+- Linux Unified Key Setup (LUKS): https://gitlab.com/cryptsetup/cryptsetup/
 
-   Linux Unified Key Setup (LUKS): https://gitlab.com/cryptsetup/cryptsetup/
+- Hat.sh: https://github.com/sh-dv/hat.sh
 
 ## Self-contained Networks
  TorBrowser: https://gitweb.torproject.org/tor.git


### PR DESCRIPTION
<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: https://github.com/privacytoolsIO/privacytools.io/issues/1056

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [CONTRIBUTING.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] I have listed the source code for this project in [source_code.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md).

- [x] This project is [free/libre software](https://www.wikipedia.org/wiki/Free_software).

- [x] This project has an [associated discussion](https://github.com/privacytoolsIO/privacytools.io/issues).

Code Repository (if applicable): https://github.com/sh-dv/hat.sh
