### PR TITLE
privacytools.io sponsorships

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -61,8 +61,8 @@
     </div>
 
     <div class="col-sm-4 mb-3 d-flex justify-content-center">
-      <i class="fas fa-heart fa-2x text-danger"></i>
-      <a data-toggle="tooltip" data-placement="top" data-original-title="Please support this project by donating. We are ad free and not affiliated with any providers. Your donation will cover our cost for server and domain." href="/donate/">Donate</a>
+      <i class="fas fa-donate fa-2x"></i>
+      <a data-toggle="tooltip" data-placement="top" data-original-title="Please support this project by donating. We are ad free and not affiliated with any providers. Your donation will cover our cost for server and domain." href="https://opencollective.com/privacytoolsio#section-contribute">Support Us!</a>
     </div>
   </div>
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -142,8 +142,8 @@
         </details>
 
         <a href="https://blog.privacytools.io/" class="nav-anchor">Blog </a>
-        <a href="/donate/" class="nav-anchor">
-          Donate <span class="fas fa-heart text-danger fa-fw"></span>
+        <a href="/sponsors/" class="nav-anchor">
+          Sponsors
         </a>
         <span id="nav-switch-theme" class="nav-anchor">
           Theme <span class="nav-theme-icon fas fa-fw"></span>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@ layout: default
 <script src="/assets/js/redirects.js"></script>
 {% include sections/header.html %}
 {% include sections/resources.html %}
+<h1 id="sponsors" class="anchor"><a href="#sponsors"><i class="fas fa-link anchor-icon"></i></a> Sponsors</h1>
+
+<div class="alert alert-success" role="alert">
+  <strong>New!</strong> We have a great new opportunity for you or your organization to support the spread of privacy-related education online! <a href="/sponsors/" class="alert-link">Learn more...</a>
+</div>
 {% include sections/quotes.html %}
 {% include sections/privacy-resources.html %}
 {% include sections/participate.html %}

--- a/pages/sponsors.html
+++ b/pages/sponsors.html
@@ -36,7 +36,6 @@ permalink: /sponsors/
   <h5>🥇 Gold Sponsorship</h5>
   <ul>
   <li>Your medium-sized logo as a link on the privacytools.io homepage and at the very top of our sponsors page.</li>
-  <li>Your medium-sized logo included in our GitHub</li>
   </ul>
   <h5>We will not provide...</h5>
   <p>We pride ourselves on our integrity and commitment to spreading unbiased and fact-based information regarding privacy and privacy-respecting tools. All tools we recommend throughout our website are subject to strict criteria as judged by our team and the community across our various platforms. Your sponsorship will not grant your organization any special consideration when choosing our recommendations throughout the website, a process which we make clear via our transparent ledger on OpenCollective and our public discussions on GitHub. Your sponsorship benefits are limited to those outlined above.</p>

--- a/pages/sponsors.html
+++ b/pages/sponsors.html
@@ -24,10 +24,10 @@ permalink: /sponsors/
   <p>With this exposure and sponsorship, your customers will recognize your intrinsic understanding and commitment to user privacy. Moreover, you'll directly contribute to our mission of spreading privacy-respecting tools and knowledge worldwide!</p>
   <p>As a sponsor of privacytools.io, your company will be widely recognized in a variety of ways, some of which we've detailed below.</p>
   <h5>General Information</h5>
-  <p>This website receives well over 250,000 pageviews on a monthly basis and is highly ranked for privacy-related keywords. In addition to the benefits below your sponsorship will be featured on our OpenCollective page and we will thank you via social media for your contribution.</p>
+  <p>This website receives well over 250,000 pageviews on a monthly basis and is highly ranked for privacy-related keywords. In addition to the benefits below your contribution will be featured on our OpenCollective page and we will thank you via social media for your contribution.</p>
   <h5>🥉 Bronze Sponsorship</h5>
   <ul>
-  <li>Your name and link along with a small logo or avatar on the sponsors page of this website. The link is a nofollow link.</li>
+  <li>Your name and link along with a small logo or avatar on the sponsors page of this website.</li>
   </ul>
   <h5>🥈 Silver Sponsorship</h5>
   <ul>
