### PR TITLE
about: don't link to Keybase for my keys

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -97,7 +97,6 @@ nick="Mikaela"
 bio="I am interested in instant messengers. I review privacy tools, and participate in our forum, Matrix room, and issue tracker."
 website="https://mikaela.info/"
 keys="https://gitea.blesmrt.net/mikaela/shell-things/src/branch/master/.mikaela/keys"
-mastodon="https://mastodon.partipirate.org/@mikaela"
 %}
 
 {% include team.html

--- a/pages/about.html
+++ b/pages/about.html
@@ -96,7 +96,7 @@ name="Mikaela Suomalainen"
 nick="Mikaela"
 bio="I am interested in instant messengers. I review privacy tools, and participate in our forum, Matrix room, and issue tracker."
 website="https://mikaela.info/"
-keys="https://keybase.io/mikaela/"
+keys="https://gitea.blesmrt.net/mikaela/shell-things/src/branch/master/.mikaela/keys"
 mastodon="https://mastodon.partipirate.org/@mikaela"
 %}
 


### PR DESCRIPTION
I am against listing Keybase as the PGP host, because they are a centralized service and may terminate accounts at any time. Also I cannot link keys to https://mikaela.info/PGP/0xB2F32B67.txt as it excludes existence of SSH and all the other key types (e.g. minisign?).

Of course now I am giving that power to gitea.blesmrt.net, but at least that instance is not for-profit business.

Later I may move the keys onto IPFS to be more sure that they won't be tampered with.

<!-- PLEASE READ OUR CODE OF CONDUCT (https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->