### PR TITLE
Remove password.html, it's not needed anymore

### DIFF
--- a/password.html
+++ b/password.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=index.html#pw" />


### PR DESCRIPTION
It was redirecting to `index.html#pw`, but we don't have that id in new
layout, it only exists in ` /classic/`, but such redirect to `/classic/#pw`
doesn't make any sense and was broken for some time, so clearly nobody
cares.
