### PR TITLE
Add DoH to NixNet

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -343,7 +343,7 @@
           </a>
         </td>
         <td>No</td>
-        <td>DoT</td>
+        <td>DoH, DoT</td>
         <td>Yes</td>
         <td>Yes</td>
         <td>


### PR DESCRIPTION
Updated the Nixnet protocol field by adding "DoH" as it also offers DNS over HTTPS.

## Description

* Netlify preview for the mainly edited page: <!-- link or Non Applicable? Edit this in afterwards --> https://deploy-preview-1321--privacytools-io.netlify.com/providers/dns/
