### PR TITLE
Kolab Now Webclient now supports PGP encryption

### DIFF
--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -58,7 +58,7 @@
         <td data-value="2048">2 GB</td>
         <td data-value="6000">$ 60</td>
         <td data-value="1"><span class="label label-success">Accepted</span></td>
-        <td data-value="0"><span class="label label-primary">No</span></td>
+        <td data-value="1"><span class="label label-success">Built-in</span></td>
         <td data-value="1"><span class="label label-success">Yes</span></td>
       </tr>
 


### PR DESCRIPTION
> BTW: Encryption is built in to the web client these days. You can update your
> schema.

According to someone from Kolab Now, they now support PGP encryption.

I could found more information about that on
https://kb.kolabnow.com/documentation/encryption

https://deploy-preview-1521--privacytools-io.netlify.com/providers/email/