### PR TITLE
Improve EteSync: add iOS link, improve description and change links

### DIFF
--- a/_includes/sections/calendar-contacts-sync.html
+++ b/_includes/sections/calendar-contacts-sync.html
@@ -34,16 +34,20 @@
   include cardv2.html
   title="EteSync"
   image="/assets/img/provider/etesync.png"
-  description="<strong>EteSync</strong> is a secure, end-to-end encrypted, and journaled personal information (e.g. contacts and calendar) cloud synchronization and backup for Android and any OS that supports CalDAV/CardDAV. It costs $24 per year to use, or you can host the server yourself for free."
+  description="<strong>EteSync</strong> is a secure, end-to-end encrypted, and privacy-respecting cloud backup and synchronization software for your personal information (e.g. contacts and calendars). There are native clients for Android, iOS, and the web, and an adapter layer for most desktop clients. It costs $24 per year to use, or you can host the server yourself for free."
   website="https://www.etesync.com/"
   forum="https://forum.privacytools.io/t/discussion-etesync-calender-contacts-sync-tools/1536"
   github="https://github.com/etesync"
   web="https://client.etesync.com/"
-  windows="https://github.com/etesync/etesync-dav/blob/master/README.md#installation"
-  mac="https://github.com/etesync/etesync-dav/blob/master/README.md#installation"
-  linux="https://github.com/etesync/etesync-dav/blob/master/README.md#installation"
+  windows="https://www.etesync.com/install/dav/"
+  mac="https://www.etesync.com/install/dav/"
+  linux="https://www.etesync.com/install/dav/"
+  freebsd="https://www.etesync.com/install/dav/"
+  openbsd="https://www.etesync.com/install/dav/"
+  netbsd="https://www.etesync.com/install/dav/"
   fdroid="https://f-droid.org/packages/com.etesync.syncadapter/"
   googleplay="https://play.google.com/store/apps/details?id=com.etesync.syncadapter"
+  ios="https://www.etesync.com/install/ios/"
 %}
 
 <h3>Worth Mentioning</h3>


### PR DESCRIPTION
The dav bridge install instructions will soon be moved so better to
use the new links now already (for now, they are just a redirect).

## Description

As the commit message says it improves the EteSync entry by adding a link to the new iOS app, improving the description and changing the soon to be deprecated DAV installation instructions links.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [X] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [X] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: https://deploy-preview-1490--privacytools-io.netlify.com/software/calendar-contacts/

* Code repository of the project (if applicable):
The project is already on privacy-tools, though anyhow, here's the source code: https://github.com/etesync/