### PR TITLE
Add a warning to Cryptomator entry in file encryption recommendations

### DIFF
--- a/_includes/sections/file-encryption.html
+++ b/_includes/sections/file-encryption.html
@@ -46,7 +46,7 @@
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.</li>
+  <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration. <b>- WARNING: Cryptomator's Android app is not fully open source -</b></li>
   <li><a href="https://diskcryptor.net/">DiskCryptor</a> - A full disk and partition encryption system for Windows including the ability to encrypt the partition and disk on which the OS is installed.</li>
   <li><a href="https://gitlab.com/cryptsetup/cryptsetup/">Linux Unified Key Setup (LUKS)</a> - A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.</li>
   <li><a href="https://hat.sh/">Hat.sh</a> - A cross-platform, serverless JavaScript web application that provides secure file encryption using the AES-256-GCM algorithm in your browser. It can also be downloaded and run offline.</a></li>


### PR DESCRIPTION
Cryptomator android app is not open source. See https://github.com/cryptomator/cryptomator-android
I suggest adding a clear and concise warning explaining that their Android app is not open source.

<!-- PLEASE READ OUR CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #none <!-- The number of the issue that is resolved by this pull request. If there is none, feel free to delete this line -->

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] I have [listed the source code](https://github.com/privacytoolsIO/privacytools.io/blob/master/source_code.md).

- [x] This project is [free/libre software](https://www.wikipedia.org/wiki/Free_software).

- [ ] This project has an [associated discussion](https://github.com/privacytoolsIO/privacytools.io/issues).

* Netlify preview for the mainly edited page: <!-- link or Non Applicable? Edit this in afterwards -->

* Code Repository (if applicable): 
