### PR TITLE
Remove kopimi from the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -51,20 +51,16 @@
   <hr class="footer-divider" />
 
   <div class="row mt-3">
-    <div class="col-md-3 col-sm-6 mb-3 d-flex justify-content-center d-flex justify-content-center">
+    <div class="col-sm-4 mb-3 d-flex justify-content-center d-flex justify-content-center">
       <a href="/LICENSE.txt" data-toggle="tooltip" data-placement="top" data-original-title="This work is free. You can redistribute it and/or modify it under the terms of the &quot;Creative Commons CC0 1.0 Universal Public Domain Dedication&quot;."><img alt="CC0" src="/assets/img/layout/zero.png" width="32" height="32">CC0</a>
     </div>
 
-    <div class="col-md-3 col-sm-6 mb-3 d-flex justify-content-center">
-      <a href="https://www.kopimi.com/" data-toggle="tooltip" data-placement="top" data-original-title="kopimi (copyme), symbol showing that you want to be copied. use kopimi in your own fancy. kopimi may be put on homepages or blogs, in books, in software, as sound logos in music or whatever."><img alt="kopimi" src="/assets/img/layout/kopimi.png" width="32" height="33">kopimi</a>
-    </div>
-
-    <div class="col-md-3 col-sm-6 mb-3 d-flex justify-content-center">
+    <div class="col-sm-4 mb-3 d-flex justify-content-center">
       <i class="far fa-envelope fa-2x"></i>
       <a href="/contact/">Contact</a>
     </div>
 
-    <div class="col-md-3 col-sm-6 mb-3 d-flex justify-content-center">
+    <div class="col-sm-4 mb-3 d-flex justify-content-center">
       <i class="fas fa-heart fa-2x text-danger"></i>
       <a data-toggle="tooltip" data-placement="top" data-original-title="Please support this project by donating. We are ad free and not affiliated with any providers. Your donation will cover our cost for server and domain." href="/donate/">Donate</a>
     </div>


### PR DESCRIPTION
It is being removed because https://kopimi.com blocks all Tor traffic.

![screenshot](https://user-images.githubusercontent.com/38681822/65036020-0236ff00-d93a-11e9-84cf-1af6f2addacd.png)