### PR TITLE
browser-addons: put Privacy Badger on bottom

### DIFF
--- a/_includes/sections/browser-addons.html
+++ b/_includes/sections/browser-addons.html
@@ -5,17 +5,6 @@
 </div>
 
 
-{% include cardv2.html
-title="Privacy Badger: Stop Tracking"
-image="/assets/img/addons/privacy-badger.png"
-description="<strong>Privacy Badger</strong> is a browser add-on that stops advertisers and other third-party trackers from secretly tracking where you go and what pages you look at on the web. Privacy Badger learns about trackers as you browse."
-website="https://www.eff.org/privacybadger"
-forum="https://forum.privacytools.io/t/discussion-privacy-badger/265"
-github="https://github.com/EFForg/privacybadger"
-firefox="https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17"
-chrome="https://chrome.google.com/webstore/detail/privacy-badger/pkehgijcmpdhfbdbbnkijodmdjhbjlgp"
-opera="https://addons.opera.com/en/extensions/details/privacy-badger/"
-%}
 
 {% include cardv2.html
 title="uBlock Origin: Block Ads and Trackers"
@@ -90,6 +79,17 @@ firefox="https://addons.mozilla.org/en-US/firefox/addon/torproject-snowflake"
 chrome="https://chrome.google.com/webstore/detail/snowflake/mafpmfcccpbjnhfhjnllmmalhifmlcie"
 %}
 
+{% include cardv2.html
+title="Privacy Badger: Stop Tracking"
+image="/assets/img/addons/privacy-badger.png"
+description="<strong>Privacy Badger</strong> is a browser add-on that stops advertisers and other third-party trackers from secretly tracking where you go and what pages you look at on the web. Privacy Badger learns about trackers as you browse."
+website="https://www.eff.org/privacybadger"
+forum="https://forum.privacytools.io/t/discussion-privacy-badger/265"
+github="https://github.com/EFForg/privacybadger"
+firefox="https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17"
+chrome="https://chrome.google.com/webstore/detail/privacy-badger/pkehgijcmpdhfbdbbnkijodmdjhbjlgp"
+opera="https://addons.opera.com/en/extensions/details/privacy-badger/"
+%}
 
 <h2>For Power Users Only</h2>
 


### PR DESCRIPTION
## Description

Resolves: #1301 where moving Privacy Badger on the bottom was given as a requirement for keeping it.

* Netlify preview for the mainly edited page: https://deploy-preview-1306--privacytools-io.netlify.com/browsers/#addons

