### PR TITLE
Add Onion service URL for Keybase

### DIFF
--- a/_includes/sections/teamchat.html
+++ b/_includes/sections/teamchat.html
@@ -4,35 +4,38 @@
         <strong>If your project or organization currently uses a platform like <a href="https://web.archive.org/web/20171029114027/https://feedback.discordapp.com/forums/326712-discord-dream-land/suggestions/17094256-implement-whispersystems-encryption-for-voice-and">Discord</a> or <a href="https://drewdevault.com/2015/11/01/Please-stop-using-slack.html">Slack</a> you should pick an alternative here.</strong>
 </div>
 
-{% include cardv2.html
-title="Rocket.chat"
-image="/assets/img/tools/rocket.chat.png"
-description="Rocket.chat is an self-hostable open source platform for team communication. It has optional federation and experimental E2EE."
-labels="warning:<a href=//rocket.chat/docs/user-guides/end-to-end-encryption/>Experimental</a>:Regarding E2EE their documentation states 'This feature is currently in alpha. It's also not yet supported on mobile'. There is no forward secrecy so compromised decryption password would leak all messages. The federation was also added afterwards potentially causing room for mistakes."
-website="https://rocket.chat/"
-forum="https://forum.privacytools.io/t/discussion-rocket-chat/1223"
-github="https://github.com/rocketchat/"
-android=""
-ios=""
-mac=""
-windows=""
-linux=""
+{%
+  include cardv2.html
+  title="Rocket.chat"
+  image="/assets/img/tools/rocket.chat.png"
+  description="Rocket.chat is an self-hostable open source platform for team communication. It has optional federation and experimental E2EE."
+  labels="warning:<a href=//rocket.chat/docs/user-guides/end-to-end-encryption/>Experimental</a>:Regarding E2EE their documentation states 'This feature is currently in alpha. It's also not yet supported on mobile'. There is no forward secrecy so compromised decryption password would leak all messages. The federation was also added afterwards potentially causing room for mistakes."
+  website="https://rocket.chat/"
+  forum="https://forum.privacytools.io/t/discussion-rocket-chat/1223"
+  github="https://github.com/rocketchat/"
+  android=""
+  ios=""
+  mac=""
+  windows=""
+  linux=""
 %}
 
-{% include cardv2.html
-title="Keybase"
-image="/assets/img/tools/keybase.png"
-description='Keybase provides a hosted team chat with end-to-end encryption. It has also been <a href="https://keybase.io/docs-assets/blog/NCC_Group_Keybase_KB2018_Public_Report_2019-02-27_v1.3.pdf">indepedently audited (PDF)</a>.'
-labels="warning:<a href=//github.com/keybase/client/issues/6374>Warning</a>:The server side of Keybase runs on proprietary code and is centralized."
-website="https://keybase.io/"
-forum="https://forum.privacytools.io/t/discussion-keybase/1224"
-github="https://github.com/Keybase"
-android=""
-ios=""
-mac=""
-windows=""
-linux=""
-web=""
+{%
+  include cardv2.html
+  title="Keybase"
+  image="/assets/img/tools/keybase.png"
+  description='Keybase provides a hosted team chat with end-to-end encryption. It has also been <a href="https://keybase.io/docs-assets/blog/NCC_Group_Keybase_KB2018_Public_Report_2019-02-27_v1.3.pdf">indepedently audited (PDF)</a>.'
+  labels="warning:<a href=//github.com/keybase/client/issues/6374>Warning</a>:The server side of Keybase runs on proprietary code and is centralized."
+  website="https://keybase.io/"
+  forum="https://forum.privacytools.io/t/discussion-keybase/1224"
+  tor="http://keybase5wmilwokqirssclfnsqrjdsi7jdir5wy7y7iu3tanwmtp6oid.onion/"
+  github="https://github.com/Keybase"
+  android=""
+  ios=""
+  mac=""
+  windows=""
+  linux=""
+  web=""
 %}
 
 


### PR DESCRIPTION
<!-- PLEASE READ OUR CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Adds link to [Keybase's onion service](https://keybase.io/docs/command_line/tor): http://keybase5wmilwokqirssclfnsqrjdsi7jdir5wy7y7iu3tanwmtp6oid.onion/

Resolves: #none <!-- The number of the issue that is resolved by this pull request. If there is none, feel free to delete this line -->

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [ ] This project has an [associated discussion](https://github.com/privacytoolsIO/privacytools.io/issues).

* Netlify preview for the mainly edited page:
https://deploy-preview-1255--privacytools-io.netlify.com/software/real-time-communication/#teamchat