### PR TITLE
DNS: mention providers using Tor and link to The Great Cloudwall in further reading (and sort the further reading alphabetically)

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -330,7 +330,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     </li>
     <li><strong>Further reading:</strong>
       <ul>
-        <li>Cloudflare is one of the world's largest network infrastructure and DDoS protection corporations, and a problem considering anonymity and decentralization. <em>…a huge portion of the Internet now sits behind our network. <a href="https://w3techs.com/technologies/history_overview/proxy/all">10% of the top million, 17% of the top 100,000, and 19% of the top 10,000 Internet properties use us today. 10% of the Fortune 1,000 are paying Cloudflare customers</em></a>. See also <a href="https://codeberg.org/crimeflare/cloudflare-tor/">The Great Cloudwall</a></li>
+        <li>Cloudflare is one of the world's largest network infrastructure and DDoS protection corporations, and due to its size a problem considering anonymity and decentralization; <em>…a huge portion of the Internet now sits behind our network. <a href="https://w3techs.com/technologies/history_overview/proxy/all">10% of the top million, 17% of the top 100,000, and 19% of the top 10,000 Internet properties use us today. 10% of the Fortune 1,000 are paying Cloudflare customers</em></a>. See also <a href="https://codeberg.org/crimeflare/cloudflare-tor/">The Great Cloudwall</a>.</li>
         <li><a href="https://www.isc.org/dnssec/">DNSSEC and BIND 9</a> by the ISC</li>
         <li><a href="https://www.isc.org/blogs/qname-minimization-and-privacy/">QNAME Minimization and Your Privacy</a> by the Internet Systems Consortium (ISC)</li>
       </ul>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -51,8 +51,8 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     </thead>
     <tbody>
       <tr>
-        <td data-value="AdGuard"> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare, see further reading below."><i class="fas fa-exclamation-triangle"></i></span>
-          <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a>
+        <td data-value="AdGuard">
+          <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare, see further reading below."><i class="fas fa-exclamation-triangle"></i></span>
         </td>
         <td>Anycast (based in <span class="flag-icon flag-icon-cy"></span> Cyprus)</td>
         <td>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -51,14 +51,14 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     </thead>
     <tbody>
       <tr>
-        <td data-value="AdGuard">
+        <td data-value="AdGuard"> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare, see further reading below."><i class="fas fa-exclamation-triangle"></i></span>
           <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a>
         </td>
         <td>Anycast (based in <span class="flag-icon flag-icon-cy"></span> Cyprus)</td>
         <td>
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://adguard.com/en/privacy/dns.html" href="https://adguard.com/en/privacy/dns.html">
             <img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35">
-          </a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare, see further reading below."><i class="fas fa-exclamation-triangle"></i></span>
+          </a>
         </td>
         <td>Commercial</td>
         <td>No</td>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -330,7 +330,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     </li>
     <li><strong>Further reading:</strong>
       <ul>
-        <li>Cloudflare is one of the world's largest network infrastructure and DDoS protection corporations, and a problem considering anonymity and decentralization. <em>…a huge portion of the Internet now sits behind our network. <a href="https://w3techs.com/technologies/history_overview/proxy/all">10% of the top million, 17% of the top 100,000, and 19% of the top 10,000 Internet properties use us today. 10% of the Fortune 1,000 are paying Cloudflare customers.</em></a> See also <a href="https://codeberg.org/crimeflare/cloudflare-tor/">The Great Cloudwall</a></li>
+        <li>Cloudflare is one of the world's largest network infrastructure and DDoS protection corporations, and a problem considering anonymity and decentralization. <em>…a huge portion of the Internet now sits behind our network. <a href="https://w3techs.com/technologies/history_overview/proxy/all">10% of the top million, 17% of the top 100,000, and 19% of the top 10,000 Internet properties use us today. 10% of the Fortune 1,000 are paying Cloudflare customers</em></a>. See also <a href="https://codeberg.org/crimeflare/cloudflare-tor/">The Great Cloudwall</a></li>
         <li><a href="https://www.isc.org/dnssec/">DNSSEC and BIND 9</a> by the ISC</li>
         <li><a href="https://www.isc.org/blogs/qname-minimization-and-privacy/">QNAME Minimization and Your Privacy</a> by the Internet Systems Consortium (ISC)</li>
       </ul>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -330,7 +330,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     </li>
     <li><strong>Further reading:</strong>
       <ul>
-        <li>Cloudflare is one of the world's largest network infrastructure and DDoS protection corporations, and a problem considering anonymity and decentralization. <em>...a huge portion of the Internet now sits behind our network. <a href="https://w3techs.com/technologies/history_overview/proxy/all">10% of the top million, 17% of the top 100,000, and 19% of the top 10,000 Internet properties use us today. 10% of the Fortune 1,000 are paying Cloudflare customers.</em></a> See also <a href="https://codeberg.org/crimeflare/cloudflare-tor/">The Great Cloudwall</a></li>
+        <li>Cloudflare is one of the world's largest network infrastructure and DDoS protection corporations, and a problem considering anonymity and decentralization. <em>…a huge portion of the Internet now sits behind our network. <a href="https://w3techs.com/technologies/history_overview/proxy/all">10% of the top million, 17% of the top 100,000, and 19% of the top 10,000 Internet properties use us today. 10% of the Fortune 1,000 are paying Cloudflare customers.</em></a> See also <a href="https://codeberg.org/crimeflare/cloudflare-tor/">The Great Cloudwall</a></li>
         <li><a href="https://www.isc.org/dnssec/">DNSSEC and BIND 9</a> by the ISC</li>
         <li><a href="https://www.isc.org/blogs/qname-minimization-and-privacy/">QNAME Minimization and Your Privacy</a> by the Internet Systems Consortium (ISC)</li>
       </ul>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -58,7 +58,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         <td>
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://adguard.com/en/privacy/dns.html" href="https://adguard.com/en/privacy/dns.html">
             <img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35">
