### PR TITLE
Add section to validate DNS connection

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -290,15 +290,15 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
   <ul>
     <li>DoH / DoT
       <ul>
-        <li>Check <a href="https://www.dnsleaktest.com/">https://www.dnsleaktest.com/</a>.</li>
+        <li>Check <a href="https://www.dnsleaktest.com/">DNSLeakTest.com</a>. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title="If your DNS provider relies on anycast, the displayed ISP, hostname, or location may be misleading although valid."><i class="fas fa-exclamation-triangle"></i></span></li>
         <li>Check the website of your DNS provider. They may have a page for telling "you are using X DNS." Examples include <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a> and <a href="https://1.1.1.1/help">Cloudflare</a>.</li>
-        <li>If using Firefox's trusted recursive resolver (TRR), navigate to <code>about:networking#dns</code>. If the TRR column says "true" for some fields, you are using DoH.</li>
+        <li>If using Firefox's trusted recursive resolver (TRR), navigate to <code>about:networking#dns</code>. If the TRR column says "true" for some fields, you are using DoH. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title='Some fields will say "false" depending on the the value of network.trr.mode in about:config'><a href="https://wiki.mozilla.org/Trusted_Recursive_Resolver"><i class="fas fa-exclamation-triangle"></i></a></span></li>
       </ul>
     </li>