@@ -41,6 +41,8 @@ permalink: /sponsors/
   <p>We pride ourselves on our integrity and commitment to spreading unbiased and fact-based information regarding privacy and privacy-respecting tools. All tools we recommend throughout our website are subject to strict criteria as judged by our team and the community across our various platforms. Your sponsorship will not grant your organization any special consideration when choosing our recommendations throughout the website, a process which we make clear via our transparent ledger on OpenCollective and our public discussions on GitHub. Your sponsorship benefits are limited to those outlined above.</p>
   <h5>Tax and Financial Information</h5>
   <p>Your contribution to privacytools.io will be handled by the Open Collective Foundation 501(c)(3). For US companies and taxpayers, this means your contribution is <strong>tax deductible</strong>. As a non-profit, your sponsorship contribution will not be used for private profit and will only be used to cover expenses incurred by the project. All of our transactions (donations and expenses) are published transparently on OpenCollective. For the benefit of our readership, anonymous contributions will not be eligible for the sponsorship opportunities outlined above.</p>
+  <h5>More Information</h5>
+  <p>If you are interested and have further questions, you are welcome to reach out to us directly at <a href="mailto:sponsors@privacytools.io">sponsors@privacytools.io</a>.</p>
   <div class="mt-5 text-center">
     <a href="https://opencollective.com/privacytoolsio#section-contribute" class="btn btn-success mb-5">Become a Sponsor</a>
   </div>

--- a/pages/sponsors.html
+++ b/pages/sponsors.html
@@ -1,0 +1,48 @@
+---
+layout: default
+active_page: sponsors
+permalink: /sponsors/
+---
+
+<div class="col-12">
+  <div class="row">
+    <div class="mx-auto text-center">
+      <div class="mt-4 mb-4">
+        <h1>Sponsors of privacytools.io</h1>
+      </div>
+      <div class="mb-4">
+        <p>The privacytools.io website and services are a community project. There is no advertising, affiliate links, or other forms of monetization.<br><strong>Your donations here directly support hosting this website and compensating contributors to this project.</strong></p>
+        <p>
+          <a href="https://opencollective.com/privacytoolsio#section-contribute" class="btn btn-success mb-5">Become a Sponsor</a>
+          <a href="/donate/" class="btn btn-outline-danger mb-5"><span class="fas fa-heart fa-fw"></span> Donate Directly</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <h3>Why sponsor privacytools.io?</h3>
+  <p>This sponsorship program is designed to allow companies, organizations, and individuals partner with the privacytools.io team to support our vision of a more privacy-respecting internet and the greater online community.</p>
+  <p>With this exposure and sponsorship, your customers will recognize your intrinsic understanding and commitment to user privacy. Moreover, you'll directly contribute to our mission of spreading privacy-respecting tools and knowledge worldwide!</p>
+  <p>As a sponsor of privacytools.io, your company will be widely recognized in a variety of ways, some of which we've detailed below.</p>
+  <h5>General Information</h5>
+  <p>This website receives well over 250,000 pageviews on a monthly basis and is highly ranked for privacy-related keywords. In addition to the benefits below your sponsorship will be featured on our OpenCollective page and we will thank you via social media for your contribution.</p>
+  <h5>🥉 Bronze Sponsorship</h5>
+  <ul>
+  <li>Your name and link along with a small logo or avatar on the sponsors page of this website. The link is a nofollow link.</li>
+  </ul>
+  <h5>🥈 Silver Sponsorship</h5>
+  <ul>
+  <li>Your medium-sized logo as a link at the top of our sponsors page.</li>
+  </ul>
+  <h5>🥇 Gold Sponsorship</h5>
+  <ul>
+  <li>Your medium-sized logo as a link on the privacytools.io homepage and at the very top of our sponsors page.</li>
+  <li>Your medium-sized logo included in our GitHub</li>
+  </ul>
+  <h5>We will not provide...</h5>
+  <p>We pride ourselves on our integrity and commitment to spreading unbiased and fact-based information regarding privacy and privacy-respecting tools. All tools we recommend throughout our website are subject to strict criteria as judged by our team and the community across our various platforms. Your sponsorship will not grant your organization any special consideration when choosing our recommendations throughout the website, a process which we make clear via our transparent ledger on OpenCollective and our public discussions on GitHub. Your sponsorship benefits are limited to those outlined above.</p>
+  <h5>Tax and Financial Information</h5>
+  <p>Your contribution to privacytools.io will be handled by the Open Collective Foundation 501(c)(3). For US companies and taxpayers, this means your contribution is <strong>tax deductible</strong>. As a non-profit, your sponsorship contribution will not be used for private profit and will only be used to cover expenses incurred by the project. All of our transactions (donations and expenses) are published transparently on OpenCollective. For the benefit of our readership, anonymous contributions will not be eligible for the sponsorship opportunities outlined above.</p>
+  <div class="mt-5 text-center">
+    <a href="https://opencollective.com/privacytoolsio#section-contribute" class="btn btn-success mb-5">Become a Sponsor</a>
+  </div>
+</div>