-          </a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare"><i class="fas fa-exclamation-triangle"></i></span>
+          </a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare, see further reading below."><i class="fas fa-exclamation-triangle"></i></span>
         </td>
         <td>Commercial</td>
         <td>No</td>
@@ -75,7 +75,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
 
       <tr>
         <td data-value="BlahDNS">
-          <a href="https://blahdns.com/">BlahDNS</a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare"><i class="fas fa-exclamation-triangle"></i></span>
+          <a href="https://blahdns.com/">BlahDNS</a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare, see further reading below."><i class="fas fa-exclamation-triangle"></i></span>
         </td>
         <td><span class="flag-icon flag-icon-ch"></span> Switzerland, <span class="flag-icon flag-icon-jp"></span> Japan, <span class="flag-icon flag-icon-de"></span> Germany</td>
         <td>
@@ -98,7 +98,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
 
       <tr>
         <td data-value="Cloudflare">
-          <a href="https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/">Cloudflare</a> <span class="badge badge-warning" data-toggle="tooltip" title="Cloudflare is one of the world's largest networks, and a problem considering anonymity and decentralization."><a href="https://codeberg.org/crimeflare/cloudflare-tor/"><i class="fas fa-exclamation-triangle"></i></a></span>
+          <a href="https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/">Cloudflare</a> <span class="badge badge-warning" data-toggle="tooltip" title="Cloudflare itself, see further reading below."><i class="fas fa-exclamation-triangle"></i></span>
         </td>
         <td>Anycast (based in <span class="flag-icon flag-icon-us"></span> US)</td>
         <td>
@@ -178,7 +178,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
 
       <tr>
         <td data-value="nextdns">
-          <a href="https://www.nextdns.io/">nextdns</a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare"><i class="fas fa-exclamation-triangle"></i></span>
+          <a href="https://www.nextdns.io/">nextdns</a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare, see further reading below."><i class="fas fa-exclamation-triangle"></i></span>
         </td>
         <td>Anycast (based in <span class="flag-icon flag-icon-us"></span> US)</td>
         <td>
@@ -330,8 +330,9 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
     </li>
     <li><strong>Further reading:</strong>
       <ul>
-        <li><a href="https://www.isc.org/blogs/qname-minimization-and-privacy/">QNAME Minimization and Your Privacy</a> by the Internet Systems Consortium (ISC)</li>
+        <li>Cloudflare is one of the world's largest network infrastructure and DDoS protection corporations, and a problem considering anonymity and decentralization. <em>...a huge portion of the Internet now sits behind our network. <a href="https://w3techs.com/technologies/history_overview/proxy/all">10% of the top million, 17% of the top 100,000, and 19% of the top 10,000 Internet properties use us today. 10% of the Fortune 1,000 are paying Cloudflare customers.</em></a> See also <a href="https://codeberg.org/crimeflare/cloudflare-tor/">The Great Cloudwall</a></li>
         <li><a href="https://www.isc.org/dnssec/">DNSSEC and BIND 9</a> by the ISC</li>
+        <li><a href="https://www.isc.org/blogs/qname-minimization-and-privacy/">QNAME Minimization and Your Privacy</a> by the Internet Systems Consortium (ISC)</li>
       </ul>
     </li>
   </ul>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -58,7 +58,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
         <td>
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://adguard.com/en/privacy/dns.html" href="https://adguard.com/en/privacy/dns.html">
             <img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35">
-          </a>
+          </a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare"><i class="fas fa-exclamation-triangle"></i></span>
         </td>
         <td>Commercial</td>
         <td>No</td>
@@ -75,7 +75,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
 
       <tr>
         <td data-value="BlahDNS">
-          <a href="https://blahdns.com/">BlahDNS</a>
+          <a href="https://blahdns.com/">BlahDNS</a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare"><i class="fas fa-exclamation-triangle"></i></span>
         </td>
         <td><span class="flag-icon flag-icon-ch"></span> Switzerland, <span class="flag-icon flag-icon-jp"></span> Japan, <span class="flag-icon flag-icon-de"></span> Germany</td>
         <td>
@@ -178,7 +178,7 @@ github="https://github.com/jedisct1/dnscrypt-proxy"
 
       <tr>
         <td data-value="nextdns">
-          <a href="https://www.nextdns.io/">nextdns</a>
+          <a href="https://www.nextdns.io/">nextdns</a> <span class="badge badge-warning" data-toggle="tooltip" title="Uses Cloudflare"><i class="fas fa-exclamation-triangle"></i></span>
         </td>
         <td>Anycast (based in <span class="flag-icon flag-icon-us"></span> US)</td>
         <td>


### PR DESCRIPTION
## Description

Resolves: #none 

I think we had Cloudflare warnings in the beginning, but they seem to have been removed at some point of development. I think knowing the existence of Cloudflare is particularly relevant with such a critical part of infrastructure as DNS even if we didn't list it anywhere else.

I was most recently reminded of this by https://github.com/privacytoolsIO/privacytools.io/issues/1215.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

* Netlify preview for the mainly edited page: https://deploy-preview-1218--privacytools-io.netlify.com/providers/dns/#icanndns