### PR TITLE
Remove addon links which don't work with up-to-date Safari

### DIFF
--- a/_includes/sections/browser-addons.html
+++ b/_includes/sections/browser-addons.html
@@ -4,8 +4,6 @@
   <strong>Improve your privacy with these browser add-ons.</strong>
 </div>
 
-
-
 {% include cardv2.html
 title="uBlock Origin: Block Ads and Trackers"
 image="/assets/img/addons/ublock-origin.png"
@@ -15,7 +13,6 @@ forum="https://forum.privacytools.io/t/discussion-ublock-origin/266"
 github="https://github.com/gorhill/uBlock/"
 firefox="https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/"
 chrome="https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm"
-safari="https://safari-extensions.apple.com/details/?id=com.el1t.uBlock-3NU33NW2M3"
 opera="https://addons.opera.com/en/extensions/details/ublock/"
 edge="https://www.microsoft.com/en-us/p/ublock-origin/9nblggh444l4"
 %}
@@ -65,7 +62,6 @@ github="https://github.com/tosdr/"
 firefox="https://addons.mozilla.org/en-US/firefox/addon/terms-of-service-didnt-read/"
 chrome="https://chrome.google.com/webstore/detail/terms-of-service-didn%E2%80%99t-r/hjdoplcnndgiblooccencgcggcoihigg"
 opera="https://addons.opera.com/en/extensions/details/terms-of-service-didnt-read"
-safari="https://safariextension.tosdr.org/"
 %}
 
 {% include cardv2.html


### PR DESCRIPTION
NOTE: I don't have any personal macOS device.

Since Catalina, addons have to be written in Swift and use new API. Legacy
addons, don't work anymore and new API is much more limited in terms of
content blocking. https://github.com/el1t/uBlock-Safari/issues/158

TOS;DR is written in JavaScript and last commit was on 2013, so yeah.

https://deploy-preview-1347--privacytools-io.netlify.com/browsers/#addons