-    <li>dnscrypt-proxy - Try the above steps or attempt to stop it. If you have configured it correctly, your DNS requests will stop working (with the exception having Firefox's TRR configured).
+    <li>dnscrypt-proxy - Check <a href="https://github.com/jedisct1/dnscrypt-proxy/wiki/Checking">dnscrypt-proxy's wiki on how to verify that your DNS is encrypted</a>.
     </li>
-    <li>DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">https://dnssec.vs.uni-due.de/</a>.</li>
-    <li>QNAME Minimization - Run <code>dig +short txt qnamemintest.internet.nl</code> from the command-line (taken from <a href="https://nlnetlabs.nl/downloads/presentations/unbound_qnamemin_oarc24.pdf">this NLnet Labs presentation</a>). You should see this display: <code>"HOORAY - QNAME minimisation is enabled on your resolver :)!"</code></li>
+    <li>DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">DNSSEC Resolver Test by Matthäus Wander</a>.</li>
+    <li>QNAME Minimization - Run <code><a href="https://en.wikipedia.org/wiki/Dig_(command)">dig</a> +short txt qnamemintest.internet.nl</code> from the command-line (taken from <a href="https://nlnetlabs.nl/downloads/presentations/unbound_qnamemin_oarc24.pdf">this NLnet Labs presentation</a>). You should see this display: <code>"HOORAY - QNAME minimisation is enabled on your resolver :)!"</code></li>
   </ul>
 
   <h3>Worth Mentioning and Additional Information</h3>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -297,7 +297,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     </li>
     <li>dnscrypt-proxy - Check <a href="https://github.com/jedisct1/dnscrypt-proxy/wiki/Checking">dnscrypt-proxy's wiki on how to verify that your DNS is encrypted</a>.
     </li>
-    <li>DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">DNSSEC Resolver Test by Matthäus Wander</a>.</li>
+    <li>DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">DNSSEC Resolver Test by Matthäus Wander</a> or <a href="https://www.dnssec.cz/">DNSSEC Test by CZ.NIC</a>.</li>
     <li>QNAME Minimization - Run <code><a href="https://en.wikipedia.org/wiki/Dig_(command)">dig</a> +short txt qnamemintest.internet.nl</code> from the command-line (taken from <a href="https://nlnetlabs.nl/downloads/presentations/unbound_qnamemin_oarc24.pdf">this NLnet Labs presentation</a>). You should see this display: <code>"HOORAY - QNAME minimisation is enabled on your resolver :)!"</code></li>
   </ul>
 

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -285,7 +285,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     <li>DNSCrypt - An older yet robust method of encrypting DNS.</li>
   </ul>
 
-  <h4>How to Validate</h4>
+  <h4>How to verify DNS is encrypted</h4>
 
   <ul>
     <li>DoH / DoT

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -291,7 +291,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     <li>DoH / DoT
       <ul>
         <li>Check <a href="https://www.dnsleaktest.com/">DNSLeakTest.com</a>. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title="Your DNS provider may not appear with their own name, so compare the responses to what you know or can find about your DNS provider. Just ensure you don't see your ISP or old unencrypted DNS provider."><i class="fas fa-exclamation-triangle"></i></span></li>
-        <li>Check the website of your DNS provider. They may have a page for telling "you are using X DNS." Examples include <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a> and <a href="https://1.1.1.1/help">Cloudflare</a>.</li>
+        <li>Check the website of your DNS provider. They may have a page for telling "you are using our DNS." Examples include <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a> and <a href="https://1.1.1.1/help">Cloudflare</a>.</li>
         <li>If using Firefox's trusted recursive resolver (TRR), navigate to <code>about:networking#dns</code>. If the TRR column says "true" for some fields, you are using DoH. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title='Some fields will say "false" depending on the the value of network.trr.mode in about:config'><a href="https://wiki.mozilla.org/Trusted_Recursive_Resolver"><i class="fas fa-exclamation-triangle"></i></a></span></li>
       </ul>
     </li>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -290,7 +290,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
   <ul>
     <li>DoH / DoT
       <ul>
-        <li>Check <a href="https://www.dnsleaktest.com/">DNSLeakTest.com</a>. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title="If your DNS provider relies on anycast, the displayed ISP, hostname, or location may be misleading although valid."><i class="fas fa-exclamation-triangle"></i></span></li>
+        <li>Check <a href="https://www.dnsleaktest.com/">DNSLeakTest.com</a>. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title="Your DNS provider may not appear with their own name, so compare the responses to what you know or can find about your DNS provider. Just ensure you don't see your ISP or old unencrypted DNS provider."><i class="fas fa-exclamation-triangle"></i></span></li>
         <li>Check the website of your DNS provider. They may have a page for telling "you are using X DNS." Examples include <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a> and <a href="https://1.1.1.1/help">Cloudflare</a>.</li>
         <li>If using Firefox's trusted recursive resolver (TRR), navigate to <code>about:networking#dns</code>. If the TRR column says "true" for some fields, you are using DoH. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title='Some fields will say "false" depending on the the value of network.trr.mode in about:config'><a href="https://wiki.mozilla.org/Trusted_Recursive_Resolver"><i class="fas fa-exclamation-triangle"></i></a></span></li>
       </ul>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -37,7 +37,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
   <table class="table sortable-theme-bootstrap" data-sortable>
     <thead>
       <tr>
-        <th data-sorted="true" data-sorted-direction="descending">ICANN DNS Provider</th>
+        <th data-sorted="true" data-sorted-direction="ascending">ICANN DNS Provider</th>
         <th data-sortable="true">Server Locations</th>
         <th data-sortable="false">Privacy Policy</th>
         <th data-sortable="true">Type</th>
@@ -283,6 +283,22 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     <li>DNS-over-TLS (DoT) - A security protocol for encrypted DNS on a dedicated port 853.</li>
     <li>DNS-over-HTTPS (DoH) - Similar to DoT, but uses HTTPS instead, being indistinguishable from "normal" HTTPS traffic on port 443.</li>
     <li>DNSCrypt - An older yet robust method of encrypting DNS.</li>
+  </ul>
+
+  <h4>How to Validate</h4>
+
+  <ul>
+    <li>DoH / DoT
+      <ul>
+        <li>Check <a href="https://www.dnsleaktest.com/">https://www.dnsleaktest.com/</a>.</li>
+        <li>Check the website of your DNS provider. They may have a page for telling "you are using X DNS." Examples include <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a> and <a href="https://1.1.1.1/help">Cloudflare</a>.</li>
+        <li>If using Firefox's trusted recursive resolver (TRR), navigate to <code>about:networking#dns</code>. If the TRR column says "true" for some fields, you are using DoH.</li>
+      </ul>
+    </li>
+    <li>dnscrypt-proxy - Try the above steps or attempt to stop it. If you have configured it correctly, your DNS requests will stop working (with the exception having Firefox's TRR configured).
+    </li>
+    <li>DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">https://dnssec.vs.uni-due.de/</a>.</li>
+    <li>QNAME Minimization - Run <code>dig +short txt qnamemintest.internet.nl</code> from the command-line (taken from <a href="https://nlnetlabs.nl/downloads/presentations/unbound_qnamemin_oarc24.pdf">this NLnet Labs presentation</a>). You should see this display: <code>"HOORAY - QNAME minimisation is enabled on your resolver :)!"</code></li>
   </ul>
 
   <h3>Worth Mentioning and Additional Information</h3>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -297,7 +297,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     </li>
     <li>dnscrypt-proxy - Check <a href="https://github.com/jedisct1/dnscrypt-proxy/wiki/Checking">dnscrypt-proxy's wiki on how to verify that your DNS is encrypted</a>.
     </li>
-    <li>DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">DNSSEC Resolver Test by Matthäus Wander</a> or <a href="https://www.dnssec.cz/">DNSSEC Test by CZ.NIC</a>.</li>
+    <li>DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">DNSSEC Resolver Test by Matthäus Wander</a>.</li>
     <li>QNAME Minimization - Run <code><a href="https://en.wikipedia.org/wiki/Dig_(command)">dig</a> +short txt qnamemintest.internet.nl</code> from the command-line (taken from <a href="https://nlnetlabs.nl/downloads/presentations/unbound_qnamemin_oarc24.pdf">this NLnet Labs presentation</a>). You should see this display: <code>"HOORAY - QNAME minimisation is enabled on your resolver :)!"</code></li>
   </ul>
 


### PR DESCRIPTION
<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

This PR adds a new section for giving users easy to follow steps to validate their encrypted DNS connection is working for them. Definitely open to any feedback to make this clearer and more readable.

@Mikaela did note in the issue:
> Should we note here [in Firefox's `about:networking#dns` step] that it's normal that some first queries such as captive portal checking may be going plaintext? Is it OK that our instructions allow downgrading to insecure DNS if DoH is down? I guess as optimally the user has global DNS encryption and eDNS is just going to benefit as DoH?

I address this by saying `If the TRR column says "true" for some fields, you are using DoH.` Maybe this could be changed to something more clearer?

Resolves: https://github.com/privacytoolsIO/privacytools.io/issues/1152 

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [CONTRIBUTING.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- ~~[ ] I have listed the source code for this project in [source_code.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md).~~

- ~~[ ] This project is [free/libre software](https://www.wikipedia.org/wiki/Free_software).~~

- [x] This project has an [associated discussion](https://github.com/privacytoolsIO/privacytools.io/issues).

Code Repository (if applicable): N/A
