### PR TITLE
Replace bash with sh in build.sh for compatibility

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e # halt script on error
 
 bundle exec jekyll build


### PR DESCRIPTION
Systems like OpenBSD, FreeBSD, NetBSD or macOS (might be removed soon
https://support.apple.com/en-us/HT208050) don't have bash installed.

This script should run perfectly fine with POSIX `sh`.