### PR TITLE
Remove "Contact" from navbar

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -142,7 +142,6 @@
         </details>
 
         <a href="https://blog.privacytools.io/" class="nav-anchor">Blog </a>
-        <a href="/contact" class="nav-anchor">Contact </a>
         <a href="/donate/" class="nav-anchor">
           Donate <span class="fas fa-heart text-danger fa-fw"></span>
         </a>


### PR DESCRIPTION
I don't see any other solution to this (no, changing paddings is not the solution).

![image](https://user-images.githubusercontent.com/38681822/64923029-743a0780-d7c5-11e9-8935-514447b537f5.png)