### PR TITLE
gitignore .jekyll-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site/
 .sass-cache/
+.jekyll-metadata
 .DS_Store


### PR DESCRIPTION
It's generated by Jekyll on my machine with `bundle exec jekyll serve --livereload --incremental`