### PR TITLE
footer: Change link and tooltip of "Support Us!"

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -62,7 +62,7 @@
 
     <div class="col-sm-4 mb-3 d-flex justify-content-center">
       <i class="fas fa-donate fa-2x"></i>
-      <a data-toggle="tooltip" data-placement="top" data-original-title="Please support this project by donating. We are ad free and not affiliated with any providers. Your donation will cover our cost for server and domain." href="https://opencollective.com/privacytoolsio#section-contribute">Support Us!</a>
+      <a href="/donate/" data-toggle="tooltip" data-placement="top" data-original-title="Please support this project by donating. We are ad-free and not affiliated with any providers. Your donation will cover our costs for servers and domains.">Support Us!</a>
     </div>
   </div>
 


### PR DESCRIPTION
OpenCollective is not the only way to donate. We should just refer users to the donate page (which already emphasizes OpenCollective at the top anyway) if a user prefers to donate via cryptocurrencies.

PR changes:
* Changes link of "Support Us" from `https://opencollective.com/privacytoolsio#section-contribute` to `/donate/`
* Change "ad free" to "ad-free" and adjust grammar of the last bit
* Move href attribute to the front to be more consistent with the others
