### PR TITLE
Delist DiskCryptor

### DIFF
--- a/_includes/sections/file-encryption.html
+++ b/_includes/sections/file-encryption.html
@@ -54,7 +54,6 @@
 
 <ul>
   <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open-source software: No backdoors, no registration.</li>
-  <li><a href="https://diskcryptor.net/">DiskCryptor</a> - A full disk and partition encryption system for Windows including the ability to encrypt the partition and disk on which the OS is installed.</li>
   <li><a href="https://gitlab.com/cryptsetup/cryptsetup/">Linux Unified Key Setup (LUKS)</a> - A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.</li>
   <li><a href="https://hat.sh/">Hat.sh</a> - A cross-platform, serverless JavaScript web application that provides secure file encryption using the AES-256-GCM algorithm in your browser. It can also be downloaded and run offline.</a></li>
   <li><a href="https://www.keka.io/">Keka</a> - A macOS-only, open-source file archiver with the ability to encrypt files.</li>


### PR DESCRIPTION
Windows only encryption software which has not been updated since version 1.1.846.118 was released on 2014-07-09.

Website certificate has been expired **since on 2019-06-22** which is 4 months, 23 days ago, this is **unacceptable** for encryption software.

An attack could occur whereby someone could be subject to a [MiTM](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) and accept a fraudulent certificate. gpg signatures could be also replaced with this kind of attack so that makes gpg signing the binary pointless. Many people don't check these anyway.

On a side note there appears to be **no** administrative moderation on their forums. Allowing [posts like this one](https://diskcryptor.net/forum/index.php?topic=5424.msg12276#msg12276) in your release thread which declare "UEFI" a security risk because of some ancient CVEs (that were fixed), should not be allowed.

UEFI in turn brings [Secure Boot](https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface#Secure_boot) which provide extra protection against a person booting unsigned binaries on your device should they gain physical access. It can be [completely controlled](http://www.rodsbooks.com/efi-bootloaders/controlling-sb.html) on most good motherboards, and in fact [I do this](https://wiki.archlinux.org/index.php/Secure_Boot#Using_your_own_keys). In addition the use of [TPM](https://en.wikipedia.org/wiki/Trusted_Platform_Module) requires UEFI which is something that can provide [further security](https://wiki.archlinux.org/index.php/Trusted_Platform_Module).