### PR TITLE
Add blog to navbar

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -107,6 +107,9 @@
         <li class="nav-item">
           <a class="nav-link" href="/donate/">Donate <i class="fas fa-heart text-danger"></i></a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="https://blog.privacytools.io">Blog</a>
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Building on ideas in #972 and #848, this adds our new official blog to the navbar.

Short-term this will be the location for more in-depth articles/tutorials like "Self-hosting a VPN" and announcements like "[Tor on privacytools.io](https://blog.privacytools.io/posts/securing-services-with-tor-and-alt-svc/)". Long-term we could expand to guest posting, syndication, etc.

This blog is made with Jekyll and the source can be found at https://github.com/privacytoolsIO/blog.privacytools.io