### PR TITLE
Indicate which DNS providers support DoT over port 443

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -85,7 +85,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         </td>
         <td>Hobby Project</td>
         <td>No</td>
-        <td>DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success">DoT</span>, DNSCrypt</td>
+        <td data-value="dot/443">DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success"><strong>DoT</strong></span>, DNSCrypt</td>
         <td>Yes</td>
         <td>Yes</td>
         <td>Ads, trackers, malicious domains <span class="badge badge-warning" data-toggle="tooltip" data-original-title="And some wildcard, IDN, and non-ASCII domains."><a href="https://github.com/ookangzheng/blahdns#default-blocked-wildcard-domain"><i class="fas fa-exclamation-triangle"></i></a></span></td>
@@ -150,7 +150,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         </td>
         <td>Hobby Project</td>
         <td>No</td>
-        <td>DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success">DoT</span>, DNSCrypt</td>
+        <td data-value="dot/443">DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success"><strong>DoT</strong></span>, DNSCrypt</td>
         <td>Yes</td>
         <td>Yes</td>
         <td>Based on server choice</td>
@@ -169,7 +169,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         </td>
         <td>Non-Profit</td>
         <td><a data-toggle="tooltip" data-placement="bottom" data-original-title='"We do NOT log your IP address or DNS queries during normal operations. We do NOT share query data with third parties that are not directly involved with resolving the query (i.e. sending queries to authoritative nameservers for resolution)."' href="https://appliedprivacy.net/privacy-policy/">Some</a></td>
-        <td>DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success">DoT</span></td>
+        <td data-value="dot/443">DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success"><strong>DoT</strong></span></td>
         <td>Yes</td>
         <td>Yes</td>
         <td>No</td>
@@ -280,7 +280,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
   <h4>Terms</h4>
 
   <ul>
-    <li>DNS-over-TLS (DoT) - A security protocol for encrypted DNS on a dedicated port 853.</li>
+    <li>DNS-over-TLS (DoT) - A security protocol for encrypted DNS on a dedicated port 853. Some providers support port 443 which generally works everywhere while port 853 is often blocked by restrictive firewalls.</li>
     <li>DNS-over-HTTPS (DoH) - Similar to DoT, but uses HTTPS instead, being indistinguishable from "normal" HTTPS traffic on port 443.</li>
     <li>DNSCrypt - An older yet robust method of encrypting DNS.</li>
   </ul>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -85,7 +85,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         </td>
         <td>Hobby Project</td>
         <td>No</td>
-        <td>DoH, DoT, DNSCrypt</td>
+        <td>DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success">DoT</span>, DNSCrypt</td>
         <td>Yes</td>
         <td>Yes</td>
         <td>Ads, trackers, malicious domains <span class="badge badge-warning" data-toggle="tooltip" data-original-title="And some wildcard, IDN, and non-ASCII domains."><a href="https://github.com/ookangzheng/blahdns#default-blocked-wildcard-domain"><i class="fas fa-exclamation-triangle"></i></a></span></td>
@@ -150,7 +150,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         </td>
         <td>Hobby Project</td>
         <td>No</td>
-        <td>DoH, DoT, DNSCrypt</td>
+        <td>DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success">DoT</span>, DNSCrypt</td>
         <td>Yes</td>
         <td>Yes</td>
         <td>Based on server choice</td>
@@ -169,7 +169,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         </td>
         <td>Non-Profit</td>
         <td><a data-toggle="tooltip" data-placement="bottom" data-original-title='"We do NOT log your IP address or DNS queries during normal operations. We do NOT share query data with third parties that are not directly involved with resolving the query (i.e. sending queries to authoritative nameservers for resolution)."' href="https://appliedprivacy.net/privacy-policy/">Some</a></td>
-        <td>DoH, DoT</td>
+        <td>DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success">DoT</span></td>
         <td>Yes</td>
         <td>Yes</td>
         <td>No</td>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -85,7 +85,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         </td>
         <td>Hobby Project</td>
         <td>No</td>
-        <td data-value="dot/443">DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success"><strong>DoT</strong></span>, DNSCrypt</td>
+        <td data-value="dot/443">DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853"><strong>DoT</strong></span>, DNSCrypt</td>
         <td>Yes</td>
         <td>Yes</td>
         <td>Ads, trackers, malicious domains <span class="badge badge-warning" data-toggle="tooltip" data-original-title="And some wildcard, IDN, and non-ASCII domains."><a href="https://github.com/ookangzheng/blahdns#default-blocked-wildcard-domain"><i class="fas fa-exclamation-triangle"></i></a></span></td>
@@ -150,7 +150,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         </td>
         <td>Hobby Project</td>
         <td>No</td>
-        <td data-value="dot/443">DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success"><strong>DoT</strong></span>, DNSCrypt</td>
+        <td data-value="dot/443">DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853"><strong>DoT</strong></span>, DNSCrypt</td>
         <td>Yes</td>
         <td>Yes</td>
         <td>Based on server choice</td>
@@ -169,7 +169,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         </td>
         <td>Non-Profit</td>
         <td><a data-toggle="tooltip" data-placement="bottom" data-original-title='"We do NOT log your IP address or DNS queries during normal operations. We do NOT share query data with third parties that are not directly involved with resolving the query (i.e. sending queries to authoritative nameservers for resolution)."' href="https://appliedprivacy.net/privacy-policy/">Some</a></td>
-        <td data-value="dot/443">DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853" class="text-success"><strong>DoT</strong></span></td>
+        <td data-value="dot/443">DoH, <span data-toggle="tooltip" data-placement="bottom" data-original-title="Supports port 443 in addition to 853"><strong>DoT</strong></span></td>
         <td>Yes</td>
         <td>Yes</td>
         <td>No</td>


### PR DESCRIPTION
<!-- PLEASE READ OUR [CONTRIBUTING GUIDELINES](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

This PR adds a tooltip to the providers who support DoT over port 443 in addition to the expected port 853. This is an important indication because like DoH, DoT/443 makes eavesdropping more difficult for third parties and provides the benefit of not easily being blocked by firewalls compared to 853.

Resolves: #none

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [CONTRIBUTING.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- ~~[ ] I have listed the source code for this project in [source_code.md](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md).~~

- ~~[ ] This project is [free/libre software](https://www.wikipedia.org/wiki/Free_software).~~

- ~~[ ] This project has an [associated discussion](https://github.com/privacytoolsIO/privacytools.io/issues).~~ (via Wire chat)

Code Repository (if applicable): N/A
