### PR TITLE
DNS: BlahDNS has unblocked UTF-8 domains

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -134,7 +134,7 @@
           </span>
           <span class="no-text-wrap">
             malicious domains
-            <span class="badge badge-warning" data-toggle="tooltip" data-original-title="And some wildcard, IDN, and non-ASCII domains."><a href="https://github.com/ookangzheng/blahdns#default-blocked-wildcard-domain"><i class="fas fa-exclamation-triangle"></i></a></span>
+            <span class="badge badge-warning" data-toggle="tooltip" data-original-title="And some wildcard and IDN domains."><a href="https://github.com/ookangzheng/blahdns#default-blocked-wildcard-domain"><i class="fas fa-exclamation-triangle"></i></a></span>
           </span>
         </td>
         <td>


### PR DESCRIPTION
Ref: ookangzheng/blahdns#66

https://deploy-preview-1396--privacytools-io.netlify.com/providers/dns/#icanndns