### PR TITLE
teamchat: link to ToSDR instead of web.archive.org

### DIFF
--- a/_includes/sections/teamchat.html
+++ b/_includes/sections/teamchat.html
@@ -1,7 +1,7 @@
 <h1 id="teamchat" class="anchor"><a href="#teamchat"><i class="fas fa-link anchor-icon"></i></a> Team Chat Platforms</h1>
 
 <div class="alert alert-warning" role="alert">
-        <strong>If your project or organization currently uses a platform like <a href="https://web.archive.org/web/20171029114027/https://feedback.discordapp.com/forums/326712-discord-dream-land/suggestions/17094256-implement-whispersystems-encryption-for-voice-and">Discord</a> or <a href="https://drewdevault.com/2015/11/01/Please-stop-using-slack.html">Slack</a> you should pick an alternative here.</strong>
+        <strong>If your project or organization currently uses a platform like <a href="https://tosdr.org/#discord">Discord</a> or <a href="https://drewdevault.com/2015/11/01/Please-stop-using-slack.html">Slack</a> you should pick an alternative here.</strong>
 </div>
 
 {%


### PR DESCRIPTION
I am just wondering if it's a better link than an web.archive.org link to a closed feature request for a single privacy feature where they say to not have any plans for it, while there are more things wrong with them.