### PR TITLE
operating-systems: include the supersets instead of just mds

### DIFF
--- a/_includes/sections/operating-systems.html
+++ b/_includes/sections/operating-systems.html
@@ -53,16 +53,17 @@ tor="http://sejnfjrq6szgca7v.onion"
 
 <ol>
   <li><code>sudo mkdir /etc/default/grub.d/</code> to create a directory for additional grub configuration</li>
-  <li><code>echo GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT mds=full,nosmt" | sudo tee /etc/default/grub.d/mds.conf</code> to create a new grub config file source with the echoed content</li>
-  <li><code>sudo grub-mkconfig -o /boot/grub/grub.cfg</code> to generate a new grub config file including this new kernel boot flag</li>
+  <li><code>echo GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT l1tf=full,force mds=full,nosmt mitigations=auto,nosmt nosmt=force" | sudo tee /etc/default/grub.d/mitigations.cfg</code> to create a new grub config file source with the echoed content</li>
+  <li><code>sudo grub-mkconfig -o /boot/grub/grub.cfg</code> to generate a new grub config file including these new kernel boot flags</li>
   <li><code>sudo reboot</code> to reboot</li>
-  <li>after the reboot, check <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code> again to see that MDS now says "SMT disabled."</li>
+  <li>after the reboot, check <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code> again to see that everything referring to SMT now says "SMT disabled."</li>
 </ol>
 
 <h5>Further reading</h5>
 
 <ul>
   <li><a href="https://cpu.fail/">CPU.fail</a></li>
+  <li><a href="https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/">Hardware vulnerabilities index on The Linux kernel user's and administrator's guide</a></li>
   <li><a href="https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html">MDS - Microarchitectural Data Sampling on The Linux kernel user's and administrator's guide</a></li>
   <li><a href="https://mdsattacks.com/">RIDL and Fallout: MDS attacks on mdsattacks.com</a></li>
   <li><a href="https://en.wikipedia.org/wiki/Simultaneous_multithreading">Simultaneous multithreading on Wikipedia</a></li>


### PR DESCRIPTION
TL;DR: This changes `mds=full,nosmt` to its superset `mitigations=auto,nosmt` which includes all CPU mitigation support of Linux kernel. I understand that `nosmt=force` means that the root user cannot restore SMT after boot by running a sysctl command to adjust kernel configuration runtime. While I am unsure whether it's really needed in our scope, I would say better safe than sorry.

To quote the kernel doc https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html

        mitigations=
                        [X86,PPC,S390,ARM64] Control optional mitigations for
                        CPU vulnerabilities.  This is a set of curated,
                        arch-independent options, each of which is an
                        aggregation of existing arch-specific options.

                        off
                                Disable all optional CPU mitigations.  This
                                improves system performance, but it may also
                                expose users to several CPU vulnerabilities.
                                Equivalent to: nopti [X86,PPC]
                                               kpti=0 [ARM64]
                                               nospectre_v1 [X86,PPC]
                                               nobp=0 [S390]
                                               nospectre_v2 [X86,PPC,S390,ARM64]
                                               spectre_v2_user=off [X86]
                                               spec_store_bypass_disable=off [X86,PPC]
                                               ssbd=force-off [ARM64]
                                               l1tf=off [X86]
                                               mds=off [X86]

                        auto (default)
                                Mitigate all CPU vulnerabilities, but leave SMT
                                enabled, even if it's vulnerable.  This is for
                                users who don't want to be surprised by SMT
                                getting disabled across kernel upgrades, or who
                                have other ways of avoiding SMT-based attacks.
                                Equivalent to: (default behavior)

                        auto,nosmt
                                Mitigate all CPU vulnerabilities, disabling SMT
                                if needed.  This is for users who always want to
                                be fully mitigated, even if it means losing SMT.
                                Equivalent to: l1tf=flush,nosmt [X86]
                                               mds=full,nosmt [X86]

...

        nosmt           [KNL,S390] Disable symmetric multithreading (SMT).
                        Equivalent to smt=1.

                        [KNL,x86] Disable symmetric multithreading (SMT).
                        nosmt=force: Force disable SMT, cannot be undone
                                     via the sysfs control file.

* * * * *

Mainly edited page: https://deploy-preview-1269--privacytools-io.netlify.com/operating-systems/#cpuvulns

Resolves: #1272