### PR TITLE
privacy-resources: delist Keybase, list Open Wireless Movement

### DIFF
--- a/_includes/sections/privacy-resources.html
+++ b/_includes/sections/privacy-resources.html
@@ -16,7 +16,7 @@
 <ul>
   <li><a href="https://freedom.press/"><strong>Freedom of the Press Foundation</strong></a> - Supporting and defending journalism dedicated to transparency and accountability since 2012.</li>
   <li><a href="https://www.erfahrungen.com/mit/anonymisierung/t/"><strong>Erfahrungen.com</strong></a> - German review aggregator website of privacy-related services.</li>
-  <li><a href="https://keybase.io/"><strong>Keybase.io</strong></a> - Get a public key, safely, starting just with someone's social media username.</li>
+  <li><a href="https://openwireless.org/"><strong>Open Wireless Movement</strong></a> - a coalition of Internet freedom advocates, companies, organizations, and technologists working to develop new wireless technologies and to inspire a movement of Internet openness.</li>
   <li><a href="https://privacy.net/us-government-surveillance-spying-data"><strong>privacy.net</strong></a> - What does the US government know about you?</li>
   <li><a href="https://www.reddit.com/r/privacytoolsIO/wiki/index"><strong>r/privacytoolsIO Wiki</strong></a> - Our Wiki on reddit.com.</li>
   <li><a href="https://www.grc.com/securitynow.htm"><strong>Security Now!</strong></a> - Weekly Internet Security Podcast by Steve Gibson and Leo Laporte.</li>


### PR DESCRIPTION
## Description

* openwireless.org, see also: https://github.com/privacytoolsIO/privacytools.io/issues/1184
* Keybase: we list it on other sections and the description is a bit unhelpful.

>  <li><a href="https://keybase.io/"><strong>Keybase.io</strong></a> - Get a public key, safely, starting just with someone's social media username.</li>

While there is a "search Keybase on top", I think this description should either be removed or changed a lot as Keybase's homepage doesn't advertise this capability and instead advertises itself as kind of a team chat and file sync.

* https://deploy-preview-1279--privacytools-io.netlify.com/#resources