### PR TITLE
Fix grammar in CPU vulnerability section

### DIFF
--- a/_includes/sections/operating-systems.html
+++ b/_includes/sections/operating-systems.html
@@ -56,7 +56,7 @@ gitlab="https://salsa.debian.org/qa/debsources"
 
 <p><em><a href="https://support.microsoft.com/en-us/help/4073757/protect-windows-devices-from-speculative-execution-side-channel-attack">This also affects Windows 10</a>, but it doesn't expose this information or mitigation instructions as easily. MacOS users check <a href="https://support.apple.com/en-us/HT210108">How to enable full mitigation for Microarchitectural Data Sampling (MDS) vulnerabilities on Apple Support</a>.</em></p>
 
-<p>When running a enough recent Linux kernel, you can check the CPU vulnerabilities it detects by <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code>. By using <code>tail -n +1</code> instead of <code>cat</code>, the file names are also visible.</p>
+<p>When running a recent enough Linux kernel, you can check the CPU vulnerabilities it detects by <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code>. By using <code>tail -n +1</code> instead of <code>cat</code>, the file names are also visible.</p>
 
 <p>
     In case you have an Intel CPU, you may notice "SMT vulnerable" display after running the <code>tail</code> command. To mitigate this, disable <a href="https://en.wikipedia.org/wiki/Hyper-threading">hyper-threading</a> from the UEFI/BIOS. You can also take the following mitigation steps below if your system/distribution uses GRUB and supports <code>/etc/default/grub.d/</code>:


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description
This fixes a grammar mistake in the _CPU vulnerability mitigations_ section of the Operating Systems page ("a enough recent Linux kernel" to "a recent enough Linux kernel"). A reference to the kernel commit that added the `vulnerabilities/` directory could also be added. Here is a link to the commit: [http://lkml.iu.edu/hypermail/linux/kernel/1801.1/00145.html](http://lkml.iu.edu/hypermail/linux/kernel/1801.1/00145.html)

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: [https://deploy-preview-1506--privacytools-io.netlify.com/operating-systems/#cpuvulns](https://deploy-preview-1506--privacytools-io.netlify.com/operating-systems/#cpuvulns)

* Code repository of the project (if applicable): N/A