### PR TITLE
Fix LessPass GitHub link

### DIFF
--- a/_includes/sections/password-managers.html
+++ b/_includes/sections/password-managers.html
@@ -44,7 +44,7 @@
   description="<strong>LessPass</strong> is a free and open source password manager that generates unique passwords for websites, email accounts, or anything else based on a master password and information you know. No sync needed. Uses PBKDF2 and SHA-256. It's advised to use the browser addons for more security."
   website="https://lesspass.com/"
   forum="https://forum.privacytools.io/t/discussion-keepassxc/1344/2"
-  github="https://github.com/keepassxreboot/keepassxc"
+  github="https://github.com/lesspass/lesspass"
   firefox="https://addons.mozilla.org/en-US/firefox/addon/lesspass/"
   chrome="https://chrome.google.com/webstore/detail/lesspass/lcmbpoclaodbgkbjafnkbbinogcbnjih"
   android="https://play.google.com/store/apps/details?id=com.lesspass.android&hl=en"


### PR DESCRIPTION
<!-- PLEASE READ OUR CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Currently points to KeePassXC's GitHub repository -- my mistake.

Resolves: #none <!-- The number of the issue that is resolved by this pull request. If there is none, feel free to delete this line -->

* Netlify preview for the mainly edited page: https://deploy-preview-1238--privacytools-io.netlify.com/software/passwords/#pw <!-- link or Non Applicable? Edit this in afterwards -->