### PR TITLE
Delist OpenNIC & NameCoin

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -2,16 +2,6 @@
 
 {%
   include cardv2.html
-  title="OpenNIC - Service"
-  image="/assets/img/tools/OpenNIC.png"
-  description="OpenNIC is an alternate network information center/alternative DNS root which lists itself as an alternative to ICANN and its registries. Like all alternative root DNS systems, OpenNIC-hosted domains are unreachable to the vast majority of the Internet."
-  website="https://www.opennic.org/"
-  forum="https://forum.privacytools.io/t/discussion-opennic/338"
-  github="https://github.com/OpenNIC"
-%}
-
-{%
-  include cardv2.html
   title="Njalla - Domain Registration"
   image="/assets/img/provider/Njalla.png"
   description="Njalla only needs your email or XMPP address in order to register a domain name for you. Created by people from The Pirate Bay and IPredator VPN. Accepted Payments: Bitcoin, Litecoin, Monero, DASH, Bitcoin Cash and PayPal. A privacy-aware domain registration service."
@@ -563,7 +553,6 @@
   </li>
   <li><strong>Local DNS servers:</strong>
     <ul>
-      <li><em><a href="https://namecoin.info/">Namecoin</a></em> - A decentralized DNS open-source information registration and transfer system based on the Bitcoin cryptocurrency.</li>
       <li><em><a href="https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby">Stubby</a></em> - An open-source application for Linux, macOS, and Windows that acts as a local DNS Privacy stub resolver using DoT.</li>
       <li><em><a href="https://nlnetlabs.nl/projects/unbound/about/">Unbound</a></em> - a validating, recursive, caching DNS resolver. It can also be ran network-wide and has supported DNS-over-TLS since version 1.7.3.</li>
       <ul>

--- a/source_code.md
+++ b/source_code.md
@@ -275,8 +275,6 @@ Raddle: https://gitlab.com/postmill
 
 ## Domain Name System (DNS)
 
-OpenNic: https://github.com/opennic/
-
 Njalla: Non-free/Proprietary Software
 
 DNSCrypt-Proxy: https://github.com/jedisct1/dnscrypt-proxy/
@@ -308,8 +306,6 @@ PowerDNS: https://github.com/PowerDNS/pdns
 - Nebulo: https://git.frostnerd.com/PublicAndroidApps/smokescreen/
 
 #### Local DNS servers
-
-- Namecoin: https://github.com/namecoin
 
 - Stubby: https://github.com/getdnsapi/stubby
 


### PR DESCRIPTION
## Description

Resolves: #1258 

While OpenNIC and Namecoin allow private domain registration, I am let to understand that they cannot get SSL certificates, that are globally recognised as valid, due to their nature as an alternative to ICANN managed DNS.

If I am correct, this results to them either not having https/TLS at all or teaching users to blindly accept any SSL certificates, either announcing in plaintext to any network listener (or Tor exit node) what they are doing or leaving them vulnarable to MITM attackers. Thus I don't consider them as private.

See also:

* https://github.com/privacytoolsIO/privacytools.io/issues/1258#issuecomment-528486198
* https://github.com/opennic/opennic-web/issues/68

#### Check List

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] I have [delisted the source code](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md).

- [x] This project has an [associated discussion](https://github.com/privacytoolsIO/privacytools.io/issues).

* Netlify preview for the mainly edited page: https://deploy-preview-1273--privacytools-io.netlify.com/providers/dns/
