### PR TITLE
Convert self-contained networks to cardv2

### DIFF
--- a/_includes/sections/self-contained-networks.html
+++ b/_includes/sections/self-contained-networks.html
@@ -6,33 +6,33 @@
 
 <div class="row mb-2">
 
-  {% include card.html color="success"
-  title="Tor"
-  image="/assets/img/tools/Tor-Project.png"
-  url="https://www.torproject.org/"
-  tor="http://expyuzz4wqqyqhjn.onion"
-  footer='OS: Windows, macOS, Linux, <a href="https://mike.tig.as/onionbrowser/">iOS</a>, Android (<a href="https://www.torproject.org/download/#android">Tor Browser</a>, <a href="https://guardianproject.info/apps/orbot/">Proxy other apps with Orbot</a>), <a href="https://github.com/torbsd/openbsd-ports">OpenBSD.</a>'
-  description="The Tor network is a group of volunteer-operated servers that allows people to improve their privacy and security on the Internet. Tor's users employ this network by connecting through a series of virtual tunnels rather than making a direct connection, thus allowing both organizations and individuals to share information over public networks without compromising their privacy. Tor is an effective censorship circumvention tool."
-  %}
+{% include cardv2.html
+title="Tor"
+image="/assets/img/tools/Tor-Project.png"
+description="The Tor network is a group of volunteer-operated servers that allows people to improve their privacy and security on the Internet. Tor's users employ this network by connecting through a series of virtual tunnels rather than making a direct connection, thus allowing both organizations and individuals to share information over public networks without compromising their privacy. Tor is an effective censorship circumvention tool."
+website="https://www.torproject.org/"
+tor="http://expyuzz4wqqyqhjn.onion"
+forum="https://forum.privacytools.io/t/discussion-tor/1589"
+git="https://gitweb.torproject.org/tor.git"
+%}
 
-  {% include card.html color="primary"
-  title="I2P Anonymous Network"
-  image="/assets/img/tools/I2P.png"
-  url="https://geti2p.net/"
-  footer="OS: Windows, macOS, Linux, Android, BSD / Solaris."
-  description="The Invisible Internet Project (I2P) is a computer network layer that allows applications to send messages to each other pseudonymously and securely. Uses include anonymous
-  Web surfing, chatting, blogging, and file transfers. The software that implements this layer is called an I2P router and a computer running I2P is called an I2P node. The software is free and open-source and is published under multiple licenses."
-  %}
+{% include cardv2.html
+title="I2P Anonymous Network"
+image="/assets/img/tools/I2P.png"
+description="The Invisible Internet Project (I2P) is a computer network layer that allows applications to send messages to each other pseudonymously and securely. Uses include anonymous Web surfing, chatting, blogging, and file transfers. The software that implements this layer is called an I2P router and a computer running I2P is called an I2P node. The software is free and open-source and is published under multiple licenses."
+website="https://geti2p.net/"
+forum="https://forum.privacytools.io/t/discussion-i2p/1590"
+github="https://github.com/i2p/"
+%}
 
-  {% include card.html color="warning"
-  title="The Freenet Project"
-  image="/assets/img/tools/Freenet.png"
-  url="https://freenetproject.org/"
-  footer="OS: Windows, macOS, Linux."
-  description="Freenet is a peer-to-peer platform for censorship-resistant communication. It uses a decentralized distributed data store to keep and deliver information, and
-  has a suite of free software for publishing and communicating on the Web without fear of censorship. Both Freenet and some of its associated tools were originally designed by Ian Clarke, who defined Freenet's goal as providing freedom of speech
-  on the Internet with strong anonymity protection."
-  %}
+{% include cardv2.html
+title="The Freenet Project"
+image="/assets/img/tools/Freenet.png"
+description="Freenet is a peer-to-peer platform for censorship-resistant communication. It uses a decentralized distributed data store to keep and deliver information, and has a suite of free software for publishing and communicating on the Web without fear of censorship. Both Freenet and some of its associated tools were originally designed by Ian Clarke, who defined Freenet's goal as providing freedom of speech on the Internet with strong anonymity protection."
+website="https://freenetproject.org/"
+forum="https://forum.privacytools.io/t/discussion-freenet/1591"
+github="https://github.com/freenet/"
+%}
 
 </div>
 


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #1286

- Changes self-contained networks to use cardv2
- Adds in links to the git repositories and forum discussions
- Didn't add any links to actual software, but this is up for discussion

Preview: https://deploy-preview-1459--privacytools-io.netlify.com/software/networks/