### PR DESCRIPTION
## The Program

This sponsorship program is designed to allow companies, organizations, and individuals partner with the privacytools.io team to support our vision of a more privacy-respecting internet and the greater online community.

In exchange for financial support, we will provide companies with the exposure and recognition that they are supporting privacy education online. We will do so by displaying their logo and link on various portions of privacytools.io as described on the sponsors page in this PR.

### Proposed Plans & Pricing

Context: The privacytools.io website receives well in excess of 250,000 pageviews monthly and is ranked highly for privacy-related searches.

#### Bronze: $250/month

- Your name and link along with a small logo or avatar on the sponsors page of this website.

#### Silver: $500/month

- Your medium-sized logo as a link at the top of our sponsors page.

#### Gold: $1000/month

- Your medium-sized logo as a link on the privacytools.io homepage and at the very top of our sponsors page.

## Website Recommendations

The sponsorship program will not impact any recommendations on the website. This will be ensured in a few ways.

1. Changes to recommendations on the site will be made by @privacytoolsIO/editorial only, a team within this organization that operates on a purely volunteer basis and will not receive direct compensation from any of the sponsoring companies.
2. All financial transactions will be transparently published at https://opencollective.com/privacytoolsio to be verified by the community to ensure no community member is receiving financial compensation for their recommendation.
3. All discussions regarding the recommendation or removal of a certain product will take place on GitHub and changes will require the authorization of two @privacytoolsIO/editorial team members. This team notably does not include myself (the primary beneficiary of most funding on this website, which is put towards server operation costs).
4. Sponsorships are not tied directly to recommendations through affiliate links. We will not receive compensation per user we refer to a service nor provide sponsors with information regarding how many people we recommend their service to, if their product is already recommended on the site.

## Financial Information

These sponsorships, like all contributions to privacytools.io, would be facilitated by the Open Collective Foundation, a registered 501(c)(3) charity. This means that all sponsorship spots would *also* be tax-deductible by US taxpayers.

This also means that we are legally not allowed to privately profit from any contributions given to us by our sponsors. The sole purpose of any funding we receive would go towards expenses that benefit our mission (to spread privacy education within our community and worldwide via outreach programs, and to host privacy-friendly services for our community and to serve as an example for self-hosters).

## Clarity

I want to be clear that sponsorships are not advertisements. Sponsors will not receive tracking information and should not compare this program to an advertising or referral channel. This program allows organizations to support our mission while linking their brand as a supporter of the cause.

I would also like to restate that the actual listings on this website will be reviewed solely by a team of editors on a volunteer basis, who will not be paid by sponsors to adjust the recommendations. Because our expenses and contributions are tracked in public on OpenCollective, this can be verified by the community.

## PR Information

**Netlify link:** https://deploy-preview-1451--privacytools-io.netlify.com/sponsors/

**Changes:** In addition to the /sponsors/ page, the donate link in the navbar has been replaced with the Sponsors page, and the donate link in the footer now links directly to OpenCollective. Crypto donations are still available at /donate/ and are also accessible via a donate link on the new /sponsors/ page.

Related: #899, #966. Closes #1452.