### PR TITLE
Don't wrap text for jurisdiction column in Email Providers table

### DIFF
--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -30,7 +30,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://disroot.org" href="https://disroot.org"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="2015">2015</td>
-        <td><span class="flag-icon flag-icon-nl"></span> Netherlands</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-nl"></span> Netherlands
+          </span>
+        </td>
         <td data-value="1000">1 GB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
@@ -46,7 +50,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://kolabnow.com" href="https://kolabnow.com"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="2010">2010</td>
-        <td><span class="flag-icon flag-icon-ch"></span> Switzerland</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-ch"></span> Switzerland
+          </span>
+        </td>
         <td data-value="2048">2 GB</td>
         <td data-value="6000">$ 60</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
@@ -63,7 +71,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://mailbox.org" href="https://mailbox.org"><img alt="WWW" src="/assets/img/layout/www.png" width="35 "height="35"></a>
         </td>
         <td data-value="2014">2014</td>
-        <td><span class="flag-icon flag-icon-de"></span> Germany</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-de"></span> Germany
+          </span>
+        </td>
         <td data-value="2000">2 GB</td>
         <td data-value="1444">12 €</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
@@ -79,7 +91,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://mailfence.com" href="https://mailfence.com"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="2013">2013</td>
-        <td><span class="flag-icon flag-icon-be"></span> Belgium</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-be"></span> Belgium
+          </span>
+        </td>
         <td data-value="500">500 MB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
@@ -95,7 +111,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.neomailbox.com" href="https://www.neomailbox.com"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="2003">2003</td>
-        <td><span class="flag-icon flag-icon-ch"></span> Switzerland</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-ch"></span> Switzerland
+          </span>
+        </td>
         <td data-value="1000">1 GB</td>
         <td data-value="4995">$ 49.95</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
@@ -111,7 +131,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://posteo.de" href="https://posteo.de"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="2009">2009</td>
-        <td><span class="flag-icon flag-icon-de"></span> Germany</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-de"></span> Germany
+          </span>
+        </td>
         <td data-value="2000">2 GB</td>
         <td data-value="1444">12 €</td>
         <td data-value="0"><span class="label label-primary">No</span></td>
@@ -128,7 +152,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://protonirockerxow.onion. Requires specific software to access: torproject.org" href="https://protonirockerxow.onion"><img alt="Tor" src="/assets/img/layout/tor.png" width="35"></a>
         </td>
         <td data-value="2013">2013</td>
-        <td><span class="flag-icon flag-icon-ch"></span> Switzerland</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-ch"></span> Switzerland
+          </span>
+        </td>
         <td data-value="500">500 MB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
@@ -145,7 +173,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://runbox.com" href="https://runbox.com"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="1999">1999</td>
-        <td><span class="flag-icon flag-icon-no"></span> Norway</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-no"></span> Norway
+          </span>
+        </td>
         <td data-value="1000">1 GB</td>
         <td data-value="1995">$ 19.95</td>
         <td data-value="1"><span class="label label-primary">Accepted</span></td>
@@ -161,7 +193,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://soverin.net/" href="https://soverin.net/"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="2015">2015</td>
-        <td><span class="flag-icon flag-icon-nl"></span> Netherlands</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-nl"></span> Netherlands
+          </span>
+        </td>
         <td data-value="25000">25 GB</td>
         <td data-value="3489">29 €</td>
         <td data-value="0"><span class="label label-success">No</span></td>
@@ -177,7 +213,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.startmail.com" href="https://www.startmail.com"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="2014">2014</td>
-        <td><span class="flag-icon flag-icon-nl"></span> Netherlands</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-nl"></span> Netherlands
+          </span>
+        </td>
         <td data-value="10000">10 GB</td>
         <td data-value="5995">$ 59.95</td>
         <td data-value="0"><span class="label label-success">Accepted</span></td>
@@ -193,7 +233,11 @@
           <a data-toggle="tooltip" data-placement="bottom" data-original-title="https://www.tutanota.com" href="https://www.tutanota.com"><img alt="WWW" src="/assets/img/layout/www.png" width="35" height="35"></a>
         </td>
         <td data-value="2011">2011</td>
-        <td><span class="flag-icon flag-icon-de"></span> Germany</td>
+        <td>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-de"></span> Germany
+          </span>
+        </td>
         <td data-value="1000">1 GB</td>
         <td data-value="0"><span class="label label-warning">Free</span></td>
         <td data-value="0"><span class="label label-primary">No</span></td>


### PR DESCRIPTION
<!-- PLEASE READ OUR CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Like the DNS table, this keeps flags with country names on the same line for readability.

Resolves: #none <!-- The number of the issue that is resolved by this pull request. If there is none, feel free to delete this line -->

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [ ] This project has an [associated discussion](https://github.com/privacytoolsIO/privacytools.io/issues).

* Netlify preview for the mainly edited page: https://deploy-preview-1260--privacytools-io.netlify.com/providers/email/#email
