### PR TITLE
i18n: Fix permalink generation

### DIFF
--- a/_plugins/translated-page-generator.rb
+++ b/_plugins/translated-page-generator.rb
@@ -48,7 +48,7 @@ module Jekyll
           translated_page.data['title']       = translated_page_title.nil? ? page_title : translated_page_title.strip
           translated_page.data['description'] = translated_page_description.nil? ? page_description
                                                                                  : translated_page_description.strip
-          translated_page.data['permalink']   = "#{language}/#{page.dir}"
+          translated_page.data['permalink']   = "/#{language}#{page.dir}"
           translated_page.data['src_dir']     = page.dir
           translated_page.data['language']    = language
           translated_page.content             = page.content


### PR DESCRIPTION
This fixes the permalink generation. 

Permalinks from before looked like
``
http://localhost:4000es//sponsors/
``
Now, they should look like
``
http://localhost:4000/es/sponsors/
``