### PR TITLE
i18n: Encode length and punctuation in key IDs

### DIFF
--- a/_plugins/weblate-source-file.rb
+++ b/_plugins/weblate-source-file.rb
@@ -21,8 +21,11 @@ module Weblate
     def self.get(source_text)
       source_text.nil? or source_text.empty? ? source_text
                                              : source_text.strip[0..150]
-                                                          .gsub(/([^\w\d\s\!]|\n)/, '')
-                                                          .tr(' ', '_') << "_KEY"
+                                                          .gsub(/([^\w\d\s\.\?\!]|\n)/, '')
+                                                          .tr(' ', '_') 
+                                                          .tr('.', 'P')
+                                                          .tr('?', 'Q')
+                                                          .tr('!', 'E') << "_" << source_text.length.to_s << "_KEY"
     end
   end
 

--- a/weblate-source-file.yml
+++ b/weblate-source-file.yml
@@ -1,5492 +1,5630 @@
 ---
-About_PrivacyTools_KEY: |
+About_PrivacyTools_18_KEY: |
   About PrivacyTools
 
-About_the_PrivacyTools_organization_and_contributors_to_the_PrivacyTools_website_communities_and_services_KEY: |
+About_the_PrivacyTools_organization_and_contributors_to_the_PrivacyTools_website_communities_and_servicesP_109_KEY: |
   About the PrivacyTools organization, and contributors to the PrivacyTools website, communities, and services.
 
-Web_Browsers_KEY: |
+Web_Browsers_12_KEY: |
   Web Browsers
 
-These_are_our_current_web_browser_recommendations_and_some_tweaks_you_can_use_to_preserve_your_privacy_KEY: |
+These_are_our_current_web_browser_recommendations_and_some_tweaks_you_can_use_to_preserve_your_privacyP_103_KEY: |
   These are our current web browser recommendations and some tweaks you can use to preserve your privacy.
 
-CalendarContacts_Sync_Tools_KEY: |
+CalendarContacts_Sync_Tools_28_KEY: |
   Calendar/Contacts Sync Tools
 
-Discover_free_opensource_and_secure_ways_to_sync_your_contacts_and_calendars_across_your_devices_KEY: |
+Discover_free_opensource_and_secure_ways_to_sync_your_contacts_and_calendars_across_your_devicesP_100_KEY: |
   Discover free, open-source, and secure ways to sync your contacts and calendars across your devices.
 
-Self_Hosted_Cloud_KEY: |
+Self_Hosted_Cloud_19_KEY: |
   Self Hosted "Cloud"
 
-Discover_how_to_securely_and_privately_selfhost_your_cloud_with_opensource_software_KEY: |
+Discover_how_to_securely_and_privately_selfhost_your_cloud_with_opensource_softwareP_86_KEY: |
   Discover how to securely and privately self-host your cloud with open-source software.
 
-Encrypted_DNS_Resolvers_KEY: |
+Encrypted_DNS_Resolvers_23_KEY: |
   Encrypted DNS Resolvers
 
-Dont_let_Google_see_all_your_DNS_traffic_Discover_privacycentric_alternatives_to_the_traditional_DNS_providers_KEY: |
+Dont_let_Google_see_all_your_DNS_trafficP_Discover_privacycentric_alternatives_to_the_traditional_DNS_providersP_114_KEY: |
   Don't let Google see all your DNS traffic. Discover privacy-centric alternatives to the traditional DNS providers.
 
-Best_Secure_Email_Providers_for_Privacy_KEY: |
-  Best Secure Email Providers for Privacy
-
-Find_a_secure_email_provider_that_will_keep_your_privacy_in_mind_Dont_settle_for_adsupported_platforms_Never_trust_any_company_with_your_privacy_a_KEY: |
-  Find a secure email provider that will keep your privacy in mind. Don't settle for ad-supported platforms. Never trust any company with your privacy, always encrypt.
-
-Email_Clients_KEY: |
+Email_Clients_13_KEY: |
   Email Clients
 
-Discover_free_opensource_and_secure_email_clients_along_with_some_email_alternatives_you_may_not_have_considered_KEY: |
+Discover_free_opensource_and_secure_email_clients_along_with_some_email_alternatives_you_may_not_have_consideredP_117_KEY: |
   Discover free, open-source, and secure email clients, along with some email alternatives you may not have considered.
 
-Encryption_Tools_KEY: |
+Best_Secure_Email_Providers_for_Privacy_39_KEY: |
+  Best Secure Email Providers for Privacy
+
+Find_a_secure_email_provider_that_will_keep_your_privacy_in_mindP_Dont_settle_for_adsupported_platformsP_Never_trust_any_company_with_your_privacy_a_165_KEY: |
+  Find a secure email provider that will keep your privacy in mind. Don't settle for ad-supported platforms. Never trust any company with your privacy, always encrypt.
+
+Encryption_Tools_16_KEY: |
   Encryption Tools
 
-Discover_free_opensource_and_secure_ways_to_encrypt_your_sensitive_data_to_keep_it_from_prying_eyes_KEY: |
+Discover_free_opensource_and_secure_ways_to_encrypt_your_sensitive_data_to_keep_it_from_prying_eyesP_103_KEY: |
   Discover free, open-source, and secure ways to encrypt your sensitive data to keep it from prying eyes.
 
-File_Sharing_KEY: |
+File_Sharing_12_KEY: |
   File Sharing
 
-Discover_how_to_share_your_files_with_your_friends_and_family_or_anonymously_without_a_middleman_KEY: |
+Discover_how_to_share_your_files_with_your_friends_and_family_or_anonymously_without_a_middlemanP_98_KEY: |
   Discover how to share your files with your friends and family or anonymously, without a middleman.
 
-File_Sync_KEY: |
+File_Sync_9_KEY: |
   File Sync
 
-Discover_free_opensource_and_secure_ways_to_sync_your_files_across_your_devices_KEY: |
+Discover_free_opensource_and_secure_ways_to_sync_your_files_across_your_devicesP_83_KEY: |
   Discover free, open-source, and secure ways to sync your files across your devices.
 
-Web_Hosting_KEY: |
+Web_Hosting_11_KEY: |
   Web Hosting
 
-Find_a_web_hosting_provider_that_wont_track_your_visitors_or_give_into_government_data_requests_KEY: |
+Find_a_web_hosting_provider_that_wont_track_your_visitors_or_give_into_government_data_requestsP_97_KEY: |
   Find a web hosting provider that won't track your visitors or give into government data requests.
 
-SelfContained_Networks_KEY: |
+SelfContained_Networks_23_KEY: |
   Self-Contained Networks
 
-If_you_are_currently_browsing_clearnet_and_want_to_access_the_dark_web_this_section_is_for_you_KEY: |
+If_you_are_currently_browsing_clearnet_and_want_to_access_the_dark_web_this_section_is_for_youP_96_KEY: |
   If you are currently browsing clearnet and want to access the dark web, this section is for you.
 
-Notebooks_KEY: |
+Notebooks_9_KEY: |
   Notebooks
 
-Keep_track_of_your_notes_and_journalings_without_giving_them_to_a_third_party_KEY: |
+Keep_track_of_your_notes_and_journalings_without_giving_them_to_a_third_partyP_78_KEY: |
   Keep track of your notes and journalings without giving them to a third party.
 
-Operating_Systems_KEY: |
+Operating_Systems_17_KEY: |
   Operating Systems
 
-Even_your_own_computer_could_be_compromising_your_privacy_Discover_our_recommended_OS_choices_for_all_the_devices_you_use_KEY: |
+Even_your_own_computer_could_be_compromising_your_privacyP_Discover_our_recommended_OS_choices_for_all_the_devices_you_useP_123_KEY: |
   Even your own computer could be compromising your privacy. Discover our recommended OS choices for all the devices you use.
 
-Password_Managers_KEY: |
+Password_Managers_17_KEY: |
   Password Managers
 
-Stay_safe_and_secure_online_with_an_encrypted_and_opensource_password_manager_KEY: |
+Stay_safe_and_secure_online_with_an_encrypted_and_opensource_password_managerP_79_KEY: |
   Stay safe and secure online with an encrypted and open-source password manager.
 
-Pastebin_hosting_services_KEY: |
+Pastebin_hosting_services_25_KEY: |
   Pastebin hosting services
 
-Find_a_pastebin_provider_that_wont_read_your_content_to_share_sensitive_code_or_other_information_KEY: |
+Find_a_pastebin_provider_that_wont_read_your_content_to_share_sensitive_code_or_other_informationP_99_KEY: |
   Find a pastebin provider that won't read your content to share sensitive code or other information.
 
-Productivity_Tools_KEY: |
+Productivity_Tools_18_KEY: |
   Productivity Tools
 
-Get_working_and_collaborating_without_sharing_your_documents_with_a_middleman_or_trusting_a_cloud_provider_KEY: |
+Get_working_and_collaborating_without_sharing_your_documents_with_a_middleman_or_trusting_a_cloud_providerP_107_KEY: |
   Get working and collaborating without sharing your documents with a middleman or trusting a cloud provider.
 
-Providers_KEY: |
+Providers_9_KEY: |
   Providers
 
-Theres_a_ton_of_people_providing_services_online_Discover_which_ones_you_should_avoid_and_our_recommendations_for_a_variety_of_services_KEY: |
+Theres_a_ton_of_people_providing_services_onlineP_Discover_which_ones_you_should_avoid_and_our_recommendations_for_a_variety_of_servicesP_138_KEY: |
   There's a ton of people providing services online. Discover which ones you should avoid and our recommendations for a variety of services.
 
-RealTime_Communication_KEY: |
+RealTime_Communication_23_KEY: |
   Real-Time Communication
 
-Discover_secure_and_private_ways_to_communicate_with_others_online_without_letting_any_third_parties_read_your_messages_KEY: |
+Discover_secure_and_private_ways_to_communicate_with_others_online_without_letting_any_third_parties_read_your_messagesP_120_KEY: |
   Discover secure and private ways to communicate with others online without letting any third parties read your messages.
 
-Search_Engines_KEY: |
+Search_Engines_14_KEY: |
   Search Engines
 
-Find_a_search_engine_that_doesnt_track_your_queries_or_build_an_advertising_profile_based_on_your_searches_KEY: |
+Find_a_search_engine_that_doesnt_track_your_queries_or_build_an_advertising_profile_based_on_your_searchesP_108_KEY: |
   Find a search engine that doesn't track your queries or build an advertising profile based on your searches.
 
-Services_from_PrivacyTools_KEY: |
+Services_from_PrivacyTools_26_KEY: |
   Services from PrivacyTools
 
-The_PrivacyTools_team_is_proud_to_introduce_a_suite_of_privacycentric_online_services_to_connect_you_with_other_privacyminded_individuals_and_stay_sa_KEY: |
+The_PrivacyTools_team_is_proud_to_introduce_a_suite_of_privacycentric_online_services_to_connect_you_with_other_privacyminded_individuals_and_stay_sa_259_KEY: |
   The PrivacyTools team is proud to introduce a suite of privacy-centric online services to connect you with other privacy-minded individuals and stay safe and secure online. No advertisers, no Google Analytics, no tracking, no third-party requests of any kind.
 
-Social_Networks_KEY: |
+Social_Networks_15_KEY: |
   Social Networks
 
-Find_a_social_network_that_doesnt_pry_into_your_data_or_monetize_your_profile_KEY: |
+Find_a_social_network_that_doesnt_pry_into_your_data_or_monetize_your_profileP_79_KEY: |
   Find a social network that doesn't pry into your data or monetize your profile.
 
-Social_News_Aggregator_KEY: |
+Social_News_Aggregator_22_KEY: |
   Social News Aggregator
 
-Stay_uptodate_with_privacyrespecting_online_bulletin_boards_KEY: |
+Stay_uptodate_with_privacyrespecting_online_bulletin_boardsP_63_KEY: |
   Stay up-to-date with privacy-respecting online bulletin boards.
 
-Cloud_Storage_KEY: |
+Cloud_Storage_13_KEY: |
   Cloud Storage
 
-Find_a_cloud_storage_provider_that_wont_look_through_your_files_KEY: |
+Find_a_cloud_storage_provider_that_wont_look_through_your_filesP_65_KEY: |
   Find a cloud storage provider that won't look through your files.
 
-VPN_Services_KEY: |
+VPN_Services_12_KEY: |
   VPN Services
 
-Find_a_nologging_VPN_operator_who_isnt_out_to_sell_or_read_your_web_traffic_KEY: |
+Find_a_nologging_VPN_operator_who_isnt_out_to_sell_or_read_your_web_trafficP_78_KEY: |
   Find a no-logging VPN operator who isn't out to sell or read your web traffic.
 
-Provider_KEY: |
+Provider_9_KEY: |
   Provider
 
-Avoid_US__UK_services_KEY: |
+Avoid_US__UK_services_23_KEY: |
   Avoid US & UK services
 
-DNS_KEY: |
+Cloud_Storage_14_KEY: |
+  Cloud Storage
+
+DNS_4_KEY: |
   DNS
 
-Email_KEY: |
+Email_6_KEY: |
   Email
 
-Hosting_KEY: |
+Hosting_8_KEY: |
   Hosting
 
-Pastebins_KEY: |
+Pastebins_10_KEY: |
   Pastebins
 
-Social_News_Aggregators_KEY: |
+Search_Engines_15_KEY: |
+  Search Engines
+
+Social_Networks_16_KEY: |
+  Social Networks
+
+Social_News_Aggregators_24_KEY: |
   Social News Aggregators
 
-VPN_KEY: |
+VPN_4_KEY: |
   VPN
 
-Browser_KEY: |
+Browser_8_KEY: |
   Browser
 
-Recommendation_KEY: |
+Recommendation_15_KEY: |
   Recommendation
 
-Fingerprinting_Info_KEY: |
+Fingerprinting_Info_20_KEY: |
   Fingerprinting Info
 
-WebRTC_IP_Leak_KEY: |
+WebRTC_IP_Leak_15_KEY: |
   WebRTC IP Leak
 
-Browser_Addons_KEY: |
+Browser_Addons_16_KEY: |
   Browser Add-ons
 
-Firefox_Tweaks_KEY: |
+Firefox_Tweaks_15_KEY: |
   Firefox Tweaks
 
-Software_KEY: |
+Software_9_KEY: |
   Software
 
-Digital_Notebook_KEY: |
+CalendarContacts_Sync_Tools_29_KEY: |
+  Calendar/Contacts Sync Tools
+
+Digital_Notebook_17_KEY: |
   Digital Notebook
 
-Email_Alternatives_KEY: |
+Email_Alternatives_19_KEY: |
   Email Alternatives
 
-File_Encryption_KEY: |
+Email_Clients_14_KEY: |
+  Email Clients
+
+File_Encryption_16_KEY: |
   File Encryption
 
-Metadata_Removal_Tools_KEY: |
+File_Sharing_13_KEY: |
+  File Sharing
+
+File_Sync_10_KEY: |
+  File Sync
+
+Metadata_Removal_Tools_23_KEY: |
   Metadata Removal Tools
 
-Password_Manager_KEY: |
+Password_Manager_17_KEY: |
   Password Manager
 
-Selfcontained_Networks_KEY: |
+Productivity_Tools_19_KEY: |
+  Productivity Tools
+
+RealTime_Communication_24_KEY: |
+  Real-Time Communication
+
+Selfcontained_Networks_24_KEY: |
   Self-contained Networks
 
-SelfHosted_Cloud_Server_KEY: |
+SelfHosted_Cloud_Server_25_KEY: |
   Self-Hosted Cloud Server
 
-OS_KEY: |
+OS_3_KEY: |
   OS
 
-PC_OS_KEY: |
+PC_OS_6_KEY: |
   PC OS
 
-Live_CD_OS_KEY: |
+Live_CD_OS_11_KEY: |
   Live CD OS
 
-Mobile_OS_KEY: |
+Mobile_OS_10_KEY: |
   Mobile OS
 
-Android_Privacy_Addons_KEY: |
+Android_Privacy_Addons_24_KEY: |
   Android Privacy Add-ons
 
-Router_Firmware_KEY: |
+Router_Firmware_16_KEY: |
   Router Firmware
 
-Dont_use_Windows_10_KEY: |
+Dont_use_Windows_10_21_KEY: |
   Don't use Windows 10
 
-Participate_KEY: |
+Participate_12_KEY: |
   Participate
 
-Services_KEY: |
+Services_9_KEY: |
   Services
 
-Blog_KEY: |
+Blog_5_KEY: |
   Blog
 
-Sponsors_KEY: |
+Sponsors_9_KEY: |
   Sponsors
 
-About_Us_KEY: |
+About_Us_9_KEY: |
   About Us
 
-Theme_KEY: |
+Theme_6_KEY: |
   Theme
 
-Toggle_Theme_KEY: |
+Toggle_Theme_13_KEY: |
   Toggle Theme
 
-Language_KEY: |
+Language_9_KEY: |
   Language
 
-Language_Selection_KEY: |
+Language_Selection_19_KEY: |
   Language Selection
 
-You_are_being_watched_Private_and_statesponsored_organizations_are_monitoring_and_recording_your_online_activities_KEY: |
+You_are_being_watchedP_Private_and_statesponsored_organizations_are_monitoring_and_recording_your_online_activitiesP_118_KEY: |
   You are being watched. Private and state-sponsored organizations are monitoring and recording your online activities.
 
-At_strongPrivacyToolsstrong_we_provide_services_tools_and_knowledge_to_protect_your_privacy_against_global_mass_surveillance_and_moderate_a_th_KEY: |
+At_strongPrivacyToolsstrong_we_provide_services_tools_and_knowledge_to_protect_your_privacy_against_global_mass_surveillance_and_moderate_a_th_422_KEY: |
   At <strong>PrivacyTools</strong>, we provide services, tools, and knowledge to protect your privacy against global mass surveillance, and moderate a thriving community of privacy-minded individuals like yourself to discuss and learn about new advances in protecting your online data. This website serves as the centerpiece of our organization, where we research and recommend various software solutions for our community.
 
-strongTransparencystrong_is_our_strongest_value_and_its_what_sets_us_apart_from_the_rest_of_the_privacy_recommendations_community_Editorial_c_KEY: |
+strongTransparencystrong_is_our_strongest_value_and_its_what_sets_us_apart_from_the_rest_of_the_privacy_recommendations_communityP_Editorial_c_1014_KEY: |
   <strong>Transparency</strong> is our strongest value, and it's what sets us apart from the rest of the "privacy recommendations" community. Editorial changes to this website and the products we recommend are always discussed on our extensive <a href="https://github.com/privacytoolsIO/privacytools.io/issues">issue tracker</a>, drafted in a public <a href="https://github.com/privacytoolsIO/privacytools.io/pulls">pull request</a> open for further discussion, and logged in a comprehensive <a href="https://github.com/privacytoolsIO/privacytools.io/commits/master">commit log</a> dating back to our original founding date in 2015. The <em>core</em> team members listed below are responsible for most of the edits and final decisions to changes on this website and across our services, but this website is truly the work of hundreds <a href="https://github.com/privacytoolsIO/privacytools.io/graphs/contributors">contributors and fact checkers</a> working to make sure our recommendations are solid and trustworthy.
 
-Additionally_we_are_a_notforprofit_organization_We_do_not_utilize_paid_recommendations_or_affiliate_programs_to_make_the_recommendations_on_this_we_KEY: |
+Additionally_we_are_a_notforprofit_organizationP_We_do_not_utilize_paid_recommendations_or_affiliate_programs_to_make_the_recommendations_on_this_we_1210_KEY: |
   Additionally, we are a not-for-profit organization. We do not utilize paid recommendations or affiliate programs to make the recommendations on this website. Unfortunately this practice is very common elsewhere online, which makes it difficult to trust other review sites. We are unique in this area, in that all of our research is conducted independently, and we will never accept payments to modify, add, or remove any of our reviews or recommendations. Our finances are provided entirely by our community <a href="https://opencollective.com/privacytoolsio">donors</a> and <a href=' {{ "/sponsors/" | translate_page }}'>sponsors</a>, and are handled by the Open Collective Foundation 501(c)(3). Because we are operating as a charity in the United States, we are legally obligated to only use our funding to further our mission of spreading privacy education and promoting online services like Mastodon, Matrix, and WriteFreely. This website is a public resource, not a profit generator. To that regard, all our financial transactions (incoming and outgoing) are logged and made available to the public via our page at <a href="https://opencollective.com/privacytoolsio">opencollective.com/privacytoolsio</a>.
 
-We_take_the_operation_of_our_various_a_href_services__translate_page_servicesa_very_seriously_and_require_all_participants_to_adhere__KEY: |
+We_take_the_operation_of_our_various_a_href_services__translate_page_servicesa_very_seriously_and_require_all_participants_to_adhere__440_KEY: |
   We take the operation of our various <a href='{{ "/services/" | translate_page }}'>services</a> very seriously, and require all participants to adhere to our <a href="https://github.com/privacytoolsIO/.github/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a>. For any questions or to report abuse, please see our CoC’s <a href="https://github.com/privacytoolsIO/.github/blob/master/CODE_OF_CONDUCT.md#enforcement">Enforcement section</a>.
 
-Core_Contributors_KEY: |
+Core_Contributors_18_KEY: |
   Core Contributors
 
-Founder_KEY: |
+Founder_7_KEY: |
   Founder
 
-I_founded_PrivacyTools_in_2015_to_share_resources_and_tools_allowing_users_to_avoid_international_masssurveillance_programs_KEY: |
+I_founded_PrivacyTools_in_2015_to_share_resources_and_tools_allowing_users_to_avoid_international_masssurveillance_programsP_126_KEY: |
   I founded PrivacyTools in 2015 to share resources and tools, allowing users to avoid international mass-surveillance programs.
 
-Administrator_KEY: |
+Administrator_13_KEY: |
   Administrator
 
-I_run_the_website_and_services_for_PrivacyTools_My_goal_is_to_spread_the_word_about_data_privacy_as_widely_as_possible_KEY: |
+I_run_the_website_and_services_for_PrivacyToolsP_My_goal_is_to_spread_the_word_about_data_privacy_as_widely_as_possibleP_120_KEY: |
   I run the website and services for PrivacyTools. My goal is to spread the word about data privacy as widely as possible.
 
-Community_Manager_KEY: |
+Community_Manager_17_KEY: |
   Community Manager
 
-I_research_new_privacy_recommendations_and_moderate_our_communities_My_expertise_is_endpoint_security_and_networking_KEY: |
+I_research_new_privacy_recommendations_and_moderate_our_communitiesP_My_expertise_is_endpoint_security_and_networkingP_118_KEY: |
   I research new privacy recommendations and moderate our communities. My expertise is endpoint security and networking.
 
-ThinkPrivacy_Editor_KEY: |
+ThinkPrivacy_Editor_19_KEY: |
   ThinkPrivacy Editor
 
-Im_an_author_columnist_and_privacy_advocate_whose_work_has_appeared_in_Time_Huff_Post_OpenSource_and_more_KEY: |
+Im_an_author_columnist_and_privacy_advocate_whose_work_has_appeared_in_Time_Huff_Post_OpenSource_and_moreP_112_KEY: |
   I'm an author, columnist, and privacy advocate whose work has appeared in Time, Huff Post, OpenSource, and more.
 
-Developer_KEY: |
+Developer_9_KEY: |
   Developer
 
-Im_a_student_interested_in_software_development_I_help_improve_PrivacyTools_and_promote_using_free_libre_software_KEY: |
+Im_a_student_interested_in_software_developmentP_I_help_improve_PrivacyTools_and_promote_using_free_libre_softwareP_116_KEY: |
   I'm a student interested in software development. I help improve PrivacyTools and promote using free libre software.
 
-Contributor_KEY: |
+Contributor_11_KEY: |
   Contributor
 
-I_liaise_with_and_research_privacyfocused_services_to_refine_our_recommendations_My_background_is_infosec_and_network_security_KEY: |
+I_liaise_with_and_research_privacyfocused_services_to_refine_our_recommendationsP_My_background_is_infosec_and_network_securityP_129_KEY: |
   I liaise with and research privacy-focused services to refine our recommendations. My background is infosec and network security.
 
-I_am_interested_in_instant_messengers_I_review_privacy_tools_and_participate_in_our_forum_Matrix_room_and_issue_tracker_KEY: |
+I_am_interested_in_instant_messengersP_I_review_privacy_tools_and_participate_in_our_forum_Matrix_room_and_issue_trackerP_124_KEY: |
   I am interested in instant messengers. I review privacy tools, and participate in our forum, Matrix room, and issue tracker.
 
-Im_a_privacy_advocate_and_software_developer_I_write_web_extensions_help_research_and_make_updates_to_the_site_KEY: |
+Im_a_privacy_advocate_and_software_developerP_I_write_web_extensions_help_research_and_make_updates_to_the_siteP_115_KEY: |
   I'm a privacy advocate and software developer. I write web extensions, help research, and make updates to the site.
 
-Subreddit_Mod_KEY: |
+Subreddit_Mod_13_KEY: |
   Subreddit Mod
 
-Im_the_moderator_at_rPrivacy_and_rprivacytoolsIO_Day_to_day_I_am_also__iirony_alerti__an_ethical_digital_marketer_KEY: |
+Im_the_moderator_at_rPrivacy_and_rprivacytoolsIOP_Day_to_day_I_am_also__iirony_alerti__an_ethical_digital_marketerP_128_KEY: |
   I'm the moderator at r/Privacy and r/privacytoolsIO. Day to day, I am also – <i>irony alert</i> – an (ethical) digital marketer.
 
-Of_course_we_couldnt_do_any_of_this_without_our_very_generous_a_hrefhttpsopencollectivecomprivacytoolsiofinancial_contributorsa_a_hre_KEY: |
+Of_course_we_couldnt_do_any_of_this_without_our_very_generous_a_hrefhttpsopencollectivePcomprivacytoolsiofinancial_contributorsa_a_hre_333_KEY: |
   Of course, we couldn't do any of this without our very generous <a href="https://opencollective.com/privacytoolsio/">financial contributors</a>, <a href="https://github.com/privacytoolsIO/privacytools.io/graphs/contributors">website contributors</a>, and the countless community members that help share new ideas and spread the word!
 
-Thank_you_KEY: |
+Thank_youP_11_KEY: |
   Thank you.
 
-Get_involved!_KEY: |
+Get_involvedE_14_KEY: |
   Get involved!
 
-Donate_KEY: |
+Donate_7_KEY: |
   Donate
 
-Contact_Us_KEY: |
+Contact_Us_11_KEY: |
   Contact Us
 
-Its_very_important_to_us_to_stay_uptodate_on_the_latest_changes_in_the_privacy_space_If_you_have_a_software_recommendation_for_us_or_want_to_reque_KEY: |
+Its_very_important_to_us_to_stay_uptodate_on_the_latest_changes_in_the_privacy_spaceP_If_you_have_a_software_recommendation_for_us_or_want_to_reque_245_KEY: |
   It's very important to us to stay up-to-date on the latest changes in the privacy space. If you have a software recommendation for us, or want to request a change on this website, please don't hesitate to reach out in one of the following ways.
 
-Start_a_discussion_in_our_Discourse_forum_KEY: |
+Start_a_discussion_in_our_Discourse_forum_42_KEY: |
   Start a discussion in our Discourse forum
 
-Open_an_issue_on_GitHub_KEY: |
+Open_an_issue_on_GitHub_24_KEY: |
   Open an issue on GitHub
 
-Suggest_something_new_on_our_subreddit_KEY: |
+Suggest_something_new_on_our_subreddit_39_KEY: |
   Suggest something new on our subreddit
 
-For_complete_transparency_software_and_providers_will_only_be_considered_for_this_website_after_discussions_take_place_on_our_GitHub_issue_tracker_We_KEY: |
+For_complete_transparency_software_and_providers_will_only_be_considered_for_this_website_after_discussions_take_place_on_our_GitHub_issue_trackerP_We_196_KEY: |
   For complete transparency, software and providers will only be considered for this website after discussions take place on our GitHub issue tracker. We of course don't make any changes in secret.
 
-Join_our_Matrix_room_at_codegeneralprivacytoolsiocode_or_join_the_a_hrefhttpskeybaseioteamprivacytools_ioprivacytools_io_Keybase_tea_KEY: |
+Join_our_Matrix_room_at_codegeneralprivacytoolsPiocode_or_join_the_a_hrefhttpskeybasePioteamprivacytools_ioprivacytools_io_Keybase_tea_400_KEY: |
   Join our Matrix room at <code>#general:privacytools.io</code> or join the <a href="https://keybase.io/team/privacytools_io">privacytools_io Keybase team</a> to chat with us and other members about this site and privacy in general! If you need a Matrix account, you can sign up with our own homeserver (<code>https://chat.privacytools.io</code>) using <a href="https://riot.privacytools.io">Riot</a>.
 
-Spread_the_word_and_help_your_friends_KEY: |
+Spread_the_word_and_help_your_friends_38_KEY: |
   Spread the word and help your friends
 
-privacytoolsio__encryption_against_global_mass_surveillance_KEY: |
+privacytoolsPio__encryption_against_global_mass_surveillance_61_KEY: |
   privacytools.io - encryption against global mass surveillance
 
-Facebook_KEY: |
+Facebook_9_KEY: |
   Facebook
 
-Knowledge_and_tools_to_protect_your_privacy_against_global_mass_surveillance_KEY: |
+Knowledge_and_tools_to_protect_your_privacy_against_global_mass_surveillance_76_KEY: |
   Knowledge and tools to protect your privacy against global mass surveillance
 
-Twitter_KEY: |
+Twitter_8_KEY: |
   Twitter
 
-Mastodon_KEY: |
+Mastodon_9_KEY: |
   Mastodon
 
-reddit_KEY: |
+reddit_7_KEY: |
   reddit
 
-LinkedIn_KEY: |
+LinkedIn_9_KEY: |
   LinkedIn
 
-Mix_KEY: |
+Mix_4_KEY: |
   Mix
 
-Diaspora_KEY: |
+Diaspora_10_KEY: |
   Diaspora*
 
-Copy_URL_and_Description_KEY: |
+Copy_URL_and_Description_25_KEY: |
   Copy URL and Description
 
-_sitename___Encryption_and_tools_to_protect_against_global_mass_surveillance___siteproduction_url__append_lang__uri_escape__KEY: |
+_sitePname___Encryption_and_tools_to_protect_against_global_mass_surveillance___sitePproduction_url__append_lang__uri_escape__138_KEY: |
   {{ site.name }} - Encryption and tools to protect against global mass surveillance - {{ site.production_url | append_lang | uri_escape }}
 
-For_easy_copy_and_paste_Share_this_text_snippet_KEY: |
+For_easy_copy_and_pasteP_Share_this_text_snippetP_50_KEY: |
   For easy copy and paste. Share this text snippet.
 
-This_work_is_free_You_can_redistribute_it_andor_modify_it_under_the_terms_of_the_quotCreative_Commons_CC0_10_Universal_Public_Domain_Dedicationqu_KEY: |
+This_work_is_freeP_You_can_redistribute_it_andor_modify_it_under_the_terms_of_the_quotCreative_Commons_CC0_1P0_Universal_Public_Domain_Dedicationqu_155_KEY: |
   This work is free. You can redistribute it and/or modify it under the terms of the &quot;Creative Commons CC0 1.0 Universal Public Domain Dedication&quot;.
 
-Contact_KEY: |
+Contact_8_KEY: |
   Contact
 
-Please_support_this_project_by_donating_We_are_adfree_and_not_affiliated_with_any_providers_Your_donation_will_cover_our_costs_for_servers_and_domai_KEY: |
+Please_support_this_project_by_donatingP_We_are_adfree_and_not_affiliated_with_any_providersP_Your_donation_will_cover_our_costs_for_servers_and_domai_155_KEY: |
   Please support this project by donating. We are ad-free and not affiliated with any providers. Your donation will cover our costs for servers and domains.
 
-Support_Us!_KEY: |
+Support_UsE_12_KEY: |
   Support Us!
 
-JavaScript_Licenses_KEY: |
+JavaScript_Licenses_20_KEY: |
   JavaScript Licenses
 
-Translation_status_KEY: |
+Translation_status_19_KEY: |
   Translation status
 
-Help_translate_PrivacyTools_on_Weblate!_KEY: |
+Help_translate_PrivacyTools_on_WeblateE_39_KEY: |
   Help translate PrivacyTools on Weblate!
 
-NonEnglish_translated_versions_of_PrivacyTools_are_crowdsourced_and_provided_on_an_asis_basis_and_we_make_no_guarantees_towards_the_accuracy_of_ea_KEY: |
+NonEnglish_translated_versions_of_PrivacyTools_are_crowdsourced_and_provided_on_an_asis_basis_and_we_make_no_guarantees_towards_the_accuracy_of_ea_171_KEY: |
   Non-English (translated) versions of PrivacyTools are crowdsourced and provided on an as-is basis, and we make no guarantees towards the accuracy of each translated site.
 
-No_Ads_No_Google_Analytics_No_Affiliates_No_CrossSite_Requests_KEY: |
+No_Ads_No_Google_Analytics_No_Affiliates_No_CrossSite_RequestsP_67_KEY: |
   No Ads, No Google Analytics, No Affiliates, No Cross-Site Requests.
 
-_sitename__is_a_socially_motivated_website_that_provides_information_for_protecting_your_data_security_and_privacy_Never_trust_any_company_with_y_KEY: |
+_sitePname__is_a_socially_motivated_website_that_provides_information_for_protecting_your_data_security_and_privacyP_Never_trust_any_company_with_y_180_KEY: |
   {{ site.name }} is a socially motivated website that provides information for protecting your data security and privacy. Never trust any company with your privacy, always encrypt.
 
-View_our_privacy_statement_KEY: |
+View_our_privacy_statement_27_KEY: |
   View our privacy statement
 
-Learn_More_KEY: |
+Learn_More_11_KEY: |
   Learn More
 
-Browser_Recommendations_For_Desktop_KEY: |
+Browser_Recommendations_For_Desktop_36_KEY: |
   Browser Recommendations For Desktop
 
-Firefox_KEY: |
+Firefox_7_KEY: |
   Firefox
 
-Firefox_is_fast_reliable_opensource_and_respects_your_privacy_Dont_forget_to_adjust_the_settings_according_to_our_recommendations_a_hrefwebr_KEY: |
+Firefox_is_fast_reliable_opensource_and_respects_your_privacyP_Dont_forget_to_adjust_the_settings_according_to_our_recommendations_a_hrefwebr_345_KEY: |
   Firefox is fast, reliable, open-source, and respects your privacy. Don't forget to adjust the settings according to our recommendations: <a href="#webrtc"><i class="fas fa-link"></i> WebRTC</a> and <a href="#about_config"><i class="fas fa-link"></i> about:config</a> and get the <a href="#addons"><i class="fas fa-link"></i> privacy add-ons</a>.
 
-httpsfirefoxcom_KEY: |
+httpsfirefoxPcom_19_KEY: |
   https://firefox.com
 
-Website_KEY: |
+Website_8_KEY: |
   Website
 
-Forum_KEY: |
+Forum_6_KEY: |
   Forum
 
-httpswwwmozillaorgfirefoxwindows_KEY: |
+httpswwwPmozillaPorgfirefoxwindows_40_KEY: |
   https://www.mozilla.org/firefox/windows/
 
-httpswwwmozillaorgfirefoxmac_KEY: |
+httpswwwPmozillaPorgfirefoxmac_36_KEY: |
   https://www.mozilla.org/firefox/mac/
 
-httpswwwmozillaorgfirefoxlinux_KEY: |
+httpswwwPmozillaPorgfirefoxlinux_38_KEY: |
   https://www.mozilla.org/firefox/linux/
 
-httpswwwfreshportsorgwwwfirefox_KEY: |
+httpswwwPfreshportsPorgwwwfirefox_38_KEY: |
   https://www.freshports.org/www/firefox
 
-httpopenportssewwwmozillafirefox_KEY: |
+httpopenportsPsewwwmozillafirefox_39_KEY: |
   http://openports.se/www/mozilla-firefox
 
-httppkgsrcsewwwfirefox_KEY: |
+httppkgsrcPsewwwfirefox_28_KEY: |
   http://pkgsrc.se/www/firefox
 
-httpshgmozillaorgmozillacentral_KEY: |
+httpshgPmozillaPorgmozillacentral_39_KEY: |
   https://hg.mozilla.org/mozilla-central/
 
-Tor_Browser__Provides_Anonymity_KEY: |
+Tor_Browser__Provides_Anonymity_32_KEY: |
   Tor Browser - Provides Anonymity
 
-Tor_Browser_is_your_choice_if_you_need_an_extra_layer_of_anonymity_Its_a_modified_version_of_Firefox_ESR_which_comes_with_preinstalled_privacy_add_KEY: |
+Tor_Browser_is_your_choice_if_you_need_an_extra_layer_of_anonymityP_Its_a_modified_version_of_Firefox_ESR_which_comes_with_preinstalled_privacy_add_316_KEY: |
   Tor Browser is your choice if you need an extra layer of anonymity. It's a modified version of Firefox ESR, which comes with pre-installed privacy add-ons, encryption, and an advanced proxy. <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-1-myth-busting-tor">How does Tor work?</a>
 
-httpswwwtorprojectorg_KEY: |
+httpswwwPtorprojectPorg_27_KEY: |
   https://www.torproject.org/
 
-Requires_specific_software_to_access_torprojectorg_KEY: |
+Requires_specific_software_to_access_torprojectPorg_53_KEY: |
   Requires specific software to access: torproject.org
 
-httpswwwtorprojectorgdownload_KEY: |
+httpswwwPtorprojectPorgdownload_36_KEY: |
   https://www.torproject.org/download/
 
-httpstractorprojectorgprojectstor_KEY: |
+httpstracPtorprojectPorgprojectstor_40_KEY: |
   https://trac.torproject.org/projects/tor
 
-Browser_Recommendations_For_Android_KEY: |
+Browser_Recommendations_For_Android_36_KEY: |
   Browser Recommendations For Android
 
-httpswwwmozillaorgenUSfirefoxmobile_KEY: |
+httpswwwPmozillaPorgenUSfirefoxmobile_45_KEY: |
   https://www.mozilla.org/en-US/firefox/mobile/
 
-httpsfdroidorgenpackagesorgmozillafennec_fdroid_KEY: |
+httpsfdroidPorgenpackagesorgPmozillaPfennec_fdroid_58_KEY: |
   https://f-droid.org/en/packages/org.mozilla.fennec_fdroid/
 
-httpsplaygooglecomstoreappsdetailsidorgmozillafirefox_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidorgPmozillaPfirefox_65_KEY: |
   https://play.google.com/store/apps/details?id=org.mozilla.firefox
 
-httpswwwmozillaorgfirefoxallproductandroidrelease_KEY: |
+httpswwwPmozillaPorgfirefoxallproductandroidrelease_60_KEY: |
   https://www.mozilla.org/firefox/all/#product-android-release
 
-httpsgithubcommozillamobile_KEY: |
+httpsgithubPcommozillamobile_33_KEY: |
   https://github.com/mozilla-mobile
 
-httpsguardianprojectinfofdroid_KEY: |
+Tor_Browser_is_your_choice_if_you_need_an_extra_layer_of_anonymityP_Its_a_modified_version_of_Firefox_ESR_which_comes_with_preinstalled_privacy_add_315_KEY: |
+  Tor Browser is your choice if you need an extra layer of anonymity. It's a modified version of Firefox ESR, which comes with pre-installed privacy add-ons, encryption and an advanced proxy. <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-1-myth-busting-tor">How does Tor work?</a>
+
+httpsguardianprojectPinfofdroid_36_KEY: |
   https://guardianproject.info/fdroid/
 
-httpsplaygooglecomstoreappsdetailsidorgtorprojecttorbrowser_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidorgPtorprojectPtorbrowser_71_KEY: |
   https://play.google.com/store/apps/details?id=org.torproject.torbrowser
 
-httpswwwtorprojectorgdownloadandroid_KEY: |
+httpswwwPtorprojectPorgdownloadandroid_44_KEY: |
   https://www.torproject.org/download/#android
 
-httpsgitwebtorprojectorgtorbrowsergit_KEY: |
+httpsgitwebPtorprojectPorgtorbrowserPgit_46_KEY: |
   https://gitweb.torproject.org/tor-browser.git/
 
-Bromite_KEY: |
+Bromite_7_KEY: |
   Bromite
 
-Bromite_is_a_Chromiumbased_browser_with_security_enhancement_patches_from_GrapheneOS_and_builtin_adblocking_and_DNS_over_HTTPS_support_More_info_can_KEY: |
+Bromite_is_a_Chromiumbased_browser_with_security_enhancement_patches_from_GrapheneOS_and_builtin_adblocking_and_DNS_over_HTTPS_supportP_More_info_can_219_KEY: |
   Bromite is a Chromium-based browser with security enhancement patches from GrapheneOS and built-in adblocking and DNS over HTTPS support. More info can be found <a href="https://www.bromite.org/#main-features">here</a>.
 
-httpswwwbromiteorg_KEY: |
+httpswwwPbromitePorg_24_KEY: |
   https://www.bromite.org/
 
-httpswwwbromiteorgfdroid_KEY: |
+httpswwwPbromitePorgfdroid_30_KEY: |
   https://www.bromite.org/fdroid
 
-httpswwwbromiteorgdownloadbromite_KEY: |
+httpswwwPbromitePorgdownloadbromite_41_KEY: |
   https://www.bromite.org/#download-bromite
 
-httpsgithubcombromitebromite_KEY: |
+httpsgithubPcombromitebromite_34_KEY: |
   https://github.com/bromite/bromite
 
-Worth_Mentioning_for_Android_KEY: |
+Worth_Mentioning_for_Android_29_KEY: |
   Worth Mentioning for Android
 
-httpswwwstoutnercomprivacybrowser_KEY: |
+httpswwwPstoutnerPcomprivacybrowser_42_KEY: |
   https://www.stoutner.com/privacy-browser/
 
-Privacy_Browser_KEY: |
+Privacy_Browser_16_KEY: |
   Privacy Browser
 
-An_opensource_web_browser_focused_on_user_privacy_Features_include_integrated_ad_blocking_with_a_hrefhttpseasylisttoEasyLista_a_href_KEY: |
+An_opensource_web_browser_focused_on_user_privacyP_Features_include_integrated_ad_blocking_with_a_hrefhttpseasylistPtoEasyLista_a_href_307_KEY: |
   An open-source web browser focused on user privacy. Features include integrated ad blocking with <a href="https://easylist.to/">EasyList</a>, <a href="https://www.stoutner.com/privacy-browser-2-5/">SSL certificate pinning</a>, and <a href='https://guardianproject.info/apps/orbot/'>Tor Orbot proxy support.
 
-httpsplaygooglecomstoreappsdetailsidcomgoogleandroidwebviewhlen_US_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPgooglePandroidPwebviewhlen_US_82_KEY: |
   https://play.google.com/store/apps/details?id=com.google.android.webview&hl=en_US
 
-Privacy_Browser_relies_on_the_Android_System_WebView_which_needs_to_be_kept_up_to_date_to_fix_security_issues_One_can_update_WebView_by_either_install_KEY: |
+Privacy_Browser_relies_on_the_Android_System_WebView_which_needs_to_be_kept_up_to_date_to_fix_security_issuesP_One_can_update_WebView_by_either_install_223_KEY: |
   Privacy Browser relies on the Android System WebView which needs to be kept up to date to fix security issues. One can update WebView by either installing it from Google Play or Aurora Store which you can get from F-Droid.
 
-Keep_Android_WebView_uptodate_KEY: |
+Keep_Android_WebView_uptodate_32_KEY: |
   Keep Android WebView up-to-date
 
-Browser_Recommendations_For_iOS_KEY: |
+Browser_Recommendations_For_iOS_32_KEY: |
   Browser Recommendations For iOS
 
-Firefox_is_fast_reliable_opensource_and_respects_your_privacy_Note_Because_of_limitations_set_by_Apple_in_iOS_our_recommended_tweaks_cannot_be_a_KEY: |
+Firefox_is_fast_reliable_opensource_and_respects_your_privacyP_Note_Because_of_limitations_set_by_Apple_in_iOS_our_recommended_tweaks_cannot_be_a_515_KEY: |
   Firefox is fast, reliable, open-source, and respects your privacy. Note: Because of limitations set by Apple in iOS, our recommended tweaks cannot be applied. However, Firefox for iOS has an <a href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-ios">Enhanced Tracking Protection</a> feature that uses a list provided by <a href="https://disconnect.me/trackerprotection">Disconnect</a> to identify and block ad, social, and analytics trackers, as well as cryptominers and fingerprinters.
 
-httpsappsapplecomusappfirefoxprivatesafebrowserid989804926_KEY: |
+httpsappsPapplePcomusappfirefoxprivatesafebrowserid989804926_70_KEY: |
   https://apps.apple.com/us/app/firefox-private-safe-browser/id989804926
 
-httpsgithubcommozillamobilefirefoxios_KEY: |
+httpsgithubPcommozillamobilefirefoxios_45_KEY: |
   https://github.com/mozilla-mobile/firefox-ios
 
-Onion_Browser_KEY: |
+Onion_Browser_13_KEY: |
   Onion Browser
 
-Onion_Browser_is_an_opensource_browser_that_lets_you_browse_the_web_anonymously_over_the_Tor_network_on_iOS_devices_and_is_endorsed_by_the_Tor_Project_KEY: |
+Onion_Browser_is_an_opensource_browser_that_lets_you_browse_the_web_anonymously_over_the_Tor_network_on_iOS_devices_and_is_endorsed_by_the_Tor_Project_307_KEY: |
   Onion Browser is an open-source browser that lets you browse the web anonymously over the Tor network on iOS devices and is endorsed by the Tor Project. Warning: there are certain anonymity-related <a href="https://onionbrowser.com/#security-advisories">issues</a> with Onion Browser due to iOS limitations.
 
-httpsonionbrowsercom_KEY: |
+httpsonionbrowserPcom_25_KEY: |
   https://onionbrowser.com/
 
-httpsappsapplecomusapponionbrowserid519296448_KEY: |
+httpsappsPapplePcomusapponionbrowserid519296448_55_KEY: |
   https://apps.apple.com/us/app/onion-browser/id519296448
 
-httpsgithubcomOnionBrowserOnionBrowser_KEY: |
+httpsgithubPcomOnionBrowserOnionBrowser_44_KEY: |
   https://github.com/OnionBrowser/OnionBrowser
 
-DuckDuckGo_Privacy_Browser_KEY: |
+DuckDuckGo_Privacy_Browser_26_KEY: |
   DuckDuckGo Privacy Browser
 
-DuckDuckGo_Privacy_Browser_is_an_opensource_web_browser_that_has_builtin_ad_and_tracker_blocking_and_utilizes_a_hrefhttpstosdrorgToSDRa_KEY: |
+DuckDuckGo_Privacy_Browser_is_an_opensource_web_browser_that_has_builtin_ad_and_tracker_blocking_and_utilizes_a_hrefhttpstosdrPorgToSDRa_204_KEY: |
   DuckDuckGo Privacy Browser is an open-source web browser that has built-in ad and tracker blocking and utilizes <a href="https://tosdr.org/">ToS;DR</a> to rate the privacy policies of the sites you visit.
 
-httpsduckduckgocomapp_KEY: |
+httpsduckduckgoPcomapp_26_KEY: |
   https://duckduckgo.com/app
 
-httpsappsapplecomusappduckduckgoprivacybrowserid663592361_KEY: |
+httpsappsPapplePcomusappduckduckgoprivacybrowserid663592361_68_KEY: |
   https://apps.apple.com/us/app/duckduckgo-privacy-browser/id663592361
 
-httpsgithubcomduckduckgoiOS_KEY: |
+httpsgithubPcomduckduckgoiOS_33_KEY: |
   https://github.com/duckduckgo/iOS
 
-Worth_Mentioning_for_iOS_KEY: |
+Worth_Mentioning_for_iOS_25_KEY: |
   Worth Mentioning for iOS
 
-httpssnowhazecomenindexhtml_KEY: |
+httpssnowhazePcomenindexPhtml_35_KEY: |
   https://snowhaze.com/en/index.html
 
-SnowHaze_KEY: |
+SnowHaze_9_KEY: |
   SnowHaze
 
-An_opensource_web_browser_with_builtin_ad_tracker_cookie_and_fingerprint_blocking_all_customizable_on_a_persite_basis_KEY: |
+An_opensource_web_browser_with_builtin_ad_tracker_cookie_and_fingerprint_blocking_all_customizable_on_a_persite_basisP_126_KEY: |
   An open-source web browser with built-in ad, tracker, cookie, and fingerprint blocking, all customizable on a per-site basis.
 
-Browser_Fingerprint__Is_your_browser_configuration_unique_KEY: |
+Browser_Fingerprint__Is_your_browser_configuration_uniqueQ_60_KEY: |
   Browser Fingerprint - Is your browser configuration unique?
 
-Your_Browser_sends_information_that_makes_you_unique_amongst_millions_of_users_and_therefore_easy_to_identify_KEY: |
+Your_Browser_sends_information_that_makes_you_unique_amongst_millions_of_users_and_therefore_easy_to_identifyP_111_KEY: |
   Your Browser sends information that makes you unique amongst millions of users and therefore easy to identify.
 
-When_you_visit_a_web_page_your_browser_voluntarily_sends_information_about_its_configuration_such_as_available_fonts_browser_type_and_addons_If_t_KEY: |
+When_you_visit_a_web_page_your_browser_voluntarily_sends_information_about_its_configuration_such_as_available_fonts_browser_type_and_addonsP_If_t_390_KEY: |
   When you visit a web page, your browser voluntarily sends information about its configuration, such as available fonts, browser type, and add-ons. If this combination of information is unique, it may be possible to identify and track you without using cookies. EFF created a Tool called <a href="https://panopticlick.eff.org/">Panopticlick</a> to test your browser to see how unique it is.
 
-httpspanopticlickefforg_KEY: |
+httpspanopticlickPeffPorg_30_KEY: |
   https://panopticlick.eff.org/
 
-Test_your_Browser_now_KEY: |
+Test_your_Browser_now_22_KEY: |
   Test your Browser now
 
-You_need_to_find_what_strongmost_browsersstrong_are_reporting_and_then_use_those_variables_to_bring_your_browser_in_the_same_population_This_mea_KEY: |
+You_need_to_find_what_strongmost_browsersstrong_are_reporting_and_then_use_those_variables_to_bring_your_browser_in_the_same_populationP_This_mea_650_KEY: |
   You need to find what <strong>most browsers</strong> are reporting, and then use those variables to bring your browser in the same population. This means having the same fonts, plugins, and extensions installed as the large installed base. You should have a <a href="https://addons.mozilla.org/firefox/addon/uaswitcher/">spoofed user-agent string</a> to match what the large userbase has. You need to have the same settings enabled and disabled, such as DNT and WebGL. You need your browser to look as common as everyone else. Disabling JavaScript, using Linux, or even using the Tor Browser Bundle, will make your browser stick out from the masses.
 
-Modern_web_browsers_have_not_been_architected_to_assure_personal_web_privacy_Rather_than_worrying_about_being_fingerprinted_it_seems_more_practical_t_KEY: |
+Modern_web_browsers_have_not_been_architected_to_assure_personal_web_privacyP_Rather_than_worrying_about_being_fingerprinted_it_seems_more_practical_t_417_KEY: |
   Modern web browsers have not been architected to assure personal web privacy. Rather than worrying about being fingerprinted, it seems more practical to use <a href="#addons"><i class="fas fa-link"></i> free software plugins</a> like Privacy Badger and uBlock Origin. They not only respect your freedom, but your privacy also. You can get much further with these than trying to manipulate your browser's fingerprint.
 
-Firefox_Addon_CanvasBlocker_KEY: |
+Firefox_Addon_CanvasBlocker_29_KEY: |
   Firefox Addon: CanvasBlocker
 
-httpsaddonsmozillaorgfirefoxaddoncanvasblocker_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddoncanvasblocker_56_KEY: |
   https://addons.mozilla.org/firefox/addon/canvasblocker/
 
-addonsmozillaorg_KEY: |
+addonsPmozillaPorg_19_KEY: |
   addons.mozilla.org
 
-strongCanvasBlockerstrong_allows_users_to_prevent_websites_from_using_some_Javascript_APIs_to_fingerprint_them_Users_can_choose_to_block_the_APIs_KEY: |
+strongCanvasBlockerstrong_allows_users_to_prevent_websites_from_using_some_Javascript_APIs_to_fingerprint_themP_Users_can_choose_to_block_the_APIs_280_KEY: |
   <strong>CanvasBlocker</strong> allows users to prevent websites from using some Javascript APIs to fingerprint them. Users can choose to block the APIs entirely on some or all websites (which may break some websites) or just block or fake its fingerprinting-friendly readout API.
 
-Related_Information_KEY: |
+Related_Information_20_KEY: |
   Related Information
 
-httpspanopticlickefforgstaticbrowseruniquenesspdf_KEY: |
+httpspanopticlickPeffPorgstaticbrowseruniquenessPpdf_59_KEY: |
   https://panopticlick.eff.org/static/browser-uniqueness.pdf
 
-How_Unique_Is_Your_Web_Browser_Peter_Eckersley_EFF_KEY: |
+How_Unique_Is_Your_Web_BrowserQ_Peter_Eckersley_EFFP_54_KEY: |
   How Unique Is Your Web Browser? Peter Eckersley, EFF.
 
-Our_Firefox_privacy_addons_section_KEY: |
+Our_Firefox_privacy_addons_sectionP_37_KEY: |
   Our Firefox privacy add-ons section.
 
-httpswwwbrowserleakscom_KEY: |
+httpswwwPbrowserleaksPcom_30_KEY: |
   https://www.browserleaks.com/
 
-Web_browser_security_testing_tools_that_tell_you_what_exactly_personal_identity_data_may_be_leaked_without_any_permissions_when_you_surf_the_Internet_KEY: |
+Web_browser_security_testing_tools_that_tell_you_what_exactly_personal_identity_data_may_be_leaked_without_any_permissions_when_you_surf_the_InternetP_150_KEY: |
   Web browser security testing tools that tell you what exactly personal identity data may be leaked without any permissions when you surf the Internet.
 
-WebRTC_IP_Leak_Test__Is_your_IP_address_leaking_KEY: |
+WebRTC_IP_Leak_Test__Is_your_IP_address_leakingQ_50_KEY: |
   WebRTC IP Leak Test - Is your IP address leaking?
 
-WebRTC_is_a_new_communication_protocol_that_relies_on_JavaScript_that_can_leak_your_actual_IP_address_from_behind_your_VPN_KEY: |
+WebRTC_is_a_new_communication_protocol_that_relies_on_JavaScript_that_can_leak_your_actual_IP_address_from_behind_your_VPNP_124_KEY: |
   WebRTC is a new communication protocol that relies on JavaScript that can leak your actual IP address from behind your VPN.
 
-While_software_like_NoScript_prevents_this_its_probably_a_good_idea_to_block_this_protocol_directly_as_well_just_to_be_safe_KEY: |
+While_software_like_NoScript_prevents_this_its_probably_a_good_idea_to_block_this_protocol_directly_as_well_just_to_be_safeP_128_KEY: |
   While software like NoScript prevents this, it's probably a good idea to block this protocol directly as well, just to be safe.
 
-httpsipleaknet_KEY: |
+httpsipleakPnet_19_KEY: |
   https://ipleak.net
 
-How_to_disable_WebRTC_in_Firefox_KEY: |
+How_to_disable_WebRTC_in_FirefoxQ_34_KEY: |
   How to disable WebRTC in Firefox?
 
-In_short_Set_mediapeerconnectionenabled_to_false_in_aboutconfig_KEY: |
+In_short_Set_mediaPpeerconnectionPenabled_to_false_in_aboutconfigP_74_KEY: |
   In short: Set "media.peerconnection.enabled" to "false" in "about:config".
 
-Explained_KEY: |
+Explained_11_KEY: |
   Explained:
 
-Enter_aboutconfig_in_the_firefox_address_bar_and_press_enter_KEY: |
+Enter_aboutconfig_in_the_firefox_address_bar_and_press_enterP_65_KEY: |
   Enter "about:config" in the firefox address bar and press enter.
 
-Press_the_button_Ill_be_careful_I_promise!_KEY: |
+Press_the_button_Ill_be_careful_I_promiseE_47_KEY: |
   Press the button "I'll be careful, I promise!"
 
-Search_for_mediapeerconnectionenabled_KEY: |
+Search_for_mediaPpeerconnectionPenabled_42_KEY: |
   Search for "media.peerconnection.enabled"
 
-Double_click_the_entry_the_column_Value_should_now_be_false_KEY: |
+Double_click_the_entry_the_column_Value_should_now_be_false_65_KEY: |
   Double click the entry, the column "Value" should now be "false"
 
-Done_Do_the_WebRTC_leak_test_again_KEY: |
+DoneP_Do_the_WebRTC_leak_test_againP_37_KEY: |
   Done. Do the WebRTC leak test again.
 
-If_you_want_to_make_sure_every_single_WebRTCrelated_setting_is_really_disabled_change_these_settings_KEY: |
+If_you_want_to_make_sure_every_single_WebRTCrelated_setting_is_really_disabled_change_these_settings_104_KEY: |
   If you want to make sure every single WebRTC-related setting is really disabled, change these settings:
 
-Now_you_can_be_100_sure_WebRTC_is_disabled_KEY: |
+Now_you_can_be_100_sure_WebRTC_is_disabledP_45_KEY: |
   Now you can be 100% sure WebRTC is disabled.
 
-Test_your_Browser_again_KEY: |
+Test_your_Browser_again_24_KEY: |
   Test your Browser again
 
-How_to_fix_the_WebRTC_Leak_in_Google_Chrome_KEY: |
+How_to_fix_the_WebRTC_Leak_in_Google_ChromeQ_45_KEY: |
   How to fix the WebRTC Leak in Google Chrome?
 
-WebRTC_cannot_be_fully_disabled_in_Chrome_however_it_is_possible_to_change_its_routing_settings_and_prevent_leaks_using_an_extension_Two_opensour_KEY: |
+WebRTC_cannot_be_fully_disabled_in_Chrome_however_it_is_possible_to_change_its_routing_settings_and_prevent_leaks_using_an_extensionP_Two_opensour_552_KEY: |
   WebRTC cannot be fully disabled in Chrome; however, it is possible to change its routing settings (and prevent leaks) using an extension. Two open-source solutions include <a href="https://chrome.google.com/webstore/detail/webrtc-leak-prevent/eiadekoaikejlgdbkbdfeijglgfdalml">WebRTC Leak Prevent</a> (options may need to be changed depending on the scenario), and <a href="https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm">uBlock Origin</a> (select "Prevent WebRTC from leaking local IP addresses" in Settings).
 
-What_about_other_browsers_KEY: |
+What_about_other_browsersQ_27_KEY: |
   What about other browsers?
 
-Chrome_on_iOS_Internet_Explorer_and_Safari_does_not_implement_WebRTC_yet_KEY: |
+Chrome_on_iOS_Internet_Explorer_and_Safari_does_not_implement_WebRTC_yetP_74_KEY: |
   Chrome on iOS, Internet Explorer and Safari does not implement WebRTC yet.
 
-But_we_recommend_using_Firefox_on_all_devices_KEY: |
+But_we_recommend_using_Firefox_on_all_devicesP_47_KEY: |
   But we recommend using Firefox on all devices.
 
-Recommended_Browser_Addons_KEY: |
+Recommended_Browser_Addons_28_KEY: |
   Recommended Browser Add-ons
 
-Improve_your_privacy_with_these_browser_addons_KEY: |
+Improve_your_privacy_with_these_browser_addonsP_49_KEY: |
   Improve your privacy with these browser add-ons.
 
-uBlock_Origin_Block_Ads_and_Trackers_KEY: |
+uBlock_Origin_Block_Ads_and_Trackers_37_KEY: |
   uBlock Origin: Block Ads and Trackers
 
-stronguBlock_Originstrong_is_an_efficient_a_hrefhttpsgithubcomgorhilluBlockwikiBlockingmodewidespectrum_blockera_thats_easy_on_me_KEY: |
+stronguBlock_Originstrong_is_an_efficient_a_hrefhttpsgithubPcomgorhilluBlockwikiBlockingmodewidespectrum_blockera_thats_easy_on_me_310_KEY: |
   <strong>uBlock Origin</strong> is an efficient <a href=https://github.com/gorhill/uBlock/wiki/Blocking-mode>wide-spectrum blocker</a> that's easy on memory, and yet can load and enforce thousands more filters than other popular blockers out there. It has no monetization strategy and is completely open source.
 
-httpsaddonsmozillaorgfirefoxaddonublockorigin_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddonublockorigin_55_KEY: |
   https://addons.mozilla.org/firefox/addon/ublock-origin/
 
-httpsaddonsmozillaorgenUSfirefoxaddonublockorigin_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonublockorigin_61_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/
 
-httpschromegooglecomwebstoredetailublockorigincjpalhdlnbpafiamejdnhcphjbkeiagm_KEY: |
+httpschromePgooglePcomwebstoredetailublockorigincjpalhdlnbpafiamejdnhcphjbkeiagm_88_KEY: |
   https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm
 
-httpsaddonsoperacomenextensionsdetailsublock_KEY: |
+httpsaddonsPoperaPcomenextensionsdetailsublock_54_KEY: |
   https://addons.opera.com/en/extensions/details/ublock/
 
-httpswwwmicrosoftcomenuspublockorigin9nblggh444l4_KEY: |
+httpswwwPmicrosoftPcomenuspublockorigin9nblggh444l4_60_KEY: |
   https://www.microsoft.com/en-us/p/ublock-origin/9nblggh444l4
 
-httpsgithubcomgorhilluBlock_KEY: |
+httpsgithubPcomgorhilluBlock_34_KEY: |
   https://github.com/gorhill/uBlock/
 
-Cookie_AutoDelete_Automatically_Delete_Cookies_KEY: |
+Cookie_AutoDelete_Automatically_Delete_Cookies_47_KEY: |
   Cookie AutoDelete: Automatically Delete Cookies
 
-strongCookie_AutoDeletestrong_automatically_removes_cookies_when_they_are_no_longer_used_by_open_browser_tabs_With_the_cookies_lingering_session_KEY: |
+strongCookie_AutoDeletestrong_automatically_removes_cookies_when_they_are_no_longer_used_by_open_browser_tabsP_With_the_cookies_lingering_session_214_KEY: |
   <strong>Cookie AutoDelete</strong> automatically removes cookies when they are no longer used by open browser tabs. With the cookies, lingering sessions, as well as information used to spy on you, will be expunged.
 
-httpsaddonsmozillaorgfirefoxaddoncookieautodelete_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddoncookieautodelete_59_KEY: |
   https://addons.mozilla.org/firefox/addon/cookie-autodelete/
 
-httpsaddonsmozillaorgenUSfirefoxaddoncookieautodelete_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddoncookieautodelete_64_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/cookie-autodelete
 
-httpschromegooglecomwebstoredetailcookieautodeletefhcgjolkccmbidfldomjliifgaodjagh_KEY: |
+httpschromePgooglePcomwebstoredetailcookieautodeletefhcgjolkccmbidfldomjliifgaodjagh_92_KEY: |
   https://chrome.google.com/webstore/detail/cookie-autodelete/fhcgjolkccmbidfldomjliifgaodjagh
 
-httpsgithubcomCookieAutoDeleteCookieAutoDelete_KEY: |
+httpsgithubPcomCookieAutoDeleteCookieAutoDelete_54_KEY: |
   https://github.com/Cookie-AutoDelete/Cookie-AutoDelete
 
-HTTPS_Everywhere_Secure_Connections_KEY: |
+HTTPS_Everywhere_Secure_Connections_36_KEY: |
   HTTPS Everywhere: Secure Connections
 
-strongHTTPS_Everywherestrong_encrypts_your_communications_with_many_major_websites_making_your_browsing_more_secure_A_collaboration_between_The__KEY: |
+strongHTTPS_Everywherestrong_encrypts_your_communications_with_many_major_websites_making_your_browsing_more_secureP_A_collaboration_between_The__202_KEY: |
   <strong>HTTPS Everywhere</strong> encrypts your communications with many major websites, making your browsing more secure. A collaboration between The Tor Project and the Electronic Frontier Foundation.
 
-httpswwwefforghttpseverywhere_KEY: |
+httpswwwPeffPorghttpseverywhere_36_KEY: |
   https://www.eff.org/https-everywhere
 
-httpsaddonsmozillaorgenUSfirefoxaddonhttpseverywhere_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonhttpseverywhere_63_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/https-everywhere
 
-httpschromegooglecomwebstoredetailhttpseverywheregcbommkclmclpchllfjekcdonpmejbdp_KEY: |
+httpschromePgooglePcomwebstoredetailhttpseverywheregcbommkclmclpchllfjekcdonpmejbdp_91_KEY: |
   https://chrome.google.com/webstore/detail/https-everywhere/gcbommkclmclpchllfjekcdonpmejbdp
 
-httpsaddonsoperacomenextensionsdetailshttpseverywhere_KEY: |
+httpsaddonsPoperaPcomenextensionsdetailshttpseverywhere_63_KEY: |
   https://addons.opera.com/en/extensions/details/https-everywhere
 
-httpsgithubcomEFForghttpseverywhere_KEY: |
+httpsgithubPcomEFForghttpseverywhere_42_KEY: |
   https://github.com/EFForg/https-everywhere
 
-Decentraleyes_Block_Content_Delivery_Networks_KEY: |
+Decentraleyes_Block_Content_Delivery_Networks_46_KEY: |
   Decentraleyes: Block Content Delivery Networks
 
-strongDecentraleyesstrong_emulates_Content_Delivery_Networks_locally_by_intercepting_requests_finding_the_required_resource_and_injecting_it_int_KEY: |
+strongDecentraleyesstrong_emulates_Content_Delivery_Networks_locally_by_intercepting_requests_finding_the_required_resource_and_injecting_it_int_258_KEY: |
   <strong>Decentraleyes</strong> emulates Content Delivery Networks locally by intercepting requests, finding the required resource, and injecting it into the environment. This all happens instantaneously, automatically, and no prior configuration is required.
 
-httpsdecentraleyesorg_KEY: |
+httpsdecentraleyesPorg_26_KEY: |
   https://decentraleyes.org/
 
-httpsaddonsmozillaorgenUSfirefoxaddondecentraleyes_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddondecentraleyes_60_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/decentraleyes
 
-httpschromegooglecomwebstoredetaildecentraleyesldpochfccmkkmhdbclfhpagapcfdljkj_KEY: |
+httpschromePgooglePcomwebstoredetaildecentraleyesldpochfccmkkmhdbclfhpagapcfdljkj_88_KEY: |
   https://chrome.google.com/webstore/detail/decentraleyes/ldpochfccmkkmhdbclfhpagapcfdljkj
 
-httpsaddonsoperacomenextensionsdetailsdecentraleyes_KEY: |
+httpsaddonsPoperaPcomenextensionsdetailsdecentraleyes_60_KEY: |
   https://addons.opera.com/en/extensions/details/decentraleyes
 
-httpsgitsynzioSynzvatodecentraleyes_KEY: |
+httpsgitPsynzPioSynzvatodecentraleyes_42_KEY: |
   https://git.synz.io/Synzvato/decentraleyes
 
-Terms_of_Service_Didnt_Read_Be_Informed_KEY: |
+Terms_of_Service_Didnt_Read_Be_Informed_42_KEY: |
   Terms of Service; Didn’t Read: Be Informed
 
-strongTerms_of_Service_Didnt_Readstrong_is_an_addon_that_aims_to_fix_how_I_have_read_and_agree_to_the_Terms_is_the_biggest_lie_on_the_web_by_g_KEY: |
+strongTerms_of_Service_Didnt_Readstrong_is_an_addon_that_aims_to_fix_how_I_have_read_and_agree_to_the_Terms_is_the_biggest_lie_on_the_web_by_g_359_KEY: |
   <strong>Terms of Service; Didn’t Read</strong> is an addon that aims to fix how “I have read and agree to the Terms” is the biggest lie on the web by grading websites based on their terms of service agreements and privacy policies. It also gives short summaries of those agreements. The analysis and ratings are done transparently by a community of reviewers.
 
-httpstosdrorg_KEY: |
+httpstosdrPorg_18_KEY: |
   https://tosdr.org/
 
-httpsaddonsmozillaorgenUSfirefoxaddontermsofservicedidntread_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddontermsofservicedidntread_75_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/terms-of-service-didnt-read/
 
-httpschromegooglecomwebstoredetailtermsofservicedidnE28099trhjdoplcnndgiblooccencgcggcoihigg_KEY: |
+httpschromePgooglePcomwebstoredetailtermsofservicedidnE28099trhjdoplcnndgiblooccencgcggcoihigg_108_KEY: |
   https://chrome.google.com/webstore/detail/terms-of-service-didn%E2%80%99t-r/hjdoplcnndgiblooccencgcggcoihigg
 
-httpsaddonsoperacomenextensionsdetailstermsofservicedidntread_KEY: |
+httpsaddonsPoperaPcomenextensionsdetailstermsofservicedidntread_74_KEY: |
   https://addons.opera.com/en/extensions/details/terms-of-service-didnt-read
 
-httpsgithubcomtosdr_KEY: |
+httpsgithubPcomtosdr_25_KEY: |
   https://github.com/tosdr/
 
-Snowflake_KEY: |
+Snowflake_9_KEY: |
   Snowflake
 
-strongSnowflakestrong_is_a_new_a_hrefhttps2019wwwtorprojectorgdocspluggabletransportshtmlenpluggable_transporta_from_the_Tor_Proj_KEY: |
+strongSnowflakestrong_is_a_new_a_hrefhttps2019PwwwPtorprojectPorgdocspluggabletransportsPhtmlPenpluggable_transporta_from_the_Tor_Proj_613_KEY: |
   <strong>Snowflake</strong> is a new <a href=https://2019.www.torproject.org/docs/pluggable-transports.html.en>pluggable transport</a> from the Tor Project. If you have an uncensored connection, running this extension volunteers your connection to be used as a Snowflake proxy to help users unable to connect to the Tor network. Your IP will not be visible to the sites users visit using your proxy, as this extension will not make you an exit node. If your access to the Tor network is blocked, this extension will not assist you, and you should use the <a href=https://www.torproject.org>Tor Browser</a> instead.
 
-httpssnowflaketorprojectorg_KEY: |
+httpssnowflakePtorprojectPorg_32_KEY: |
   https://snowflake.torproject.org
 
-httpsaddonsmozillaorgenUSfirefoxaddontorprojectsnowflake_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddontorprojectsnowflake_67_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/torproject-snowflake
 
-httpschromegooglecomwebstoredetailsnowflakemafpmfcccpbjnhfhjnllmmalhifmlcie_KEY: |
+httpschromePgooglePcomwebstoredetailsnowflakemafpmfcccpbjnhfhjnllmmalhifmlcie_84_KEY: |
   https://chrome.google.com/webstore/detail/snowflake/mafpmfcccpbjnhfhjnllmmalhifmlcie
 
-httpsgitwebtorprojectorgpluggabletransportssnowflakegit_KEY: |
+httpsgitwebPtorprojectPorgpluggabletransportssnowflakePgit_64_KEY: |
   https://gitweb.torproject.org/pluggable-transports/snowflake.git
 
-Privacy_Badger_Stop_Tracking_KEY: |
+Privacy_Badger_Stop_Tracking_29_KEY: |
   Privacy Badger: Stop Tracking
 
-strongPrivacy_Badgerstrong_is_a_browser_addon_that_stops_advertisers_and_other_thirdparty_trackers_from_secretly_tracking_where_you_go_and_what__KEY: |
+strongPrivacy_Badgerstrong_is_a_browser_addon_that_stops_advertisers_and_other_thirdparty_trackers_from_secretly_tracking_where_you_go_and_what__232_KEY: |
   <strong>Privacy Badger</strong> is a browser add-on that stops advertisers and other third-party trackers from secretly tracking where you go and what pages you look at on the web. Privacy Badger learns about trackers as you browse.
 
-httpswwwefforgprivacybadger_KEY: |
+httpswwwPeffPorgprivacybadger_33_KEY: |
   https://www.eff.org/privacybadger
 
-httpsaddonsmozillaorgenUSfirefoxaddonprivacybadger17_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonprivacybadger17_63_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17
 
-httpschromegooglecomwebstoredetailprivacybadgerpkehgijcmpdhfbdbbnkijodmdjhbjlgp_KEY: |
+httpschromePgooglePcomwebstoredetailprivacybadgerpkehgijcmpdhfbdbbnkijodmdjhbjlgp_89_KEY: |
   https://chrome.google.com/webstore/detail/privacy-badger/pkehgijcmpdhfbdbbnkijodmdjhbjlgp
 
-httpsaddonsoperacomenextensionsdetailsprivacybadger_KEY: |
+httpsaddonsPoperaPcomenextensionsdetailsprivacybadger_62_KEY: |
   https://addons.opera.com/en/extensions/details/privacy-badger/
 
-httpsgithubcomEFForgprivacybadger_KEY: |
+httpsgithubPcomEFForgprivacybadger_39_KEY: |
   https://github.com/EFForg/privacybadger
 
-For_Power_Users_Only_KEY: |
+For_Power_Users_Only_21_KEY: |
   For Power Users Only
 
-These_addons_require_quite_a_lot_of_interaction_from_the_user_Some_sites_will_not_work_properly_until_you_have_configured_the_addons_KEY: |
+These_addons_require_quite_a_lot_of_interaction_from_the_userP_Some_sites_will_not_work_properly_until_you_have_configured_the_addonsP_136_KEY: |
   These addons require quite a lot of interaction from the user. Some sites will not work properly until you have configured the add-ons.
 
-uMatrix_Stop_CrossSite_Requests_KEY: |
+uMatrix_Stop_CrossSite_Requests_33_KEY: |
   uMatrix: Stop Cross-Site Requests
 
-stronguMatrixstrong_gives_you_control_over_the_requests_that_websites_make_to_other_websites_Many_websites_integrate_features_which_let_other_web_KEY: |
+stronguMatrixstrong_gives_you_control_over_the_requests_that_websites_make_to_other_websitesP_Many_websites_integrate_features_which_let_other_web_218_KEY: |
   <strong>uMatrix</strong> gives you control over the requests that websites make to other websites. Many websites integrate features which let other websites track you, such as Facebook Like Buttons or Google Analytics.
 
-httpsaddonsmozillaorgfirefoxaddonumatrix_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddonumatrix_49_KEY: |
   https://addons.mozilla.org/firefox/addon/umatrix/
 
-httpsaddonsmozillaorgenUSfirefoxaddonumatrix_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonumatrix_54_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/umatrix
 
-httpschromegooglecomwebstoredetailumatrixogfcmafjalglgifnmanfmnieipoejdcf_KEY: |
+httpschromePgooglePcomwebstoredetailumatrixogfcmafjalglgifnmanfmnieipoejdcf_82_KEY: |
   https://chrome.google.com/webstore/detail/umatrix/ogfcmafjalglgifnmanfmnieipoejdcf
 
-httpsaddonsoperacomenextensionsdetailsumatrix_KEY: |
+httpsaddonsPoperaPcomenextensionsdetailsumatrix_54_KEY: |
   https://addons.opera.com/en/extensions/details/umatrix
 
-httpsgithubcomgorhilluMatrix_KEY: |
+httpsgithubPcomgorhilluMatrix_34_KEY: |
   https://github.com/gorhill/uMatrix
 
-NoScript_Security_Suite_Be_in_total_control_KEY: |
+NoScript_Security_Suite_Be_in_total_control_44_KEY: |
   NoScript Security Suite: Be in total control
 
-strongNoScriptstrong_is_a_highly_customizable_plugin_to_selectively_allow_JavaScript_Java_and_Flash_to_run_only_on_websites_you_trust_Not_for_c_KEY: |
+strongNoScriptstrong_is_a_highly_customizable_plugin_to_selectively_allow_JavaScript_Java_and_Flash_to_run_only_on_websites_you_trustP_Not_for_c_209_KEY: |
   <strong>NoScript</strong> is a highly customizable plugin to selectively allow JavaScript, Java, and Flash to run only on websites you trust. Not for casual users, it requires technical knowledge to configure.
 
-httpsaddonsmozillaorgfirefoxaddonnoscript_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddonnoscript_50_KEY: |
   https://addons.mozilla.org/firefox/addon/noscript/
 
-httpsaddonsmozillaorgenUSfirefoxaddonnoscript_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonnoscript_55_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/noscript
 
-httpschromegooglecomwebstoredetailnoscriptdoojmbjmlfjjnbmnoijecmcbfeoakpjm_KEY: |
+httpschromePgooglePcomwebstoredetailnoscriptdoojmbjmlfjjnbmnoijecmcbfeoakpjm_83_KEY: |
   https://chrome.google.com/webstore/detail/noscript/doojmbjmlfjjnbmnoijecmcbfeoakpjm
 
-httpsgithubcomhackademixnoscript_KEY: |
+httpsgithubPcomhackademixnoscript_38_KEY: |
   https://github.com/hackademix/noscript
 
-Firefox_Privacy_Related_aboutconfig_Tweaks_KEY: |
+Firefox_Privacy_Related_aboutconfig_Tweaks_47_KEY: |
   Firefox: Privacy Related "about:config" Tweaks
 
-This_is_a_collection_of_privacyrelated_strongaboutconfigstrong_tweaks_Well_show_you_how_to_enhance_the_privacy_of_your_Firefox_browser_KEY: |
+This_is_a_collection_of_privacyrelated_strongaboutconfigstrong_tweaksP_Well_show_you_how_to_enhance_the_privacy_of_your_Firefox_browserP_145_KEY: |
   This is a collection of privacy-related <strong>about:config</strong> tweaks. We'll show you how to enhance the privacy of your Firefox browser.
 
-Preparation_KEY: |
+Preparation_13_KEY: |
   Preparation:
 
-Follow_the_instructions_below_KEY: |
+Follow_the_instructions_belowPPP_33_KEY: |
   Follow the instructions below...
 
-Getting_started_KEY: |
+Getting_started_17_KEY: |
   Getting started:
 
-A_result_of_the_a_hrefhttpswikimozillaorgSecurityTor_UpliftTor_Uplifta_effort_this_preference_isolates_all_browser_identifier_sources__KEY: |
+A_result_of_the_a_hrefhttpswikiPmozillaPorgSecurityTor_UpliftTor_Uplifta_effort_this_preference_isolates_all_browser_identifier_sources__353_KEY: |
   A result of the <a href="https://wiki.mozilla.org/Security/Tor_Uplift">Tor Uplift</a> effort, this preference isolates all browser identifier sources (e.g. cookies) to the first party domain, with the goal of preventing tracking across different domains. (Don't do this if you are using the Firefox Addon "Cookie AutoDelete" with Firefox v58 or below.)
 
-A_result_of_the_a_hrefhttpswikimozillaorgSecurityTor_UpliftTor_Uplifta_effort_this_preference_makes_Firefox_more_resistant_to_browser_f_KEY: |
+A_result_of_the_a_hrefhttpswikiPmozillaPorgSecurityTor_UpliftTor_Uplifta_effort_this_preference_makes_Firefox_more_resistant_to_browser_f_166_KEY: |
   A result of the <a href="https://wiki.mozilla.org/Security/Tor_Uplift">Tor Uplift</a> effort, this preference makes Firefox more resistant to browser fingerprinting.
 
-FF67_Blocks_Fingerprinting_KEY: |
+FF67_Blocks_Fingerprinting_30_KEY: |
   [FF67+] Blocks Fingerprinting
 
-FF67_Blocks_CryptoMining_KEY: |
+FF67_Blocks_CryptoMining_28_KEY: |
   [FF67+] Blocks CryptoMining
 
-This_is_Mozillas_new_builtin_tracking_protection_It_uses_Disconnectme_filter_list_which_is_redundant_if_you_are_already_using_uBlock_Origin_3rd_pa_KEY: |
+This_is_Mozillas_new_builtin_tracking_protectionP_It_uses_DisconnectPme_filter_list_which_is_redundant_if_you_are_already_using_uBlock_Origin_3rd_pa_246_KEY: |
   This is Mozilla's new built-in tracking protection. It uses Disconnect.me filter list, which is redundant if you are already using uBlock Origin 3rd party filters, therefore you should set it to false if you are using the add-on functionalities.
 
-The_attribute_would_be_useful_for_letting_websites_track_visitors_clicks_KEY: |
+The_attribute_would_be_useful_for_letting_websites_track_visitors_clicksP_75_KEY: |
   The attribute would be useful for letting websites track visitors' clicks.
 
-Even_with_Firefox_set_to_not_remember_history_your_closed_tabs_are_stored_temporarily_at_Menu_gt_History_gt_Recently_Closed_Tabs_KEY: |
+Even_with_Firefox_set_to_not_remember_history_your_closed_tabs_are_stored_temporarily_at_Menu_gt_History_gt_Recently_Closed_TabsP_137_KEY: |
   Even with Firefox set to not remember history, your closed tabs are stored temporarily at Menu -&gt; History -&gt; Recently Closed Tabs.
 
-Disable_preloading_of_autocomplete_URLs_Firefox_preloads_URLs_that_autocomplete_when_a_user_types_into_the_address_bar_which_is_a_concern_if_URLs_are_KEY: |
+Disable_preloading_of_autocomplete_URLsP_Firefox_preloads_URLs_that_autocomplete_when_a_user_types_into_the_address_bar_which_is_a_concern_if_URLs_are_204_KEY: |
   Disable preloading of autocomplete URLs. Firefox preloads URLs that autocomplete when a user types into the address bar, which is a concern if URLs are suggested that the user does not want to connect to.
 
-httpswwwghacksnet20170724disablepreloadingfirefoxautocompleteurls_KEY: |
+httpswwwPghacksPnet20170724disablepreloadingfirefoxautocompleteurls_79_KEY: |
   https://www.ghacks.net/2017/07/24/disable-preloading-firefox-autocomplete-urls/
 
-Source_KEY: |
+Source_7_KEY: |
   Source
 
-Disable_that_websites_can_get_notifications_if_you_copy_paste_or_cut_something_from_a_web_page_and_it_lets_them_know_which_part_of_the_page_had_been_KEY: |
+Disable_that_websites_can_get_notifications_if_you_copy_paste_or_cut_something_from_a_web_page_and_it_lets_them_know_which_part_of_the_page_had_been_162_KEY: |
   Disable that websites can get notifications if you copy, paste, or cut something from a web page, and it lets them know which part of the page had been selected.
 
-Disables_playback_of_DRMcontrolled_HTML5_content_which_if_enabled_automatically_downloads_the_Widevine_Content_Decryption_Module_provided_by_Google_KEY: |
+Disables_playback_of_DRMcontrolled_HTML5_content_which_if_enabled_automatically_downloads_the_Widevine_Content_Decryption_Module_provided_by_Google_156_KEY: |
   Disables playback of DRM-controlled HTML5 content, which, if enabled, automatically downloads the Widevine Content Decryption Module provided by Google Inc.
 
-httpssupportmozillaorgkbenabledrmw_optoutofcdmplaybackuninstallcdmsandstopallcdmdownloads_KEY: |
+httpssupportPmozillaPorgkbenabledrmw_optoutofcdmplaybackuninstallcdmsandstopallcdmdownloads_110_KEY: |
   https://support.mozilla.org/kb/enable-drm#w_opt-out-of-cdm-playback-uninstall-cdms-and-stop-all-cdm-downloads
 
-Details_KEY: |
+Details_8_KEY: |
   Details
 
-DRMcontrolled_content_that_requires_the_Adobe_Flash_or_Microsoft_Silverlight_NPAPI_plugins_will_still_play_if_installed_and_enabled_in_Firefox_KEY: |
+DRMcontrolled_content_that_requires_the_Adobe_Flash_or_Microsoft_Silverlight_NPAPI_plugins_will_still_play_if_installed_and_enabled_in_FirefoxP_146_KEY: |
   DRM-controlled content that requires the Adobe Flash or Microsoft Silverlight NPAPI plugins will still play, if installed and enabled in Firefox.
 
-Disables_the_Widevine_Content_Decryption_Module_provided_by_Google_Inc_used_for_the_playback_of_DRMcontrolled_HTML5_content_KEY: |
+Disables_the_Widevine_Content_Decryption_Module_provided_by_Google_IncP_used_for_the_playback_of_DRMcontrolled_HTML5_contentP_127_KEY: |
   Disables the Widevine Content Decryption Module provided by Google Inc., used for the playback of DRM-controlled HTML5 content.
 
-httpssupportmozillaorgkbenabledrmw_disablethegooglewidevinecdmwithoutuninstalling_KEY: |
+httpssupportPmozillaPorgkbenabledrmw_disablethegooglewidevinecdmwithoutuninstalling_97_KEY: |
   https://support.mozilla.org/kb/enable-drm#w_disable-the-google-widevine-cdm-without-uninstalling
 
-Websites_can_track_the_microphone_and_camera_status_of_your_device_KEY: |
+Websites_can_track_the_microphone_and_camera_status_of_your_deviceP_68_KEY: |
   Websites can track the microphone and camera status of your device.
 
-Disable_cookies_KEY: |
+Disable_cookies_16_KEY: |
   Disable cookies
 
-Accept_all_cookies_by_default_KEY: |
+Accept_all_cookies_by_default_30_KEY: |
   Accept all cookies by default
 
-Only_accept_from_the_originating_site_block_thirdparty_cookies_KEY: |
+Only_accept_from_the_originating_site_block_thirdparty_cookies_66_KEY: |
   Only accept from the originating site (block third-party cookies)
 
-Block_all_cookies_by_default_KEY: |
+Block_all_cookies_by_default_29_KEY: |
   Block all cookies by default
 
-Only_send_codeReferercode_header_when_the_full_hostnames_match_Note_if_you_notice_significant_breakage_you_might_try_code1code_combined_w_KEY: |
+Only_send_codeReferercode_header_when_the_full_hostnames_matchP_Note_if_you_notice_significant_breakage_you_might_try_code1code_combined_w_206_KEY: |
   Only send <code>Referer</code> header when the full hostnames match. (Note: if you notice significant breakage, you might try <code>1</code> combined with an <code>XOriginTrimmingPolicy</code> tweak below.)
 
-httpsfeedingcloudgeeknzpoststweakingreferrerforprivacyinfirefox_KEY: |
+httpsfeedingPcloudPgeekPnzpoststweakingreferrerforprivacyinfirefox_78_KEY: |
   https://feeding.cloud.geek.nz/posts/tweaking-referrer-for-privacy-in-firefox/
 
-Send_codeReferercode_in_all_cases_KEY: |
+Send_codeReferercode_in_all_cases_39_KEY: |
   Send <code>Referer</code> in all cases
 
-Send_codeReferercode_to_same_eTLD_sites_KEY: |
+Send_codeReferercode_to_same_eTLD_sites_45_KEY: |
   Send <code>Referer</code> to same eTLD sites
 
-Send_codeReferercode_only_when_the_full_hostnames_match_KEY: |
+Send_codeReferercode_only_when_the_full_hostnames_match_61_KEY: |
   Send <code>Referer</code> only when the full hostnames match
 
-When_sending_codeReferercode_across_origins_only_send_scheme_host_and_port_in_the_codeReferercode_header_of_crossorigin_requests_KEY: |
+When_sending_codeReferercode_across_origins_only_send_scheme_host_and_port_in_the_codeReferercode_header_of_crossorigin_requestsP_143_KEY: |
   When sending <code>Referer</code> across origins, only send scheme, host, and port in the <code>Referer</code> header of cross-origin requests.
 
-Send_full_url_in_codeReferercode_KEY: |
+Send_full_url_in_codeReferercode_38_KEY: |
   Send full url in <code>Referer</code>
 
-Send_url_without_query_string_in_codeReferercode_KEY: |
+Send_url_without_query_string_in_codeReferercode_54_KEY: |
   Send url without query string in <code>Referer</code>
 
-Only_send_scheme_host_and_port_in_codeReferercode_KEY: |
+Only_send_scheme_host_and_port_in_codeReferercode_57_KEY: |
   Only send scheme, host, and port in <code>Referer</code>
 
-Looking_for_TRR_DoH_or_ESNI_KEY: |
+Looking_for_TRR_DoH_or_ESNIQ_30_KEY: |
   Looking for TRR, DoH or ESNI?
 
-They_have_moved_to_a_href_providersdnsicanndns__translate_page_our_DNS_pagea_KEY: |
+They_have_moved_to_a_href_providersdnsicanndns__translate_page_our_DNS_pageaP_97_KEY: |
   They have moved to <a href="{{ '/providers/dns/#icanndns' | translate_page }}">our DNS page</a>.
 
-WebGL_is_a_potential_security_risk_KEY: |
+WebGL_is_a_potential_security_riskP_35_KEY: |
   WebGL is a potential security risk.
 
-httpssecuritystackexchangecomquestions13799iswebglasecurityconcern_KEY: |
+httpssecurityPstackexchangePcomquestions13799iswebglasecurityconcern_79_KEY: |
   https://security.stackexchange.com/questions/13799/is-webgl-a-security-concern
 
-This_preference_controls_when_to_store_extra_information_about_a_session_contents_of_forms_scrollbar_positions_cookies_and_POST_data_KEY: |
+This_preference_controls_when_to_store_extra_information_about_a_session_contents_of_forms_scrollbar_positions_cookies_and_POST_dataP_137_KEY: |
   This preference controls when to store extra information about a session: contents of forms, scrollbar positions, cookies, and POST data.
 
-httpkbmozillazineorgBrowsersessionstoreprivacy_level_KEY: |
+httpkbPmozillazinePorgBrowserPsessionstorePprivacy_level_61_KEY: |
   http://kb.mozillazine.org/Browser.sessionstore.privacy_level
 
-Store_extra_session_data_for_any_site_Default_starting_with_Firefox_4_KEY: |
+Store_extra_session_data_for_any_siteP_Default_starting_with_Firefox_4P_74_KEY: |
   Store extra session data for any site. (Default starting with Firefox 4.)
 
-Store_extra_session_data_for_unencrypted_nonHTTPS_sites_only_Default_before_Firefox_4_KEY: |
+Store_extra_session_data_for_unencrypted_nonHTTPS_sites_onlyP_Default_before_Firefox_4P_93_KEY: |
   Store extra session data for unencrypted (non-HTTPS) sites only. (Default before Firefox 4.)
 
-Never_store_extra_session_data_KEY: |
+Never_store_extra_session_dataP_32_KEY: |
   Never store extra session data.
 
-Not_rendering_IDNs_as_their_Punycode_equivalent_leaves_you_open_to_phishing_attacks_that_can_be_very_difficult_to_notice_KEY: |
+Not_rendering_IDNs_as_their_Punycode_equivalent_leaves_you_open_to_phishing_attacks_that_can_be_very_difficult_to_noticeP_121_KEY: |
   Not rendering IDNs as their Punycode equivalent leaves you open to phishing attacks that can be very difficult to notice.
 
-httpskrebsonsecuritycom201803lookalikedomainsandvisualconfusionmore42636_KEY: |
+httpskrebsonsecurityPcom201803lookalikedomainsandvisualconfusionmore42636_88_KEY: |
   https://krebsonsecurity.com/2018/03/look-alike-domains-and-visual-confusion/#more-42636
 
-Firefox_userjs_Templates_KEY: |
+Firefox_userPjs_Templates_26_KEY: |
   Firefox user.js Templates
 
-httpsgithubcomghacksuserjsghacksuserjs_KEY: |
+httpsgithubPcomghacksuserjsghacksuserPjs_47_KEY: |
   https://github.com/ghacksuserjs/ghacks-user.js
 
-ghacksuserjs_KEY: |
+ghacksuserPjs_15_KEY: |
   ghacks-user.js
 
-An_ongoing_comprehensive_userjs_template_for_configuring_and_hardening_Firefox_privacy_security_and_antifingerprinting_KEY: |
+An_ongoing_comprehensive_userPjs_template_for_configuring_and_hardening_Firefox_privacy_security_and_antifingerprintingP_123_KEY: |
   An ongoing comprehensive user.js template for configuring and hardening Firefox privacy, security and anti-fingerprinting.
 
-httpsblogprivacytoolsiofirefoxprivacyanintroductiontosafe_KEY: |
+httpsblogPprivacytoolsPiofirefoxprivacyanintroductiontosafe_70_KEY: |
   https://blog.privacytools.io/firefox-privacy-an-introduction-to-safe/
 
-Firefox_Privacy_Tips_and_Tricks_for_Better_Browsing_KEY: |
+Firefox_Privacy_Tips_and_Tricks_for_Better_Browsing_53_KEY: |
   Firefox Privacy: Tips and Tricks for Better Browsing
 
-A_good_starting_guide_for_users_looking_to_keep_their_data_private_and_secure_KEY: |
+A_good_starting_guide_for_users_looking_to_keep_their_data_private_and_secureP_79_KEY: |
   A good starting guide for users looking to keep their data private and secure.
 
-httpsffprofilecom_KEY: |
+httpsffprofilePcom_23_KEY: |
   https://ffprofile.com/
 
-ffprofilecom_KEY: |
+ffprofilePcom_14_KEY: |
   ffprofile.com
 
-Helps_you_to_create_a_Firefox_profile_with_the_defaults_you_like_KEY: |
+Helps_you_to_create_a_Firefox_profile_with_the_defaults_you_likeP_66_KEY: |
   Helps you to create a Firefox profile with the defaults you like.
 
-httpkbmozillazineorgCategorySecurity_and_privacyrelated_preferences_KEY: |
+httpkbPmozillazinePorgCategorySecurity_and_privacyrelated_preferences_76_KEY: |
   http://kb.mozillazine.org/Category:Security_and_privacy-related_preferences
 
-mozillazineorg_KEY: |
+mozillazinePorg_16_KEY: |
   mozillazine.org
 
-Security_and_privacyrelated_preferences_KEY: |
+Security_and_privacyrelated_preferencesP_43_KEY: |
   Security and privacy-related preferences.
 
-httpsaddonsmozillaorgfirefoxaddonprivacysettings_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddonprivacysettings_59_KEY: |
   https://addons.mozilla.org/firefox/addon/privacy-settings/
 
-Privacy_Settings_KEY: |
+Privacy_Settings_17_KEY: |
   Privacy Settings
 
-A_Firefox_addon_to_alter_builtin_privacy_settings_easily_with_a_toolbar_panel_KEY: |
+A_Firefox_addon_to_alter_builtin_privacy_settings_easily_with_a_toolbar_panelP_81_KEY: |
   A Firefox add-on to alter built-in privacy settings easily with a toolbar panel.
 
-https12bytesorgarticlestechfirefoxthefirefoxprivacyguidefordummies_KEY: |
+https12bytesPorgarticlestechfirefoxthefirefoxprivacyguidefordummies_81_KEY: |
   https://12bytes.org/articles/tech/firefox/the-firefox-privacy-guide-for-dummies/
 
-Firefox_Privacy_Guide_For_Dummies_KEY: |
+Firefox_Privacy_Guide_For_Dummies_34_KEY: |
   Firefox Privacy Guide For Dummies
 
-Guide_on_ways_already_discussed_and_others_to_improve_your_privacy_and_safety_on_Firefox_KEY: |
+Guide_on_ways_already_discussed_and_others_to_improve_your_privacy_and_safety_on_FirefoxP_92_KEY: |
   Guide on ways (already discussed and others) to improve your privacy and safety on Firefox.
 
-Calendar_and_Contacts_Sync_KEY: |
+Calendar_and_Contacts_Sync_27_KEY: |
   Calendar and Contacts Sync
 
-If_you_are_currently_using_a_calendar_and_or_contacts_synchronization_service_like_Google_Sync_or_iCloud_you_should_pick_an_alternative_here_KEY: |
+If_you_are_currently_using_a_calendar_and_or_contacts_synchronization_service_like_Google_Sync_or_iCloud_you_should_pick_an_alternative_hereP_143_KEY: |
   If you are currently using a calendar and or contacts synchronization service like Google Sync or iCloud, you should pick an alternative here.
 
-Nextcloud_KEY: |
+Nextcloud_9_KEY: |
   Nextcloud
 
-strongNextcloudstrong_is_a_suite_of_clientserver_software_for_creating_and_using_file_hosting_services_This_includes_calendar_sync_via_CalDAV_an_KEY: |
+strongNextcloudstrong_is_a_suite_of_clientserver_software_for_creating_and_using_file_hosting_servicesP_This_includes_calendar_sync_via_CalDAV_an_300_KEY: |
   <strong>Nextcloud</strong> is a suite of client-server software for creating and using file hosting services. This includes calendar sync via CalDAV and contacts sync via CardDAV. Nextcloud is free and open-source, thereby allowing anyone to install and operate it without charge on a private server.
 
-httpsnextcloudcom_KEY: |
+httpsnextcloudPcom_22_KEY: |
   https://nextcloud.com/
 
-httpsnextcloudcominstall_KEY: |
+httpsnextcloudPcominstall_30_KEY: |
   https://nextcloud.com/install/
 
-httpswwwfreshportsorgdeskutilsnextcloudclient_KEY: |
+httpswwwPfreshportsPorgdeskutilsnextcloudclient_53_KEY: |
   https://www.freshports.org/deskutils/nextcloudclient/
 
-httpopenportssewwwnextcloud_KEY: |
+httpopenportsPsewwwnextcloud_33_KEY: |
   http://openports.se/www/nextcloud
 
-httppkgsrcsewwwphpnextcloud_KEY: |
+httppkgsrcPsewwwphpnextcloud_34_KEY: |
   http://pkgsrc.se/www/php-nextcloud
 
-httpsgithubcomnextcloud_KEY: |
+httpsgithubPcomnextcloud_28_KEY: |
   https://github.com/nextcloud
 
-Email_Providers_KEY: |
+Email_Providers_15_KEY: |
   Email Providers
 
-Many_email_providers_also_offer_calendar_and_or_contacts_sync_services_Refer_to_the_a_hrefprovidersemail__translate_page_Email_Providers_KEY: |
+Many_email_providers_also_offer_calendar_and_or_contacts_sync_servicesP_Refer_to_the_a_hrefprovidersemail__translate_page_Email_Providers_251_KEY: |
   Many email providers also offer calendar and or contacts sync services. Refer to the <a href="{{'/providers/email' | translate_page }}">Email Providers section</a> to choose an email provider and check if they also offer calendar and/or contacts sync.
 
-providersemail__translate_page__KEY: |
+providersemail__translate_page__40_KEY: |
   {{'/providers/email' | translate_page }}
 
-EteSync_KEY: |
+EteSync_7_KEY: |
   EteSync
 
-strongEteSyncstrong_is_a_secure_endtoend_encrypted_and_privacyrespecting_cloud_backup_and_synchronization_software_for_your_personal_informat_KEY: |
+strongEteSyncstrong_is_a_secure_endtoend_encrypted_and_privacyrespecting_cloud_backup_and_synchronization_software_for_your_personal_informat_364_KEY: |
   <strong>EteSync</strong> is a secure, end-to-end encrypted, and privacy-respecting cloud backup and synchronization software for your personal information (e.g. contacts and calendars). There are native clients for Android, iOS, and the web, and an adapter layer for most desktop clients. It costs $24 per year to use, or you can host the server yourself for free.
 
-httpswwwetesynccom_KEY: |
+httpswwwPetesyncPcom_24_KEY: |
   https://www.etesync.com/
 
-httpswwwetesynccominstalldav_KEY: |
+httpswwwPetesyncPcominstalldav_36_KEY: |
   https://www.etesync.com/install/dav/
 
-httpsfdroidorgpackagescometesyncsyncadapter_KEY: |
+httpsfdroidPorgpackagescomPetesyncPsyncadapter_53_KEY: |
   https://f-droid.org/packages/com.etesync.syncadapter/
 
-httpsplaygooglecomstoreappsdetailsidcometesyncsyncadapter_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPetesyncPsyncadapter_69_KEY: |
   https://play.google.com/store/apps/details?id=com.etesync.syncadapter
 
-httpswwwetesynccominstallios_KEY: |
+httpswwwPetesyncPcominstallios_36_KEY: |
   https://www.etesync.com/install/ios/
 
-httpsclientetesynccom_KEY: |
+httpsclientPetesyncPcom_27_KEY: |
   https://client.etesync.com/
 
-httpsgithubcometesync_KEY: |
+httpsgithubPcometesync_26_KEY: |
   https://github.com/etesync
 
-Worth_Mentioning_KEY: |
+Worth_Mentioning_17_KEY: |
   Worth Mentioning
 
-httpsfruuxcom_KEY: |
+httpsfruuxPcom_19_KEY: |
   https://fruux.com/
 
-fruux_KEY: |
+fruux_6_KEY: |
   fruux
 
-A_unified_contactscalendaring_system_that_works_across_platforms_and_devices_KEY: |
+A_unified_contactscalendaring_system_that_works_across_platforms_and_devicesP_79_KEY: |
   A unified contacts/calendaring system that works across platforms and devices.
 
-cloud_backups_KEY: |
+cloud_backups_14_KEY: |
   cloud backups
 
-Consider_regularly_exporting_your_calendar_and_or_contacts_and_backing_them_up_on_a_separate_storage_drive_or_uploading_them_to_cloud_storage_ideally__KEY: |
+Consider_regularly_exporting_your_calendar_and_or_contacts_and_backing_them_up_on_a_separate_storage_drive_or_uploading_them_to_cloud_storage_ideally__209_KEY: |
   Consider regularly exporting your calendar and or contacts and backing them up on a separate storage drive or uploading them to cloud storage (ideally after <a href="../encryption-tools/">encrypting</a> them).
 
-SelfHosted_Cloud_Server_Software_KEY: |
+SelfHosted_Cloud_Server_Software_34_KEY: |
   Self-Hosted Cloud Server Software
 
-If_you_are_currently_using_a_Cloud_Storage_Services_like_Dropbox_Google_Drive_Microsoft_OneDrive_or_Apple_iCloud_you_should_think_about_hosting_it_o_KEY: |
+If_you_are_currently_using_a_Cloud_Storage_Services_like_Dropbox_Google_Drive_Microsoft_OneDrive_or_Apple_iCloud_you_should_think_about_hosting_it_o_163_KEY: |
   If you are currently using a Cloud Storage Services like Dropbox, Google Drive, Microsoft OneDrive or Apple iCloud, you should think about hosting it on your own.
 
-Nextcloud_is_similar_in_functionality_to_the_widely_used_Dropbox_with_the_difference_being_that_Nextcloud_is_free_and_opensource_thereby_allowing_an_KEY: |
+Nextcloud_is_similar_in_functionality_to_the_widely_used_Dropbox_with_the_difference_being_that_Nextcloud_is_free_and_opensource_thereby_allowing_an_284_KEY: |
   Nextcloud is similar in functionality to the widely used Dropbox, with the difference being that Nextcloud is free and open-source, thereby allowing anyone to install and operate it without charge on a private server with no limits on storage space or the number of connected clients.
 
-httpsnextcloudcominstallinstallclients_KEY: |
+httpsnextcloudPcominstallinstallclients_46_KEY: |
   https://nextcloud.com/install/#install-clients
 
-httpswwwfreshportsorgwwwnextcloud_KEY: |
+httpswwwPfreshportsPorgwwwnextcloud_41_KEY: |
   https://www.freshports.org/www/nextcloud/
 
-httpsfdroidorgpackagescomnextcloudclient_KEY: |
+httpsfdroidPorgpackagescomPnextcloudPclient_50_KEY: |
   https://f-droid.org/packages/com.nextcloud.client/
 
-httpsplaygooglecomstoreappsdetailsidcomnextcloudclient_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPnextcloudPclient_66_KEY: |
   https://play.google.com/store/apps/details?id=com.nextcloud.client
 
-httpsitunesapplecomusappnextcloudid1125420102mt8_KEY: |
+httpsitunesPapplePcomusappnextcloudid1125420102Qmt8_59_KEY: |
   https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8
 
-TahoeLAFS_KEY: |
+TahoeLAFS_10_KEY: |
   Tahoe-LAFS
 
-TahoeLAFS_is_a_free_and_open_decentralized_cloud_storage_system_It_distributes_your_data_across_multiple_servers_Even_if_some_of_the_servers_fail_or_KEY: |
+TahoeLAFS_is_a_free_and_open_decentralized_cloud_storage_systemP_It_distributes_your_data_across_multiple_serversP_Even_if_some_of_the_servers_fail_or_275_KEY: |
   Tahoe-LAFS is a free and open decentralized cloud storage system. It distributes your data across multiple servers. Even if some of the servers fail or are taken over by an attacker, the entire file store continues to function correctly, preserving your privacy and security.
 
-httpswwwtahoelafsorg_KEY: |
+httpswwwPtahoelafsPorg_27_KEY: |
   https://www.tahoe-lafs.org/
 
-httpsgithubcomtahoelafstahoelafsviapip_KEY: |
+httpsgithubPcomtahoelafstahoelafsviapip_48_KEY: |
   https://github.com/tahoe-lafs/tahoe-lafs#via-pip
 
-httpsgithubcomtahoelafstahoelafsusingospackages_KEY: |
+httpsgithubPcomtahoelafstahoelafsusingospackages_58_KEY: |
   https://github.com/tahoe-lafs/tahoe-lafs#using-os-packages
 
-httppkgsrcsefilesystemstahoelafs_KEY: |
+httppkgsrcPsefilesystemstahoelafs_39_KEY: |
   http://pkgsrc.se/filesystems/tahoe-lafs
 
-httpswwwtahoelafsorgtractahoelafsbrowser_KEY: |
+httpswwwPtahoelafsPorgtractahoelafsbrowser_50_KEY: |
   https://www.tahoe-lafs.org/trac/tahoe-lafs/browser
 
-httpsgithubcomxwikilabscryptpad_KEY: |
+httpsgithubPcomxwikilabscryptpad_40_KEY: |
   https://github.com/xwiki-labs/cryptpad/
 
-CryptPad_KEY: |
+CryptPad_9_KEY: |
   CryptPad
 
-An_opensource_and_endtoend_encrypted_realtime_collaborative_editor_that_lets_you_share_folders_media_and_documents_KEY: |
+An_opensource_and_endtoend_encrypted_realtime_collaborative_editor_that_lets_you_share_folders_media_and_documentsP_122_KEY: |
   An open-source and end-to-end encrypted real-time collaborative editor that lets you share folders, media, and documents.
 
-Encrypted_Domain_Name_System_DNS_Resolvers_KEY: |
+Encrypted_Domain_Name_System_DNS_Resolvers_45_KEY: |
   Encrypted Domain Name System (DNS) Resolvers
 
-Note_Using_an_encrypted_DNS_resolver_will_not_make_you_anonymous_nor_hide_your_internet_traffic_from_your_Internet_Service_Provider_But_it_will_prev_KEY: |
+Note_Using_an_encrypted_DNS_resolver_will_not_make_you_anonymous_nor_hide_your_internet_traffic_from_your_Internet_Service_ProviderP_But_it_will_prev_342_KEY: |
   Note: Using an encrypted DNS resolver will not make you anonymous, nor hide your internet traffic from your Internet Service Provider. But it will prevent DNS hijacking, and make your DNS requests harder for third parties to eavesdrop on and tamper with. If you are currently using Google's DNS resolver, you should pick an alternative here.
 
-DNS_Provider_KEY: |
+DNS_Provider_13_KEY: |
   DNS Provider
 
-Server_Locations_KEY: |
+Server_Locations_17_KEY: |
   Server Locations
 
-Privacy_Policy_KEY: |
+Privacy_Policy_15_KEY: |
   Privacy Policy
 
-Type_KEY: |
+Type_5_KEY: |
   Type
 
-Logging_KEY: |
+Logging_8_KEY: |
   Logging
 
-Protocols_KEY: |
+Protocols_10_KEY: |
   Protocols
 
-DNSSEC_KEY: |
+DNSSEC_7_KEY: |
   DNSSEC
 
-QNAME_Minimization_KEY: |
+QNAME_Minimization_19_KEY: |
   QNAME Minimization
 
-Filtering_KEY: |
+Filtering_10_KEY: |
   Filtering
 
-Source_Code_KEY: |
+Source_Code_12_KEY: |
   Source Code
 
-Hosting_Provider_KEY: |
+Hosting_Provider_17_KEY: |
   Hosting Provider
 
-AdGuard_KEY: |
+AdGuard_8_KEY: |
   AdGuard
 
-httpsadguardcomenadguarddnsoverviewhtml_KEY: |
+httpsadguardPcomenadguarddnsoverviewPhtml_49_KEY: |
   https://adguard.com/en/adguard-dns/overview.html
 
-Anycast_based_in_span_classnotextwrapspan_classflagicon_flagiconcyspan_Cyprusspan_KEY: |
+Anycast_based_in_span_classnotextwrapspan_classflagicon_flagiconcyspan_Cyprusspan_104_KEY: |
   Anycast (based in <span class="no-text-wrap"><span class="flag-icon flag-icon-cy"></span> Cyprus)</span>
 
-httpsadguardcomenprivacydnshtml_KEY: |
+httpsadguardPcomenprivacydnsPhtml_40_KEY: |
   https://adguard.com/en/privacy/dns.html
 
-Commercial_KEY: |
+Commercial_11_KEY: |
   Commercial
 
-No_KEY: |
+No_3_KEY: |
   No
 
-DoH_DoT_DNSCrypt_KEY: |
+DoH_DoT_DNSCrypt_19_KEY: |
   DoH, DoT, DNSCrypt
 
-Yes_KEY: |
+Yes_4_KEY: |
   Yes
 
-Ads_trackers_KEY: |
+Ads_trackers_15_KEY: |
   Ads, trackers,
 
-malicious_domains_KEY: |
+malicious_domains_18_KEY: |
   malicious domains
 
-httpsgithubcomAdguardTeamAdGuardDNS_KEY: |
+httpsgithubPcomAdguardTeamAdGuardDNS_43_KEY: |
   https://github.com/AdguardTeam/AdGuardDNS/
 
-httpsflopsruenabouthtml_KEY: |
+httpsflopsPruenaboutPhtml_31_KEY: |
   https://flops.ru/en/about.html
 
-Serveroid_LLC_KEY: |
+Serveroid_LLC_15_KEY: |
   Serveroid, LLC
 
-BlahDNS_KEY: |
+BlahDNS_8_KEY: |
   BlahDNS
 
-httpsblahdnscom_KEY: |
+httpsblahdnsPcom_21_KEY: |
   https://blahdns.com/
 
-Finland_KEY: |
+Finland_8_KEY: |
   Finland
 
-Germany_KEY: |
+Germany_8_KEY: |
   Germany
 
-Japan_KEY: |
+Japan_6_KEY: |
   Japan
 
-Hobby_Project_KEY: |
+Hobby_Project_14_KEY: |
   Hobby Project
 
-DoH_KEY: |
+DoH_4_KEY: |
   DoH
 
-Supports_port_443_in_addition_to_853_KEY: |
+Supports_port_443_in_addition_to_853_37_KEY: |
   Supports port 443 in addition to 853
 
-DoT_KEY: |
+DoT_4_KEY: |
   DoT
 
-DNSCrypt_KEY: |
+DNSCrypt_9_KEY: |
   DNSCrypt
 
-And_some_wildcard_and_IDN_domains_KEY: |
+And_some_wildcard_and_IDN_domainsP_35_KEY: |
   And some wildcard and IDN domains.
 
-httpsgithubcomookangzhengblahdnsdefaultblockedwildcarddomain_KEY: |
+httpsgithubPcomookangzhengblahdnsdefaultblockedwildcarddomain_71_KEY: |
   https://github.com/ookangzheng/blahdns#default-blocked-wildcard-domain
 
-httpsgithubcomookangzhengblahdns_KEY: |
+httpsgithubPcomookangzhengblahdns_40_KEY: |
   https://github.com/ookangzheng/blahdns/
 
-httpswwwchoopacom_KEY: |
+httpswwwPchoopaPcom_24_KEY: |
   https://www.choopa.com/
 
-Choopa_LLC_KEY: |
+Choopa_LLC_12_KEY: |
   Choopa, LLC
 
-httpswwwdatacenterlightch_KEY: |
+httpswwwPdatacenterlightPch_32_KEY: |
   https://www.datacenterlight.ch/
 
-Data_Center_Light_KEY: |
+Data_Center_Light_18_KEY: |
   Data Center Light
 
-httpswwwhetznercom_KEY: |
+httpswwwPhetznerPcom_25_KEY: |
   https://www.hetzner.com/
 
-Hetzner_Online_GmbH_KEY: |
+Hetzner_Online_GmbH_20_KEY: |
   Hetzner Online GmbH
 
-Cloudflare_KEY: |
+Cloudflare_11_KEY: |
   Cloudflare
 
-httpsdeveloperscloudflarecom1111settingup1111_KEY: |
+httpsdevelopersPcloudflarePcom1P1P1P1settingup1P1P1P1_62_KEY: |
   https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/
 
-Cloudflare_is_one_of_the_worlds_largest_networks_and_a_problem_considering_anonymity_and_decentralization_KEY: |
+Cloudflare_is_one_of_the_worlds_largest_networks_and_a_problem_considering_anonymity_and_decentralizationP_109_KEY: |
   Cloudflare is one of the world's largest networks, and a problem considering anonymity and decentralization.
 
-httpscodebergorgcrimeflarecloudflaretor_KEY: |
+httpscodebergPorgcrimeflarecloudflaretor_48_KEY: |
   https://codeberg.org/crimeflare/cloudflare-tor/
 
-Anycast_based_in_span_classnotextwrap_span_classflagicon_flagiconusspan_USspan_KEY: |
+Anycast_based_in_span_classnotextwrap_span_classflagicon_flagiconusspan_USspan_101_KEY: |
   Anycast (based in <span class="no-text-wrap"> <span class="flag-icon flag-icon-us"></span> US)</span>
 
-httpswwwcloudflarecomprivacypolicy_KEY: |
+httpswwwPcloudflarePcomprivacypolicy_42_KEY: |
   https://www.cloudflare.com/privacypolicy/
 
-We_will_collect_limited_DNS_query_data_that_is_sent_to_the_resolvers_This_data_does_not_contain_user_IP_addresses_or_any_other_personally_identifiabl_KEY: |
+We_will_collect_limited_DNS_query_data_that_is_sent_to_the_resolversP_This_data_does_not_contain_user_IP_addresses_or_any_other_personally_identifiabl_220_KEY: |
   "We will collect limited DNS query data that is sent to the resolvers. This data does not contain user IP addresses or any other personally identifiable information, and the bulk of the data is only stored for 24 hours."
 
-httpsdeveloperscloudflarecom1111commitmenttoprivacyprivacypolicyprivacypolicy_KEY: |
+httpsdevelopersPcloudflarePcom1P1P1P1commitmenttoprivacyprivacypolicyprivacypolicy_94_KEY: |
   https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/
 
-Some_KEY: |
+Some_5_KEY: |
   Some
 
-Self_KEY: |
+Self_5_KEY: |
   Self
 
-CZNIC_KEY: |
+CZPNIC_7_KEY: |
   CZ.NIC
 
-httpswwwnicczodvr_KEY: |
+httpswwwPnicPczodvr_25_KEY: |
   https://www.nic.cz/odvr/
 
-Czech_Republic_KEY: |
+Czech_Republic_15_KEY: |
   Czech Republic
 
-CZNIC_resolvers_neither_collect_any_personal_data_nor_gather_information_on_pages_where_your_computer_sends_personal_data_KEY: |
+CZPNIC_resolvers_neither_collect_any_personal_data_nor_gather_information_on_pages_where_your_computer_sends_personal_dataP_126_KEY: |
   "CZ.NIC resolvers neither collect any personal data nor gather information on pages where your computer sends personal data."
 
-CZNIC_is_an_interest_association_of_legal_entities_founded_in_1998_by_leading_providers_of_Internet_services_KEY: |
+CZPNIC_is_an_interest_association_of_legal_entities_founded_in_1998_by_leading_providers_of_Internet_servicesP_113_KEY: |
   "CZ.NIC is an interest association of legal entities, founded in 1998 by leading providers of Internet services."
 
-httpswwwnicczpage351aboutassociation_KEY: |
+httpswwwPnicPczpage351aboutassociation_46_KEY: |
   https://www.nic.cz/page/351/about-association/
 
-Association_KEY: |
+Association_12_KEY: |
   Association
 
-DoH_DoT_KEY: |
+DoH_DoT_9_KEY: |
   DoH, DoT
 
-dnswarden_KEY: |
+dnswarden_10_KEY: |
   dnswarden
 
-httpsgithubcombhanupratapysdnswardenblobmasterREADMEmd_KEY: |
+httpsgithubPcombhanupratapysdnswardenblobmasterREADMEPmd_65_KEY: |
   https://github.com/bhanupratapys/dnswarden/blob/master/README.md
 
-httpsgithubcombhanupratapysdnswardenblobmasterREADMEmdprivacypolicyandtc_KEY: |
+httpsgithubPcombhanupratapysdnswardenblobmasterREADMEPmdprivacypolicyandtc_87_KEY: |
   https://github.com/bhanupratapys/dnswarden/blob/master/README.md#privacy-policy-and-tc
 
-Based_on_server_choice_KEY: |
+Based_on_server_choice_23_KEY: |
   Based on server choice
 
-Foundation_for_Applied_Privacy_KEY: |
+Foundation_for_Applied_Privacy_31_KEY: |
   Foundation for Applied Privacy
 
-httpsappliedprivacynetservicesdns_KEY: |
+httpsappliedprivacyPnetservicesdns_41_KEY: |
   https://appliedprivacy.net/services/dns/
 
-Austria_KEY: |
+Austria_8_KEY: |
   Austria
 
-httpsappliedprivacynetprivacypolicy_KEY: |
+httpsappliedprivacyPnetprivacypolicy_42_KEY: |
   https://appliedprivacy.net/privacy-policy
 
-NonProfit_KEY: |
+NonProfit_11_KEY: |
   Non-Profit
 
-We_do_NOT_log_your_IP_address_or_DNS_queries_during_normal_operations_We_do_NOT_share_query_data_with_third_parties_that_are_not_directly_involved_wi_KEY: |
+We_do_NOT_log_your_IP_address_or_DNS_queries_during_normal_operationsP_We_do_NOT_share_query_data_with_third_parties_that_are_not_directly_involved_wi_242_KEY: |
   "We do NOT log your IP address or DNS queries during normal operations. We do NOT share query data with third parties that are not directly involved with resolving the query (i.e. sending queries to authoritative nameservers for resolution)."
 
-httpswwwipaxat_KEY: |
+httpswwwPipaxPat_21_KEY: |
   https://www.ipax.at/
 
-IPAX_OG_KEY: |
+IPAX_OG_8_KEY: |
   IPAX OG
 
-httpswwwnextdnsio_KEY: |
+httpswwwPnextdnsPio_23_KEY: |
   https://www.nextdns.io/
 
-NextDNS_KEY: |
+NextDNS_8_KEY: |
   NextDNS
 
-Anycast_based_in_span_classnotextwrapspan_classflagicon_flagiconusspan_USspan_KEY: |
+Anycast_based_in_span_classnotextwrapspan_classflagicon_flagiconusspan_USspan_100_KEY: |
   Anycast (based in <span class="no-text-wrap"><span class="flag-icon flag-icon-us"></span> US)</span>
 
-httpswwwnextdnsioprivacy_KEY: |
+httpswwwPnextdnsPioprivacy_31_KEY: |
   https://www.nextdns.io/privacy
 
-Some_of_the_features_require_some_sort_of_data_retention_In_that_case_we_give_our_users_the_choice_to_granularly_or_completely_disable_those_feature_KEY: |
+Some_of_the_features_require_some_sort_of_data_retentionP_In_that_case_we_give_our_users_the_choice_to_granularly_or_completely_disable_those_feature_232_KEY: |
   "Some of the features require some sort of data retention. In that case, we give our users the choice to granularly or completely disable those features (and associated data retention), and we follow up immediately on that promise"
 
-Based_on_user_choice_KEY: |
+Based_on_user_choice_21_KEY: |
   Based on user choice
 
-NixNet_KEY: |
+NixNet_7_KEY: |
   NixNet
 
-httpsnixnetxyzdns_KEY: |
+httpsnixnetPxyzdns_24_KEY: |
   https://nixnet.xyz/dns/
 
-Anycast_based_in_span_classflagicon_flagiconusspan_USspan_KEY: |
+Anycast_based_in_span_classflagicon_flagiconusspan_USspan_74_KEY: |
   Anycast (based in <span class="flag-icon flag-icon-us"></span> US),</span>
 
-US_KEY: |
+US_3_KEY: |
   US
 
-Luxembourg_KEY: |
+Luxembourg_11_KEY: |
   Luxembourg
 
-httpsnixnetxyzprivacy_KEY: |
+httpsnixnetPxyzprivacy_28_KEY: |
   https://nixnet.xyz/privacy/
 
-Part_of_LibreHosters_a_network_of_cooperation_and_solidarity_that_uses_free_software_to_encourage_decentralisation_through_federation_and_distributed_KEY: |
+Part_of_LibreHosters_a_network_of_cooperation_and_solidarity_that_uses_free_software_to_encourage_decentralisation_through_federation_and_distributed_163_KEY: |
   Part of LibreHosters, "a network of cooperation and solidarity that uses free software to encourage decentralisation through federation and distributed platforms."
 
-httpslibrehost_KEY: |
+httpslibrehoPst_20_KEY: |
   https://libreho.st/
 
-Informal_collective_KEY: |
+Informal_collective_20_KEY: |
   Informal collective
 
-httpsgitnixnetxyzNixNetdns_KEY: |
+httpsgitPnixnetPxyzNixNetdns_34_KEY: |
   https://git.nixnet.xyz/NixNet/dns
 
-httpsfrantechca_KEY: |
+httpsfrantechPca_21_KEY: |
   https://frantech.ca/
 
-FranTech_Solutions_KEY: |
+FranTech_Solutions_19_KEY: |
   FranTech Solutions
 
-PowerDNS_KEY: |
+PowerDNS_9_KEY: |
   PowerDNS
 
-httpspowerdnsorg_KEY: |
+httpspowerdnsPorg_22_KEY: |
   https://powerdns.org/
 
-The_Netherlands_KEY: |
+The_Netherlands_16_KEY: |
   The Netherlands
 
-httpspowerdnsorgdohprivacyhtml_KEY: |
+httpspowerdnsPorgdohprivacyPhtml_38_KEY: |
   https://powerdns.org/doh/privacy.html
 
-httpsgithubcomPowerDNSpdns_KEY: |
+httpsgithubPcomPowerDNSpdns_33_KEY: |
   https://github.com/PowerDNS/pdns
 
-httpswwwtransipnl_KEY: |
+httpswwwPtransipPnl_24_KEY: |
   https://www.transip.nl/
 
-TransIP_BV_Admin_KEY: |
+TransIP_BPVP_Admin_19_KEY: |
   TransIP B.V. Admin
 
-Quad9_KEY: |
+Quad9_6_KEY: |
   Quad9
 
-httpsquad9net_KEY: |
+httpsquad9Pnet_19_KEY: |
   https://quad9.net/
 
-Founders_include_the_Global_Cyber_Alliance_composed_of_the_City_of_London_Police_and_Manhattan_District_Attorneys_Office_KEY: |
+Founders_include_the_Global_Cyber_Alliance_composed_of_the_City_of_London_Police_and_Manhattan_District_Attorneys_Office_123_KEY: |
   Founders include the Global Cyber Alliance, composed of the City of London Police and Manhattan District Attorney's Office
 
-httpsquad9netpolicy_KEY: |
+httpsquad9Pnetpolicy_26_KEY: |
   https://quad9.net/policy/
 
-Our_normal_course_of_data_management_does_not_have_any_IP_address_information_or_other_PII_logged_to_disk_or_transmitted_out_of_the_location_in_which__KEY: |
+Our_normal_course_of_data_management_does_not_have_any_IP_address_information_or_other_PII_logged_to_disk_or_transmitted_out_of_the_location_in_which__175_KEY: |
   "Our normal course of data management does not have any IP address information or other PII logged to disk or transmitted out of the location in which the query was received."
 
-Malicious_domains_KEY: |
+Malicious_domains_18_KEY: |
   Malicious domains
 
-httpswwwpchnet_KEY: |
+httpswwwPpchPnet_21_KEY: |
   https://www.pch.net/
 
-Packet_Clearing_House_KEY: |
+Packet_Clearing_House_22_KEY: |
   Packet Clearing House
 
-SecureDNS_KEY: |
+SecureDNS_10_KEY: |
   SecureDNS
 
-httpssecurednseu_KEY: |
+httpssecurednsPeu_22_KEY: |
   https://securedns.eu/
 
-httpssecurednseuprivacy_KEY: |
+httpssecurednsPeuprivacy_30_KEY: |
   https://securedns.eu/#privacy
 
-httpswwwdigitaloceancom_KEY: |
+httpswwwPdigitaloceanPcom_30_KEY: |
   https://www.digitalocean.com/
 
-DigitalOcean_Inc_KEY: |
+DigitalOcean_IncP_19_KEY: |
   DigitalOcean, Inc.
 
-httpssnopytaorgservicednsindexhtml_KEY: |
+httpssnopytaPorgservicednsindexPhtml_43_KEY: |
   https://snopyta.org/service/dns/index.html
 
-Snopyta_KEY: |
+Snopyta_8_KEY: |
   Snopyta
 
-httpssnopytaorgprivacy_policy_KEY: |
+httpssnopytaPorgprivacy_policy_36_KEY: |
   https://snopyta.org/privacy_policy/
 
-UncensoredDNS_KEY: |
+UncensoredDNS_14_KEY: |
   UncensoredDNS
 
-httpsbloguncensoreddnsorg_KEY: |
+httpsblogPuncensoreddnsPorg_31_KEY: |
   https://blog.uncensoreddns.org/
 
-Anycast_based_in_span_classnotextwrapspan_classflagicon_flagicondkspan_Denmark_KEY: |
+Anycast_based_in_span_classnotextwrapspan_classflagicon_flagicondkspan_Denmark_98_KEY: |
   Anycast (based in <span class="no-text-wrap"><span class="flag-icon flag-icon-dk"></span> Denmark)
 
-Denmark_KEY: |
+Denmark_8_KEY: |
   Denmark
 
-Absolutely_nothing_is_being_logged_neither_about_the_users_nor_the_usage_of_this_service_I_do_keep_graphs_of_the_total_number_of_queries_but_no_per_KEY: |
+Absolutely_nothing_is_being_logged_neither_about_the_users_nor_the_usage_of_this_serviceP_I_do_keep_graphs_of_the_total_number_of_queries_but_no_per_299_KEY: |
   "Absolutely nothing is being logged, neither about the users nor the usage of this service. I do keep graphs of the total number of queries, but no personally identifiable information is saved. The data that is saved will never be sold or used for anything except capacity planning of the service."
 
-httpswwwteliacompanycom_KEY: |
+httpswwwPteliacompanyPcom_29_KEY: |
   https://www.teliacompany.com
 
-Telia_Company_AB_KEY: |
+Telia_Company_AB_17_KEY: |
   Telia Company AB
 
-Terms_KEY: |
+Terms_6_KEY: |
   Terms
 
-DNSoverTLS_DoT__A_security_protocol_for_encrypted_DNS_on_a_dedicated_port_853_Some_providers_support_port_443_which_generally_works_everywhere_wh_KEY: |
+DNSoverTLS_DoT__A_security_protocol_for_encrypted_DNS_on_a_dedicated_port_853P_Some_providers_support_port_443_which_generally_works_everywhere_wh_226_KEY: |
   DNS-over-TLS (DoT) - A security protocol for encrypted DNS on a dedicated port 853. Some providers support port 443 which generally works everywhere while port 853 is often blocked by restrictive firewalls. DoT has two modes:
 
-Oppurtunistic_mode_the_client_attempts_to_form_a_DNSoverTLS_connection_to_the_server_on_port_853_without_performing_certificate_validation_If_it_fa_KEY: |
+Oppurtunistic_mode_the_client_attempts_to_form_a_DNSoverTLS_connection_to_the_server_on_port_853_without_performing_certificate_validationP_If_it_fa_184_KEY: |
   Oppurtunistic mode: the client attempts to form a DNS-over-TLS connection to the server on port 853 without performing certificate validation. If it fails, it will use unencrypted DNS.
 
-In_other_words_automatic_mode_leaves_your_DNS_traffic_vulnerable_to_SSL_strip_and_MITM_attacks_KEY: |
+In_other_words_automatic_mode_leaves_your_DNS_traffic_vulnerable_to_SSL_strip_and_MITM_attacks_95_KEY: |
   In other words automatic mode leaves your DNS traffic vulnerable to SSL strip and MITM attacks
 
-Strict_mode_the_client_connects_to_a_specific_hostname_and_performs_certificate_validation_for_it_If_it_fails_no_DNS_queries_are_made_until_it_succe_KEY: |
+Strict_mode_the_client_connects_to_a_specific_hostname_and_performs_certificate_validation_for_itP_If_it_fails_no_DNS_queries_are_made_until_it_succe_156_KEY: |
   Strict mode: the client connects to a specific hostname and performs certificate validation for it. If it fails, no DNS queries are made until it succeeds.
 
-DNSoverHTTPS_DoH__Similar_to_DoT_but_uses_HTTPS_instead_being_indistinguishable_from_normal_HTTPS_traffic_on_port_443_KEY: |
+DNSoverHTTPS_DoH__Similar_to_DoT_but_uses_HTTPS_instead_being_indistinguishable_from_normal_HTTPS_traffic_on_port_443P_127_KEY: |
   DNS-over-HTTPS (DoH) - Similar to DoT, but uses HTTPS instead, being indistinguishable from "normal" HTTPS traffic on port 443.
 
-DoH_contains_metadata_such_as_useragent_which_may_include_system_information_that_is_sent_to_the_DNS_server_KEY: |
+DoH_contains_metadata_such_as_useragent_which_may_include_system_information_that_is_sent_to_the_DNS_serverP_112_KEY: |
   DoH contains metadata such as user-agent (which may include system information) that is sent to the DNS server.
 
-httpstoolsietforghtmlrfc8484section82_KEY: |
+httpstoolsPietfPorghtmlrfc8484section8P2_48_KEY: |
   https://tools.ietf.org/html/rfc8484#section-8.2
 
-DNSCrypt__An_older_yet_robust_method_of_encrypting_DNS_KEY: |
+DNSCrypt__An_older_yet_robust_method_of_encrypting_DNSP_57_KEY: |
   DNSCrypt - An older yet robust method of encrypting DNS.
 
-How_to_verify_DNS_is_encrypted_KEY: |
+How_to_verify_DNS_is_encrypted_31_KEY: |
   How to verify DNS is encrypted
 
-DoH__DoT_KEY: |
+DoH__DoT_10_KEY: |
   DoH / DoT
 
-Check_a_hrefhttpswwwdnsleaktestcomDNSLeakTestcoma_KEY: |
+Check_a_hrefhttpswwwPdnsleaktestPcomDNSLeakTestPcomaP_65_KEY: |
   Check <a href="https://www.dnsleaktest.com/">DNSLeakTest.com</a>.
 
-Your_DNS_provider_may_not_appear_with_their_own_name_so_compare_the_responses_to_what_you_know_or_can_find_about_your_DNS_provider_Just_ensure_you_do_KEY: |
+Your_DNS_provider_may_not_appear_with_their_own_name_so_compare_the_responses_to_what_you_know_or_can_find_about_your_DNS_providerP_Just_ensure_you_do_200_KEY: |
   Your DNS provider may not appear with their own name, so compare the responses to what you know or can find about your DNS provider. Just ensure you don't see your ISP or old unencrypted DNS provider.
 
-Check_the_website_of_your_DNS_provider_They_may_have_a_page_for_telling_you_are_using_our_DNS_Examples_include_a_hrefhttpsadguardcomenadgu_KEY: |
+Check_the_website_of_your_DNS_providerP_They_may_have_a_page_for_telling_you_are_using_our_DNSP_Examples_include_a_hrefhttpsadguardPcomenadgu_236_KEY: |
   Check the website of your DNS provider. They may have a page for telling "you are using our DNS." Examples include <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a> and <a href="https://1.1.1.1/help">Cloudflare</a>.
 
-If_using_Firefoxs_trusted_recursive_resolver_TRR_navigate_to_codeaboutnetworkingdnscode_If_the_TRR_column_says_true_for_some_fields_you__KEY: |
+If_using_Firefoxs_trusted_recursive_resolver_TRR_navigate_to_codeaboutnetworkingdnscodeP_If_the_TRR_column_says_true_for_some_fields_you__165_KEY: |
   If using Firefox's trusted recursive resolver (TRR), navigate to <code>about:networking#dns</code>. If the TRR column says "true" for some fields, you are using DoH.
 
-Some_fields_will_say_false_depending_on_the_the_value_of_networktrrmode_in_aboutconfig_KEY: |
+Some_fields_will_say_false_depending_on_the_the_value_of_networkPtrrPmode_in_aboutconfig_92_KEY: |
   Some fields will say "false" depending on the the value of network.trr.mode in about:config
 
-dnscryptproxy__Check_a_hrefhttpsgithubcomjedisct1dnscryptproxywikiCheckingdnscryptproxys_wiki_on_how_to_verify_that_your_DNS_is_encry_KEY: |
+dnscryptproxy__Check_a_hrefhttpsgithubPcomjedisct1dnscryptproxywikiCheckingdnscryptproxys_wiki_on_how_to_verify_that_your_DNS_is_encry_160_KEY: |
   dnscrypt-proxy - Check <a href="https://github.com/jedisct1/dnscrypt-proxy/wiki/Checking">dnscrypt-proxy's wiki on how to verify that your DNS is encrypted</a>.
 
-DNSSEC__Check_a_hrefhttpsdnssecvsuniduedeDNSSEC_Resolver_Test_by_Matthus_Wandera_KEY: |
+DNSSEC__Check_a_hrefhttpsdnssecPvsPuniduePdeDNSSEC_Resolver_Test_by_Matthus_WanderaP_99_KEY: |
   DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">DNSSEC Resolver Test by Matthäus Wander</a>.
 
-QNAME_Minimization__Run_codedig_short_txt_qnamemintestinternetnlcode_from_the_commandline_taken_from_a_hrefhttpsnlnetlabsnldownloads_KEY: |
+QNAME_Minimization__Run_codedig_short_txt_qnamemintestPinternetPnlcode_from_the_commandline_taken_from_a_hrefhttpsnlnetlabsPnldownloads_455_KEY: |
   QNAME Minimization - Run <code>dig +short txt qnamemintest.internet.nl</code> from the command-line (taken from <a href="https://nlnetlabs.nl/downloads/presentations/unbound_qnamemin_oarc24.pdf">this NLnet Labs presentation</a>). If you are on Windows 10, run <code>Resolve-DnsName -Type TXT -Name qnamemintest.internet.nl</code> from the PowerShell. You should see this display: <code>"HOORAY - QNAME minimisation is enabled on your resolver :)!"</code>
 
-Software_Suggestions_and_Additional_Information_KEY: |
+Software_Suggestions_and_Additional_Information_48_KEY: |
   Software Suggestions and Additional Information
 
-Encrypted_DNS_clients_for_desktop_KEY: |
+Encrypted_DNS_clients_for_desktop_35_KEY: |
   Encrypted DNS clients for desktop:
 
-emFirefoxem_comes_with_builtin_DoH_support_with_Cloudflare_set_as_the_default_resolver_but_can_be_configured_to_use_any_DoH_resolver_KEY: |
+emFirefoxem_comes_with_builtin_DoH_support_with_Cloudflare_set_as_the_default_resolver_but_can_be_configured_to_use_any_DoH_resolverP_140_KEY: |
   <em>Firefox</em> comes with built-in DoH support with Cloudflare set as the default resolver, but can be configured to use any DoH resolver.
 
-Cloudflare_has_agreed_to_collect_only_a_limited_amount_of_data_about_the_DNS_requests_that_are_sent_to_the_Cloudflare_Resolver_for_Firefox_via_the_Fir_KEY: |
+Cloudflare_has_agreed_to_collect_only_a_limited_amount_of_data_about_the_DNS_requests_that_are_sent_to_the_Cloudflare_Resolver_for_Firefox_via_the_Fir_165_KEY: |
   "Cloudflare has agreed to collect only a limited amount of data about the DNS requests that are sent to the Cloudflare Resolver for Firefox via the Firefox browser."
 
-httpsdeveloperscloudflarecom1111commitmenttoprivacyprivacypolicyfirefox_KEY: |
+httpsdevelopersPcloudflarePcom1P1P1P1commitmenttoprivacyprivacypolicyfirefox_87_KEY: |
   https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/firefox/
 
-Currently_Mozilla_is_a_hrefhttpsblogmozillaorgfuturereleases20190731dnsoverhttpsdohupdatedetectingmanagednetworksanduserchoice_KEY: |
+Currently_Mozilla_is_a_hrefhttpsblogPmozillaPorgfuturereleases20190731dnsoverhttpsdohupdatedetectingmanagednetworksanduserchoice_238_KEY: |
   Currently Mozilla is <a href="https://blog.mozilla.org/futurereleases/2019/07/31/dns-over-https-doh-update-detecting-managed-networks-and-user-choice/">conducting studies</a> before enabling DoH by default for all US-based Firefox users.
 
-DNS_over_HTTPS_can_be_enabled_in_Menu__Preferences_codeaboutpreferencescode__Network_Settings__Enable_DNS_over_HTTPS_Set_Use_Provider__KEY: |
+DNS_over_HTTPS_can_be_enabled_in_Menu__Preferences_codeaboutpreferencescode__Network_Settings__Enable_DNS_over_HTTPSP_Set_Use_Provider__203_KEY: |
   DNS over HTTPS can be enabled in Menu -> Preferences (<code>about:preferences</code>) -> Network Settings -> Enable DNS over HTTPS. Set "Use Provider" to "Custom", and enter your DoH provider's address.
 
-Advanced_users_may_enable_it_in_codeaboutconfigcode_by_setting_codenetworktrrcustom_uricode_and_codenetworktrruricode_as_the_addres_KEY: |
+Advanced_users_may_enable_it_in_codeaboutconfigcode_by_setting_codenetworkPtrrPcustom_uricode_and_codenetworkPtrrPuricode_as_the_addres_450_KEY: |
   Advanced users may enable it in <code>about:config</code> by setting <code>network.trr.custom_uri</code> and <code>network.trr.uri</code> as the address you find from the documentation of your DoH provider and <code>network.trr.mode</code> as <code>2</code>. It may also be desirable to set <code>network.security.esni.enabled</code> to <code>True</code> in order to enable encrypted SNI and make sites supporting ESNI a bit more difficult to track.
 
-Encrypted_DNS_clients_for_mobile_KEY: |
+Encrypted_DNS_clients_for_mobile_34_KEY: |
   Encrypted DNS clients for mobile:
 
-emAndroid_9em_comes_with_a_DoT_client_by_a_hrefhttpssupportgooglecomandroidanswer9089903defaulta_KEY: |
+emAndroid_9em_comes_with_a_DoT_client_by_a_hrefhttpssupportPgooglePcomandroidanswer9089903defaultaP_118_KEY: |
   <em>Android 9</em> comes with a DoT client by <a href="https://support.google.com/android/answer/9089903">default</a>.
 
-but_with_some_caveats_KEY: |
+PPPbut_with_some_caveats_25_KEY: |
   ...but with some caveats
 
-httpswwwquad9netprivatednsquad9android9_KEY: |
+httpswwwPquad9Pnetprivatednsquad9android9_49_KEY: |
   https://www.quad9.net/private-dns-quad9-android9/
 
-We_recommend_selecting_emPrivate_DNS_provider_hostnameem_and_entering_the_DoT_address_from_documentation_of_your_DoT_provider_to_enable_strict_mod_KEY: |
+We_recommend_selecting_emPrivate_DNS_provider_hostnameem_and_entering_the_DoT_address_from_documentation_of_your_DoT_provider_to_enable_strict_mod_171_KEY: |
   We recommend selecting <em>Private DNS provider hostname</em> and entering the DoT address from documentation of your DoT provider to enable strict mode (see Terms above).
 
-If_you_are_on_a_network_blocking_access_to_port_853_Android_will_error_about_the_network_not_having_internet_connectivity_KEY: |
+If_you_are_on_a_network_blocking_access_to_port_853_Android_will_error_about_the_network_not_having_internet_connectivityP_124_KEY: |
   If you are on a network blocking access to port 853, Android will error about the network not having internet connectivity.
 
-httpsappsapplecomappid1452162351_KEY: |
+httpsappsPapplePcomappid1452162351_40_KEY: |
   https://apps.apple.com/app/id1452162351
 
-DNSCloak_KEY: |
+DNSCloak_9_KEY: |
   DNSCloak
 
-An_a_hrefhttpsgithubcomssdnscloakopensourcea_DNSCrypt_and_DoH_client_for_iOS_by_tda_datatoggletooltip_dataplacementbottom_da_KEY: |
+An_a_hrefhttpsgithubPcomssdnscloakopensourcea_DNSCrypt_and_DoH_client_for_iOS_by_tda_datatoggletooltip_dataplacementbottom_da_362_KEY: |
   An <a href="https://github.com/s-s/dnscloak">open-source</a> DNSCrypt and DoH client for iOS by <td><a data-toggle="tooltip" data-placement="bottom" data-original-title='"A charitable non-profit host organization for international Free Software projects."' href="https://techcultivation.org/">the Center for the Cultivation of Technology gemeinnuetzige GmbH</a>.
 
-httpsgitfrostnerdcomPublicAndroidAppssmokescreenblobmasterREADMEmd_KEY: |
+httpsgitPfrostnerdPcomPublicAndroidAppssmokescreenblobmasterREADMEPmd_78_KEY: |
   https://git.frostnerd.com/PublicAndroidApps/smokescreen/blob/master/README.md
 
-Nebulo_KEY: |
+Nebulo_7_KEY: |
   Nebulo
 
-An_opensource_application_for_Android_supporting_DoH_and_DoT_It_also_supports_caching_DNS_responses_and_locally_logging_DNS_queries_KEY: |
+An_opensource_application_for_Android_supporting_DoH_and_DoTP_It_also_supports_caching_DNS_responses_and_locally_logging_DNS_queriesP_134_KEY: |
   An open-source application for Android supporting DoH and DoT. It also supports caching DNS responses and locally logging DNS queries.
 
-Local_DNS_servers_KEY: |
+Local_DNS_servers_19_KEY: |
   Local DNS servers:
 
-httpsdnsprivacyorgwikidisplayDPDNSPrivacyDaemonStubby_KEY: |
+httpsdnsprivacyPorgwikidisplayDPDNSPrivacyDaemonStubby_66_KEY: |
   https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby
 
-Stubby_KEY: |
+Stubby_7_KEY: |
   Stubby
 
-An_opensource_application_for_Linux_macOS_and_Windows_that_acts_as_a_local_DNS_Privacy_stub_resolver_using_DoT_KEY: |
+An_opensource_application_for_Linux_macOS_and_Windows_that_acts_as_a_local_DNS_Privacy_stub_resolver_using_DoTP_114_KEY: |
   An open-source application for Linux, macOS, and Windows that acts as a local DNS Privacy stub resolver using DoT.
 
-httpsnlnetlabsnlprojectsunboundabout_KEY: |
+httpsnlnetlabsPnlprojectsunboundabout_44_KEY: |
   https://nlnetlabs.nl/projects/unbound/about/
 
-Unbound_KEY: |
+Unbound_8_KEY: |
   Unbound
 
-a_validating_recursive_caching_DNS_resolver_It_can_also_be_ran_networkwide_and_has_supported_DNSoverTLS_since_version_173_KEY: |
+a_validating_recursive_caching_DNS_resolverP_It_can_also_be_ran_networkwide_and_has_supported_DNSoverTLS_since_version_1P7P3P_130_KEY: |
   a validating, recursive, caching DNS resolver. It can also be ran network-wide and has supported DNS-over-TLS since version 1.7.3.
 
-See_also_a_hrefhttpswwwctrlblogentryunboundtlsforwardinghtmlActually_secure_DNS_over_TLS_in_Unbound_on_ctrlbloga_KEY: |
+See_also_a_hrefhttpswwwPctrlPblogentryunboundtlsforwardingPhtmlActually_secure_DNS_over_TLS_in_Unbound_on_ctrlPblogaP_132_KEY: |
   See also <a href="https://www.ctrl.blog/entry/unbound-tls-forwarding.html">Actually secure DNS over TLS in Unbound on ctrl.blog</a>.
 
-Networkwide_DNS_servers_KEY: |
+Networkwide_DNS_servers_25_KEY: |
   Network-wide DNS servers:
 
-httpspiholenet_KEY: |
+httpspiholePnet_20_KEY: |
   https://pi-hole.net/
 
-Pihole_KEY: |
+Pihole_8_KEY: |
   Pi-hole
 
-A_networkwide_DNS_server_mainly_for_the_Raspberry_Pi_Blocks_ads_tracking_and_malicious_domains_for_all_devices_on_your_network_KEY: |
+A_networkwide_DNS_server_mainly_for_the_Raspberry_PiP_Blocks_ads_tracking_and_malicious_domains_for_all_devices_on_your_networkP_132_KEY: |
   A network-wide DNS server mainly for the Raspberry Pi. Blocks ads, tracking, and malicious domains for all devices on your network.
 
-NoTrack_KEY: |
+NoTrack_8_KEY: |
   NoTrack
 
-A_networkwide_DNS_server_like_Pihole_for_blocking_ads_tracking_and_malicious_domains_KEY: |
+A_networkwide_DNS_server_like_Pihole_for_blocking_ads_tracking_and_malicious_domainsP_90_KEY: |
   A network-wide DNS server like Pi-hole for blocking ads, tracking, and malicious domains.
 
-Further_reading_KEY: |
+Further_reading_17_KEY: |
   Further reading:
 
-On_Firefox_DoH_and_ESNI_KEY: |
+On_Firefox_DoH_and_ESNI_25_KEY: |
   On Firefox, DoH and ESNI
 
-httpswikimozillaorgTrusted_Recursive_Resolver_KEY: |
+httpswikiPmozillaPorgTrusted_Recursive_Resolver_52_KEY: |
   https://wiki.mozilla.org/Trusted_Recursive_Resolver
 
-Trusted_Recursive_Resolver_DoH_on_MozillaWiki_KEY: |
+Trusted_Recursive_Resolver_DoH_on_MozillaWiki_48_KEY: |
   Trusted Recursive Resolver (DoH) on MozillaWiki
 
-httpsbugzillamozillaorgshow_bugcgiid1500289_KEY: |
+httpsbugzillaPmozillaPorgshow_bugPcgiQid1500289_53_KEY: |
   https://bugzilla.mozilla.org/show_bug.cgi?id=1500289
 
-Firefox_bug_report_requesting_the_ability_to_use_ESNI_without_DoH_KEY: |
+Firefox_bug_report_requesting_the_ability_to_use_ESNI_without_DoH_66_KEY: |
   Firefox bug report requesting the ability to use ESNI without DoH
 
-httpsbugzillamozillaorgshow_bugcgiid1542754_KEY: |
+httpsbugzillaPmozillaPorgshow_bugPcgiQid1542754_53_KEY: |
   https://bugzilla.mozilla.org/show_bug.cgi?id=1542754
 
-Firefox_bug_report_requesting_the_ability_to_use_Android_9s_Private_DNS_DoT_and_benefit_from_encrypted_SNI_without_having_to_enable_DoH_KEY: |
+Firefox_bug_report_requesting_the_ability_to_use_Android_9s_Private_DNS_DoT_and_benefit_from_encrypted_SNI_without_having_to_enable_DoH_140_KEY: |
   Firefox bug report requesting the ability to use Android 9+'s Private DNS (DoT) and benefit from encrypted SNI without having to enable DoH
 
-httpsblogcloudflarecomencryptedsni_KEY: |
+httpsblogPcloudflarePcomencryptedsni_43_KEY: |
   https://blog.cloudflare.com/encrypted-sni/
 
-Encrypt_it_or_lose_it_how_encrypted_SNI_works_on_Cloudflare_blog_KEY: |
+Encrypt_it_or_lose_it_how_encrypted_SNI_works_on_Cloudflare_blog_66_KEY: |
   Encrypt it or lose it: how encrypted SNI works on Cloudflare blog
 
-httpswwwiscorgblogsqnameminimizationandprivacy_KEY: |
+httpswwwPiscPorgblogsqnameminimizationandprivacy_58_KEY: |
   https://www.isc.org/blogs/qname-minimization-and-privacy/
 
-QNAME_Minimization_and_Your_Privacya_by_the_Internet_Systems_Consortium_ISC_KEY: |
+QNAME_Minimization_and_Your_Privacya_by_the_Internet_Systems_Consortium_ISC_81_KEY: |
   QNAME Minimization and Your Privacy</a> by the Internet Systems Consortium (ISC)
 
-httpswwwiscorgdnssec_KEY: |
+httpswwwPiscPorgdnssec_28_KEY: |
   https://www.isc.org/dnssec/
 
-DNSSEC_and_BIND_9a_by_the_ISC_KEY: |
+DNSSEC_and_BIND_9a_by_the_ISC_33_KEY: |
   DNSSEC and BIND 9</a> by the ISC
 
-Donate_via_OpenCollective_KEY: |
+Donate_via_OpenCollective_26_KEY: |
   Donate via OpenCollective
 
-If_you_are_able_please_consider_contributing_to_our_development_and_outreach_programs_KEY: |
+If_you_are_able_please_consider_contributing_to_our_development_and_outreach_programsP_87_KEY: |
   If you are able, please consider contributing to our development and outreach programs.
 
-Contributions_via_OpenCollective_to__sitename__are_tax_deductible_for_US_taxpayers_KEY: |
+Contributions_via_OpenCollective_to__sitePname__are_tax_deductible_for_US_taxpayersP_89_KEY: |
   Contributions via OpenCollective to {{ site.name }} are tax deductible for US taxpayers.
 
-These_funds_are_transparently_and_primarily_used_to_cover_server_costs_KEY: |
+These_funds_are_transparently_and_primarily_used_to_cover_server_costsP_72_KEY: |
   These funds are transparently and primarily used to cover server costs.
 
-Contribute_KEY: |
+Contribute_11_KEY: |
   Contribute
 
-More_Info_KEY: |
+More_Info_10_KEY: |
   More Info
 
-Please_Donate_KEY: |
+Please_Donate_14_KEY: |
   Please Donate
 
-Our_website_is_free_of_advertisements_and_not_affiliated_with_any_listed_providers_KEY: |
+Our_website_is_free_of_advertisements_and_not_affiliated_with_any_listed_providersP_84_KEY: |
   Our website is free of advertisements and not affiliated with any listed providers.
 
-Your_donation_will_cover_our_costs_for_servers_domains_coffee_beer_and_pizza_KEY: |
+Your_donation_will_cover_our_costs_for_servers_domains_coffee_beer_and_pizzaP_82_KEY: |
   Your donation will cover our costs for servers, domains, coffee, beer, and pizza.
 
-You_may_also_contribute_via_the_cryptocurrencies_below_however_we_will_not_be_able_to_provide_a_receipt_for_your_contribution_KEY: |
+You_may_also_contribute_via_the_cryptocurrencies_below_however_we_will_not_be_able_to_provide_a_receipt_for_your_contributionP_129_KEY: |
   You may also contribute via the cryptocurrencies below; however, we will not be able to provide a receipt for your contribution.
 
-Your_contribution_will_be_considered_an_anonymous_unrestricted_contribution_and_paid_to_our_Fiscal_Host_at_OpenCollective_when_we_convert_to_currency_KEY: |
+Your_contribution_will_be_considered_an_anonymous_unrestricted_contribution_and_paid_to_our_Fiscal_Host_at_OpenCollective_when_we_convert_to_currencyP_152_KEY: |
   Your contribution will be considered an anonymous, unrestricted contribution and paid to our Fiscal Host at OpenCollective when we convert to currency.
 
-We_prefer_Bitcoin_donations_to_be_above_5_due_to_the_state_of_the_networks_transaction_fees_You_are_welcome_to_donate_any_smaller_or_larger_amount_o_KEY: |
+We_prefer_Bitcoin_donations_to_be_above_5_due_to_the_state_of_the_networks_transaction_feesP_You_are_welcome_to_donate_any_smaller_or_larger_amount_o_223_KEY: |
   We prefer Bitcoin donations to be above $5 due to the state of the network's transaction fees. You are welcome to donate any smaller or larger amount on any other cryptocurrency, such as Bitcoin Cash, Ethereum, or Stellar.
 
-More_Cryptocurrencies_KEY: |
+More_Cryptocurrencies_22_KEY: |
   More Cryptocurrencies
 
-The_a_href_contact__translate_page__sitename__teama_does_not_necessarily_endorse_all_of_the_cryptocurrencies_listed_on_this_page_KEY: |
+The_a_href_contact__translate_page__sitePname__teama_does_not_necessarily_endorse_all_of_the_cryptocurrencies_listed_on_this_pageP_225_KEY: |
   The <a href="{{ '/contact/' | translate_page }}">{{ site.name }} team</a> does not necessarily endorse all of the cryptocurrencies listed on this page. Please conduct your own research before purchasing any cryptocurrencies.
 
-Thanks_for_your_support_You_are_awesome!_KEY: |
+Thanks_for_your_supportP_You_are_awesomeE_42_KEY: |
   Thanks for your support. You are awesome!
 
-PrivacyConscious_Email_Providers__No_Affiliates_KEY: |
-  Privacy-Conscious Email Providers - No Affiliates
-
-All_providers_listed_here_are_operating_outside_the_US_and_support_a_datatoggletooltip_dataplacementbottom_dataoriginaltitleWhen_sending_o_KEY: |
-  All providers listed here are operating outside the US and support <a data-toggle="tooltip" data-placement="bottom" data-original-title="When sending or receiving emails, if both the sending and receiving servers support TLS encryption, the email is sent between servers using an encrypted connection.">SMTP TLS.</a> The table is sortable.
-
-Email_Provider_KEY: |
-  Email Provider
-
-Since_KEY: |
-  Since
-
-Jurisdiction_KEY: |
-  Jurisdiction
-
-Storage_KEY: |
-  Storage
-
-Yearly_Price_KEY: |
-  Yearly Price
-
-Bitcoin_KEY: |
-  Bitcoin
-
-Encryption_KEY: |
-  Encryption
-
-Own_Domain_KEY: |
-  Own Domain
-
-httpsdisrootorg_KEY: |
-  https://disroot.org
-
-Netherlands_KEY: |
-  Netherlands
-
-_Free__tl_note_free_as_in_no_money_cost__KEY: |
-  {{ "Free" | tl_note: free as in no money cost }}
-
-Accepted_KEY: |
-  Accepted
-
-Builtin_KEY: |
-  Built-in
-
-httpskolabnowcom_KEY: |
-  https://kolabnow.com
-
-Switzerland_KEY: |
-  Switzerland
-
-httpsmailboxorg_KEY: |
-  https://mailbox.org
-
-httpsmailfencecom_KEY: |
-  https://mailfence.com
-
-Belgium_KEY: |
-  Belgium
-
-httpswwwneomailboxcom_KEY: |
-  https://www.neomailbox.com
-
-httpsposteode_KEY: |
-  https://posteo.de
-
-httpsprotonmailcom_KEY: |
-  https://protonmail.com
-
-Tor_KEY: |
-  Tor
-
-httpsrunboxcom_KEY: |
-  https://runbox.com
-
-Norway_KEY: |
-  Norway
-
-httpssoverinnet_KEY: |
-  https://soverin.net/
-
-httpswwwstartmailcom_KEY: |
-  https://www.startmail.com
-
-httpswwwtutanotacom_KEY: |
-  https://www.tutanota.com
-
-Interesting_Email_Providers_Under_Development_KEY: |
-  Interesting Email Providers Under Development
-
-httpswwwconfidantmailorg_KEY: |
-  https://www.confidantmail.org/
-
-Confidant_Mail_KEY: |
-  Confidant Mail
-
-An_opensource_nonSMTP_cryptographic_email_system_optimized_for_large_file_attachments_It_is_a_secure_and_spamresistant_alternative_to_regular_email_KEY: |
-  An open-source non-SMTP cryptographic email system optimized for large file attachments. It is a secure and spam-resistant alternative to regular email and online file drop services. It uses <a href="https://theprivacyguide.org/tutorials/gpg.html">GNU Privacy Guard (GPG)</a> for content encryption and authentication, and TLS 1.2 with ephemeral keys for transport encryption.
-
-Become_Your_Own_Email_Provider_with_MailinaBox_KEY: |
-  Become Your Own Email Provider with Mail-in-a-Box
-
-httpsmailinaboxemail_KEY: |
-  https://mailinabox.email/
-
-MailinaBox_KEY: |
-  Mail-in-a-Box
-
-Take_it_a_step_further_and_get_control_of_your_email_with_this_easytodeploy_mail_server_in_a_box_MailinaBox_lets_you_become_your_own_mail_service_KEY: |
-  Take it a step further and get control of your email with this easy-to-deploy mail server in a box. Mail-in-a-Box lets you become your own mail service provider in a few easy steps. It's sort of like making your own Gmail, but one you control from top to bottom. Technically, Mail-in-a-Box turns a fresh cloud computer into a working mail server. But you don't need to be a technology expert to set it up.
-
-More_KEY: |
-  More:
-
-httpswwwwiredcom201110ecpaturnstwentyfive_KEY: |
-  https://www.wired.com/2011/10/ecpa-turns-twenty-five/
-
-Aging_Privacy_Law_Leaves_Cloud_EMail_Open_to_Cops_KEY: |
-  Aging 'Privacy' Law Leaves Cloud E-Mail Open to Cops
-
-Data_stored_in_the_cloud_for_longer_than_6_months_is_considered_abandoned_and_may_be_accessed_by_intelligence_agencies_without_a_warrant_Learning_Use_KEY: |
-  Data stored in the cloud for longer than 6 months is considered abandoned and may be accessed by intelligence agencies without a warrant. Learning: Use an external email client like Thunderbird or Enigmail, download your emails and store them locally. Never leave them on the server.
-
-httpswwwefforgdeeplinks201204mayfirstriseupserverseizurefbioverreachesyetagain_KEY: |
-  https://www.eff.org/deeplinks/2012/04/may-firstriseup-server-seizure-fbi-overreaches-yet-again
-
-With_May_FirstRiseup_Server_Seizure_FBI_Overreaches_Yet_Again_KEY: |
-  With May First/Riseup Server Seizure, FBI Overreaches Yet Again
-
-httpswwwautisticiorgaicrackdown_KEY: |
-  https://www.autistici.org/ai/crackdown/
-
-AutisticiInventati_server_compromised_KEY: |
-  Autistici/Inventati server compromised
-
-The_cryptographic_services_offered_by_the_AutisticiInventati_server_have_been_compromised_on_15th_June_2004_It_was_discovered_on_21st_June_2005_One__KEY: |
-  The cryptographic services offered by the Autistici/Inventati server have been compromised on 15th June 2004. It was discovered on 21st June 2005. One year later. During an enquiry on a single mailbox, the Postal Police may have tapped for a whole year every user's private communication going through the server autistici.org/inventati.org.
-
-Thunderbird_KEY: |
+Thunderbird_11_KEY: |
   Thunderbird
 
-Thunderbird_is_a_free_open_source_crossplatform_email_newsgroup_news_feed_and_chat_XMPP_IRC_Twitter_client_developed_by_community_previously_KEY: |
+Thunderbird_is_a_free_open_source_crossplatform_email_newsgroup_news_feed_and_chat_XMPP_IRC_Twitter_client_developed_by_community_previously_178_KEY: |
   Thunderbird is a free, open source, cross-platform email, newsgroup, news feed, and chat (XMPP, IRC, Twitter) client developed by community, previously by the Mozilla Foundation.
 
-httpswwwthunderbirdnet_KEY: |
+httpswwwPthunderbirdPnet_28_KEY: |
   https://www.thunderbird.net/
 
-httpswwwthunderbirdnetenUS_KEY: |
+httpswwwPthunderbirdPnetenUS_34_KEY: |
   https://www.thunderbird.net/en-US/
 
-httpswwwfreshportsorgmailthunderbird_KEY: |
+httpswwwPfreshportsPorgmailthunderbird_44_KEY: |
   https://www.freshports.org/mail/thunderbird/
 
-httpopenportssemailmozillathunderbird_KEY: |
+httpopenportsPsemailmozillathunderbird_44_KEY: |
   http://openports.se/mail/mozilla-thunderbird
 
-httppkgsrcsemailthunderbird_KEY: |
+httppkgsrcPsemailthunderbird_33_KEY: |
   http://pkgsrc.se/mail/thunderbird
 
-httpshgmozillaorgcommcentral_KEY: |
+httpshgPmozillaPorgcommcentral_36_KEY: |
   https://hg.mozilla.org/comm-central/
 
-Claws_Mail_KEY: |
+Claws_Mail_10_KEY: |
   Claws Mail
 
-Claws_Mail_is_a_free_and_open_source_GTKbased_email_and_news_client_It_offers_easy_configuration_and_an_abundance_of_features_It_is_included_with_G_KEY: |
+Claws_Mail_is_a_free_and_open_source_GTKbased_email_and_news_clientP_It_offers_easy_configuration_and_an_abundance_of_featuresP_It_is_included_with_G_191_KEY: |
   Claws Mail is a free and open source, GTK-based email and news client. It offers easy configuration and an abundance of features. It is included with Gpg4win, an encryption suite for Windows.
 
-httpswwwclawsmailorg_KEY: |
+httpswwwPclawsmailPorg_27_KEY: |
   https://www.claws-mail.org/
 
-httpswwwclawsmailorgwin32_KEY: |
+httpswwwPclawsmailPorgwin32_33_KEY: |
   https://www.claws-mail.org/win32/
 
-httpswwwclawsmailorgfaqindexphpInstallation_and_ConfigurationWhat_do_I_need_to_compile_Claws_Mail3F_KEY: |
+httpswwwPclawsmailPorgfaqindexPphpInstallation_and_ConfigurationWhat_do_I_need_to_compile_Claws_MailP3F_111_KEY: |
   https://www.claws-mail.org/faq/index.php/Installation_and_Configuration#What_do_I_need_to_compile_Claws_Mail.3F
 
-httpswwwclawsmailorgdownloadsphpsectiondownloads_KEY: |
+httpswwwPclawsmailPorgdownloadsPphpQsectiondownloads_58_KEY: |
   https://www.claws-mail.org/downloads.php?section=downloads
 
-httpswwwfreshportsorgmailclawsmail_KEY: |
+httpswwwPfreshportsPorgmailclawsmail_43_KEY: |
   https://www.freshports.org/mail/claws-mail/
 
-httpopenportssemailclawsmail_KEY: |
+httpopenportsPsemailclawsmail_35_KEY: |
   http://openports.se/mail/claws-mail
 
-httppkgsrcsemailclawsmail_KEY: |
+httppkgsrcPsemailclawsmail_32_KEY: |
   http://pkgsrc.se/mail/claws-mail
 
-httpsgitclawsmailorg_KEY: |
+httpsgitPclawsmailPorg_27_KEY: |
   https://git.claws-mail.org/
 
-Privacy_Email_Tools_KEY: |
+Privacy_Email_Tools_20_KEY: |
   Privacy Email Tools
 
-httpswwwgpg4usborg_KEY: |
+httpswwwPgpg4usbPorg_25_KEY: |
   https://www.gpg4usb.org/
 
-gpg4usb_KEY: |
+gpg4usb_8_KEY: |
   gpg4usb
 
-A_very_easy_to_use_and_small_portable_editor_to_encrypt_and_decrypt_any_textmessage_or_file_For_Windows_and_Linux_a_hrefhttpstheprivacyguide_KEY: |
+A_very_easy_to_use_and_small_portable_editor_to_encrypt_and_decrypt_any_textmessage_or_fileP_For_Windows_and_LinuxP_a_hrefhttpstheprivacyguideP_193_KEY: |
   A very easy to use and small portable editor to encrypt and decrypt any text-message or -file. For Windows and Linux. <a href="https://theprivacyguide.org/tutorials/gpg.html">GPG tutorial</a>.
 
-httpswwwmailvelopecom_KEY: |
+httpswwwPmailvelopePcom_28_KEY: |
   https://www.mailvelope.com/
 
-Mailvelope_KEY: |
+Mailvelope_11_KEY: |
   Mailvelope
 
-A_browser_extension_that_enables_the_exchange_of_encrypted_emails_following_the_a_hrefhttpstheprivacyguideorgtutorialspgphtmlOpenPGP_encryp_KEY: |
+A_browser_extension_that_enables_the_exchange_of_encrypted_emails_following_the_a_hrefhttpstheprivacyguidePorgtutorialspgpPhtmlOpenPGP_encryp_170_KEY: |
   A browser extension that enables the exchange of encrypted emails following the <a href="https://theprivacyguide.org/tutorials/pgp.html">OpenPGP encryption standard</a>.
 
-httpswwwenigmailnet_KEY: |
+httpswwwPenigmailPnet_26_KEY: |
   https://www.enigmail.net/
 
-Enigmail_KEY: |
+Enigmail_9_KEY: |
   Enigmail
 
-A_security_extension_to_Thunderbird_and_Seamonkey_It_enables_you_to_write_and_receive_email_messages_signed_andor_encrypted_with_the_a_hrefhttps_KEY: |
+A_security_extension_to_Thunderbird_and_SeamonkeyP_It_enables_you_to_write_and_receive_email_messages_signed_andor_encrypted_with_the_a_hrefhttps_214_KEY: |
   A security extension to Thunderbird and Seamonkey. It enables you to write and receive email messages signed and/or encrypted with the <a href="https://theprivacyguide.org/tutorials/pgp.html">OpenPGP standard</a>.
 
-httpsaddonsthunderbirdnetthunderbirdaddontorbirdy_KEY: |
+httpsaddonsPthunderbirdPnetthunderbirdaddontorbirdy_59_KEY: |
   https://addons.thunderbird.net/thunderbird/addon/torbirdy/
 
-TorBirdy_KEY: |
+TorBirdy_9_KEY: |
   TorBirdy
 
-TorBirdy_configures_Thunderbird_to_make_connections_over_the_Tor_anonymity_network_This_extension_is_in_beta_and_should_be_considered_experimental_KEY: |
+TorBirdy_configures_Thunderbird_to_make_connections_over_the_Tor_anonymity_networkP_This_extension_is_in_beta_and_should_be_considered_experimentalP_149_KEY: |
   TorBirdy configures Thunderbird to make connections over the Tor anonymity network. This extension is in beta and should be considered experimental.
 
-httpswwwemailprivacytestercom_KEY: |
+httpswwwPemailprivacytesterPcom_36_KEY: |
   https://www.emailprivacytester.com/
 
-Email_Privacy_Tester_KEY: |
+Email_Privacy_Tester_21_KEY: |
   Email Privacy Tester
 
-This_tool_will_send_an_Email_to_your_address_and_perform_privacyrelated_tests_KEY: |
+This_tool_will_send_an_Email_to_your_address_and_perform_privacyrelated_testsP_80_KEY: |
   This tool will send an Email to your address and perform privacy-related tests.
 
-httpsgithubcomk9mailk9releases_KEY: |
+httpsgithubPcomk9mailk9releases_39_KEY: |
   https://github.com/k9mail/k-9/releases
 
-K9_Mail_KEY: |
+K9_Mail_9_KEY: |
   K-9 Mail
 
-An_independent_mail_application_for_Android_It_supports_both_POP3_and_IMAP_mailboxes_but_only_supports_push_mail_for_IMAP_KEY: |
+An_independent_mail_application_for_AndroidP_It_supports_both_POP3_and_IMAP_mailboxes_but_only_supports_push_mail_for_IMAPP_125_KEY: |
   An independent mail application for Android. It supports both POP3 and IMAP mailboxes, but only supports push mail for IMAP.
 
-httpswwwgnupgorg_KEY: |
+httpswwwPgnupgPorg_23_KEY: |
   https://www.gnupg.org/
 
-GNU_Privacy_Guard_KEY: |
+GNU_Privacy_Guard_18_KEY: |
   GNU Privacy Guard
 
-Email_Encryption_GnuPG_is_a_GPL_Licensed_alternative_to_the_PGP_suite_of_cryptographic_software_a_hrefhttpstheprivacyguideorgtutorialsgpght_KEY: |
+Email_EncryptionP_GnuPG_is_a_GPL_Licensed_alternative_to_the_PGP_suite_of_cryptographic_softwareP_a_hrefhttpstheprivacyguidePorgtutorialsgpgPht_229_KEY: |
   Email Encryption. GnuPG is a GPL Licensed alternative to the PGP suite of cryptographic software. <a href="https://theprivacyguide.org/tutorials/gpg.html">Tutorial.</a> Use <a href="https://gpgtools.org/">GPGTools for macOS.</a>
 
-httpswwwmailpileis_KEY: |
+httpswwwPmailpilePis_25_KEY: |
   https://www.mailpile.is/
 
-Mailpile_Beta_KEY: |
+Mailpile_Beta_16_KEY: |
   Mailpile (Beta)
 
-A_modern_fast_webmail_client_with_userfriendly_encryption_and_privacy_features_KEY: |
+A_modern_fast_webmail_client_with_userfriendly_encryption_and_privacy_featuresP_83_KEY: |
   A modern, fast web-mail client with user-friendly encryption and privacy features.
 
-Bitmessage_KEY: |
+Bitmessage_10_KEY: |
   Bitmessage
 
-Bitmessage_is_a_P2P_communications_protocol_used_to_send_encrypted_messages_to_another_person_or_to_many_subscribers_It_is_decentralized_and_trustless_KEY: |
+Bitmessage_is_a_P2P_communications_protocol_used_to_send_encrypted_messages_to_another_person_or_to_many_subscribersP_It_is_decentralized_and_trustless_373_KEY: |
   Bitmessage is a P2P communications protocol used to send encrypted messages to another person or to many subscribers. It is decentralized and trustless, meaning that you need not inherently trust any entities like root certificate authorities. It uses strong authentication which means that the sender of a message cannot be spoofed, and it aims to hide "non-content" data.
 
-httpsbitmessageorg_KEY: |
+httpsbitmessagePorg_23_KEY: |
   https://bitmessage.org/
 
-httpsgithubcomBitmessagePyBitmessagereleases_KEY: |
+httpsgithubPcomBitmessagePyBitmessagereleases_51_KEY: |
   https://github.com/Bitmessage/PyBitmessage/releases
 
-httpsrepologyorgprojectpybitmessageversions_KEY: |
+httpsrepologyPorgprojectpybitmessageversions_50_KEY: |
   https://repology.org/project/pybitmessage/versions
 
-httpsgithubcomBitmessagePyBitmessage_KEY: |
+httpsgithubPcomBitmessagePyBitmessage_42_KEY: |
   https://github.com/Bitmessage/PyBitmessage
 
-RetroShare_KEY: |
+RetroShare_10_KEY: |
   RetroShare
 
-Retroshare_creates_encrypted_connections_to_your_friends_Nobody_can_spy_on_you_Retroshare_is_completely_decentralized_This_means_there_are_no_centra_KEY: |
+Retroshare_creates_encrypted_connections_to_your_friendsP_Nobody_can_spy_on_youP_Retroshare_is_completely_decentralizedP_This_means_there_are_no_centra_251_KEY: |
   Retroshare creates encrypted connections to your friends. Nobody can spy on you. Retroshare is completely decentralized. This means there are no central servers. It is entirely open-source and free. There are no costs, no ads, and no Terms of Service.
 
-httpsretrosharecc_KEY: |
+httpsretrosharePcc_22_KEY: |
   https://retroshare.cc/
 
-httpsretroshareccdownloadshtmlwindows_KEY: |
+httpsretrosharePccdownloadsPhtmlwindows_44_KEY: |
   https://retroshare.cc/downloads.html#windows
 
-httpsretroshareccdownloadshtmlmac_KEY: |
+httpsretrosharePccdownloadsPhtmlmac_40_KEY: |
   https://retroshare.cc/downloads.html#mac
 
-httpsretroshareccdownloadshtmlgnulinux_KEY: |
+httpsretrosharePccdownloadsPhtmlgnulinux_45_KEY: |
   https://retroshare.cc/downloads.html#gnulinux
 
-httpsretroshareccdownloadshtmlfreebsd_KEY: |
+httpsretrosharePccdownloadsPhtmlfreebsd_44_KEY: |
   https://retroshare.cc/downloads.html#freebsd
 
-httpsgithubcomRetroShareRetroShare_KEY: |
+httpsgithubPcomRetroShareRetroShare_40_KEY: |
   https://github.com/RetroShare/RetroShare
 
-httpsi2pbotexyz_KEY: |
+httpsi2pbotePxyz_21_KEY: |
   https://i2pbote.xyz/
 
-I2PBote_KEY: |
+I2PBote_9_KEY: |
   I2P-Bote
 
-Endtoend_encrypted_decentralized_mail_system_within_the_I2P_network_KEY: |
+Endtoend_encrypted_decentralized_mail_system_within_the_I2P_networkP_71_KEY: |
   End-to-end encrypted decentralized mail system within the I2P network.
 
-File_Encryption_Software_KEY: |
+PrivacyConscious_Email_Providers__No_Affiliates_50_KEY: |
+  Privacy-Conscious Email Providers - No Affiliates
+
+All_providers_listed_here_are_operating_outside_the_US_and_support_a_datatoggletooltip_dataplacementbottom_dataoriginaltitleWhen_sending_o_339_KEY: |
+  All providers listed here are operating outside the US and support <a data-toggle="tooltip" data-placement="bottom" data-original-title="When sending or receiving emails, if both the sending and receiving servers support TLS encryption, the email is sent between servers using an encrypted connection.">SMTP TLS.</a> The table is sortable.
+
+Email_Provider_15_KEY: |
+  Email Provider
+
+Since_6_KEY: |
+  Since
+
+Jurisdiction_13_KEY: |
+  Jurisdiction
+
+Storage_8_KEY: |
+  Storage
+
+Yearly_Price_13_KEY: |
+  Yearly Price
+
+Bitcoin_8_KEY: |
+  Bitcoin
+
+Encryption_11_KEY: |
+  Encryption
+
+Own_Domain_11_KEY: |
+  Own Domain
+
+httpsdisrootPorg_20_KEY: |
+  https://disroot.org
+
+Netherlands_12_KEY: |
+  Netherlands
+
+_Free__tl_note_free_as_in_no_money_cost__49_KEY: |
+  {{ "Free" | tl_note: free as in no money cost }}
+
+Accepted_9_KEY: |
+  Accepted
+
+Builtin_9_KEY: |
+  Built-in
+
+httpskolabnowPcom_21_KEY: |
+  https://kolabnow.com
+
+Switzerland_12_KEY: |
+  Switzerland
+
+httpsmailboxPorg_20_KEY: |
+  https://mailbox.org
+
+httpsmailfencePcom_22_KEY: |
+  https://mailfence.com
+
+Belgium_8_KEY: |
+  Belgium
+
+httpswwwPneomailboxPcom_27_KEY: |
+  https://www.neomailbox.com
+
+httpsposteoPde_18_KEY: |
+  https://posteo.de
+
+httpsprotonmailPcom_23_KEY: |
+  https://protonmail.com
+
+Tor_4_KEY: |
+  Tor
+
+httpsrunboxPcom_19_KEY: |
+  https://runbox.com
+
+Norway_7_KEY: |
+  Norway
+
+httpssoverinPnet_21_KEY: |
+  https://soverin.net/
+
+httpswwwPstartmailPcom_26_KEY: |
+  https://www.startmail.com
+
+httpswwwPtutanotaPcom_25_KEY: |
+  https://www.tutanota.com
+
+Interesting_Email_Providers_Under_Development_46_KEY: |
+  Interesting Email Providers Under Development
+
+httpswwwPconfidantmailPorg_31_KEY: |
+  https://www.confidantmail.org/
+
+Confidant_Mail_15_KEY: |
+  Confidant Mail
+
+An_opensource_nonSMTP_cryptographic_email_system_optimized_for_large_file_attachmentsP_It_is_a_secure_and_spamresistant_alternative_to_regular_email_377_KEY: |
+  An open-source non-SMTP cryptographic email system optimized for large file attachments. It is a secure and spam-resistant alternative to regular email and online file drop services. It uses <a href="https://theprivacyguide.org/tutorials/gpg.html">GNU Privacy Guard (GPG)</a> for content encryption and authentication, and TLS 1.2 with ephemeral keys for transport encryption.
+
+Become_Your_Own_Email_Provider_with_MailinaBox_50_KEY: |
+  Become Your Own Email Provider with Mail-in-a-Box
+
+httpsmailinaboxPemail_26_KEY: |
+  https://mailinabox.email/
+
+MailinaBox_14_KEY: |
+  Mail-in-a-Box
+
+Take_it_a_step_further_and_get_control_of_your_email_with_this_easytodeploy_mail_server_in_a_boxP_MailinaBox_lets_you_become_your_own_mail_service_405_KEY: |
+  Take it a step further and get control of your email with this easy-to-deploy mail server in a box. Mail-in-a-Box lets you become your own mail service provider in a few easy steps. It's sort of like making your own Gmail, but one you control from top to bottom. Technically, Mail-in-a-Box turns a fresh cloud computer into a working mail server. But you don't need to be a technology expert to set it up.
+
+More_6_KEY: |
+  More:
+
+httpsmailinaboxPemail_25_KEY: |
+  https://mailinabox.email/
+
+httpswwwPwiredPcom201110ecpaturnstwentyfive_54_KEY: |
+  https://www.wired.com/2011/10/ecpa-turns-twenty-five/
+
+Aging_Privacy_Law_Leaves_Cloud_EMail_Open_to_Cops_53_KEY: |
+  Aging 'Privacy' Law Leaves Cloud E-Mail Open to Cops
+
+Data_stored_in_the_cloud_for_longer_than_6_months_is_considered_abandoned_and_may_be_accessed_by_intelligence_agencies_without_a_warrantP_Learning_Use_284_KEY: |
+  Data stored in the cloud for longer than 6 months is considered abandoned and may be accessed by intelligence agencies without a warrant. Learning: Use an external email client like Thunderbird or Enigmail, download your emails and store them locally. Never leave them on the server.
+
+httpswwwPeffPorgdeeplinks201204mayfirstriseupserverseizurefbioverreachesyetagain_95_KEY: |
+  https://www.eff.org/deeplinks/2012/04/may-firstriseup-server-seizure-fbi-overreaches-yet-again
+
+With_May_FirstRiseup_Server_Seizure_FBI_Overreaches_Yet_Again_64_KEY: |
+  With May First/Riseup Server Seizure, FBI Overreaches Yet Again
+
+httpswwwPautisticiPorgaicrackdown_40_KEY: |
+  https://www.autistici.org/ai/crackdown/
+
+AutisticiInventati_server_compromised_39_KEY: |
+  Autistici/Inventati server compromised
+
+The_cryptographic_services_offered_by_the_AutisticiInventati_server_have_been_compromised_on_15th_June_2004P_It_was_discovered_on_21st_June_2005P_One__342_KEY: |
+  The cryptographic services offered by the Autistici/Inventati server have been compromised on 15th June 2004. It was discovered on 21st June 2005. One year later. During an enquiry on a single mailbox, the Postal Police may have tapped for a whole year every user's private communication going through the server autistici.org/inventati.org.
+
+File_Encryption_Software_25_KEY: |
   File Encryption Software
 
-If_you_are_currently_not_using_encryption_software_for_your_hard_disk_emails_or_file_archives_you_should_pick_one_here_KEY: |
+If_you_are_currently_not_using_encryption_software_for_your_hard_disk_emails_or_file_archives_you_should_pick_one_hereP_123_KEY: |
   If you are currently not using encryption software for your hard disk, emails, or file archives, you should pick one here.
 
-VeraCrypt__Disk_Encryption_KEY: |
+VeraCrypt__Disk_Encryption_27_KEY: |
   VeraCrypt - Disk Encryption
 
-strongVeraCryptstrong_is_a_sourceavailable_freeware_utility_used_for_onthefly_encryption_It_can_create_a_virtual_encrypted_disk_within_a_file__KEY: |
+strongVeraCryptstrong_is_a_sourceavailable_freeware_utility_used_for_onthefly_encryptionP_It_can_create_a_virtual_encrypted_disk_within_a_file__483_KEY: |
   <strong>VeraCrypt</strong> is a source-available freeware utility used for on-the-fly encryption. It can create a virtual encrypted disk within a file or encrypt a partition or the entire storage device with pre-boot authentication. VeraCrypt is a fork of the discontinued TrueCrypt project. It was initially released on June 22, 2013. According to its developers, security improvements have been implemented and issues raised by the initial TrueCrypt code audit have been addressed.
 
-httpsveracryptfr_KEY: |
+httpsveracryptPfr_21_KEY: |
   https://veracrypt.fr/
 
-httpswwwveracryptfrenDownloadshtml_KEY: |
+httpswwwPveracryptPfrenDownloadsPhtml_42_KEY: |
   https://www.veracrypt.fr/en/Downloads.html
 
-httpswwwveracryptfrcode_KEY: |
+httpswwwPveracryptPfrcode_30_KEY: |
   https://www.veracrypt.fr/code/
 
-GNU_Privacy_Guard__Email_Encryption_KEY: |
+GNU_Privacy_Guard__Email_Encryption_36_KEY: |
   GNU Privacy Guard - Email Encryption
 
-strongGnuPGstrong_is_a_GPLlicensed_alternative_to_the_PGP_suite_of_cryptographic_software_GnuPG_is_compliant_with_RFC_4880_which_is_the_current_KEY: |
+strongGnuPGstrong_is_a_GPLlicensed_alternative_to_the_PGP_suite_of_cryptographic_softwareP_GnuPG_is_compliant_with_RFC_4880_which_is_the_current_444_KEY: |
   <strong>GnuPG</strong> is a GPL-licensed alternative to the PGP suite of cryptographic software. GnuPG is compliant with RFC 4880, which is the current IETF standards track specification of OpenPGP. Current versions of PGP (and Veridis' Filecrypt) are interoperable with GnuPG and other OpenPGP-compliant systems. GnuPG is a part of the Free Software Foundation's GNU software project, and has received major funding from the German government.
 
-httpsgnupgorg_KEY: |
+httpsgnupgPorg_18_KEY: |
   https://gnupg.org/
 
-httpsgpg4winorgdownloadhtml_KEY: |
+httpsgpg4winPorgdownloadPhtml_33_KEY: |
   https://gpg4win.org/download.html
 
-httpsgpgtoolsorg_KEY: |
+httpsgpgtoolsPorg_21_KEY: |
   https://gpgtools.org/
 
-httpsgnupgorgdownloadindexhtmlbinary_KEY: |
+httpsgnupgPorgdownloadindexPhtmlbinary_44_KEY: |
   https://gnupg.org/download/index.html#binary
 
-httpswwwfreshportsorgsecuritygnupg_KEY: |
+httpswwwPfreshportsPorgsecuritygnupg_42_KEY: |
   https://www.freshports.org/security/gnupg/
 
-httpopenportssesecuritygnupg_KEY: |
+httpopenportsPsesecuritygnupg_34_KEY: |
   http://openports.se/security/gnupg
 
-httppkgsrcsesecuritygnupg_KEY: |
+httppkgsrcPsesecuritygnupg_31_KEY: |
   http://pkgsrc.se/security/gnupg
 
-httpsfdroidorgapporgsufficientlysecurekeychain_KEY: |
+httpsfdroidPorgapporgPsufficientlysecurePkeychain_55_KEY: |
   https://f-droid.org/app/org.sufficientlysecure.keychain
 
-httpsplaygooglecomstoreappsdetailsidorgsufficientlysecurekeychain_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidorgPsufficientlysecurePkeychain_77_KEY: |
   https://play.google.com/store/apps/details?id=org.sufficientlysecure.keychain
 
-httpsgitgnupgorgcgibingitwebcgipgnupggit_KEY: |
+httpsgitPgnupgPorgcgibingitwebPcgiQpgnupgPgit_52_KEY: |
   https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git
 
-PeaZip__File_Archive_Encryption_KEY: |
+PeaZip__File_Archive_Encryption_32_KEY: |
   PeaZip - File Archive Encryption
 
-strongPeaZipstrong_is_a_free_and_opensource_file_manager_and_file_archiver_made_by_Giorgio_Tani_It_supports_its_native_PEA_archive_format_featu_KEY: |
+strongPeaZipstrong_is_a_free_and_opensource_file_manager_and_file_archiver_made_by_Giorgio_TaniP_It_supports_its_native_PEA_archive_format_featu_368_KEY: |
   <strong>PeaZip</strong> is a free and open-source file manager and file archiver made by Giorgio Tani. It supports its native PEA archive format (featuring compression, multi volume split and flexible authenticated encryption and integrity check schemes) and other mainstream formats, with special focus on handling open formats. It also supports 180+ archive formats.
 
-httpwwwpeaziporg_KEY: |
+httpwwwPpeazipPorg_21_KEY: |
   http://www.peazip.org
 
-httpswwwpeaziporgpeazip64bithtml_KEY: |
+httpswwwPpeazipPorgpeazip64bitPhtml_40_KEY: |
   https://www.peazip.org/peazip-64bit.html
 
-httpswwwpeaziporgpeaziplinuxhtml_KEY: |
+httpswwwPpeazipPorgpeaziplinuxPhtml_40_KEY: |
   https://www.peazip.org/peazip-linux.html
 
-httpswwwfreshportsorgarchiverspeazip_KEY: |
+httpswwwPfreshportsPorgarchiverspeazip_44_KEY: |
   https://www.freshports.org/archivers/peazip/
 
-httpswwwpeaziporgpeazipbsdhtml_KEY: |
+httpswwwPpeazipPorgpeazipbsdPhtml_38_KEY: |
   https://www.peazip.org/peazip-bsd.html
 
-httpsosdnnetprojectspeazip_KEY: |
+httpsosdnPnetprojectspeazip_32_KEY: |
   https://osdn.net/projects/peazip
 
-httpscryptomatororg_KEY: |
+httpscryptomatorPorg_25_KEY: |
   https://cryptomator.org/
 
-Cryptomator_KEY: |
+Cryptomator_12_KEY: |
   Cryptomator
 
-Free_clientside_AES_encryption_for_your_cloud_files_Open_source_software_No_backdoors_no_registration_KEY: |
+Free_clientside_AES_encryption_for_your_cloud_filesP_Open_source_software_No_backdoors_no_registrationP_106_KEY: |
   Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.
 
-Cryptomators_mobile_apps_are_not_opensource_KEY: |
+Cryptomators_mobile_apps_are_not_opensourceP_47_KEY: |
   Cryptomator's mobile apps are not open-source.
 
-httpsgitlabcomcryptsetupcryptsetup_KEY: |
+httpsgitlabPcomcryptsetupcryptsetup_42_KEY: |
   https://gitlab.com/cryptsetup/cryptsetup/
 
-Linux_Unified_Key_Setup_LUKS_KEY: |
+Linux_Unified_Key_Setup_LUKS_31_KEY: |
   Linux Unified Key Setup (LUKS)
 
-A_full_disk_encryption_system_for_Linux_using_dmcrypt_as_the_disk_encryption_backend_Included_by_default_in_Ubuntu_Available_for_Windows_and_Linux_KEY: |
+A_full_disk_encryption_system_for_Linux_using_dmcrypt_as_the_disk_encryption_backendP_Included_by_default_in_UbuntuP_Available_for_Windows_and_LinuxP_151_KEY: |
   A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.
 
-httpshatsh_KEY: |
+httpshatPsh_16_KEY: |
   https://hat.sh/
 
-Hatsh_KEY: |
+HatPsh_7_KEY: |
   Hat.sh
 
-A_crossplatform_serverless_JavaScript_web_application_that_provides_secure_file_encryption_using_the_AES256GCM_algorithm_in_your_browser_It_can_al_KEY: |
+A_crossplatform_serverless_JavaScript_web_application_that_provides_secure_file_encryption_using_the_AES256GCM_algorithm_in_your_browserP_It_can_al_189_KEY: |
   A cross-platform, serverless JavaScript web application that provides secure file encryption using the AES-256-GCM algorithm in your browser. It can also be downloaded and run offline.</a>
 
-httpswwwkekaio_KEY: |
+httpswwwPkekaPio_21_KEY: |
   https://www.keka.io/
 
-Keka_KEY: |
+Keka_5_KEY: |
   Keka
 
-A_macOSonly_opensource_file_archiver_with_the_ability_to_encrypt_files_KEY: |
+A_macOSonly_opensource_file_archiver_with_the_ability_to_encrypt_filesP_75_KEY: |
   A macOS-only, open-source file archiver with the ability to encrypt files.
 
-Firefox_Send_KEY: |
+Firefox_Send_12_KEY: |
   Firefox Send
 
-Firefox_Send_uses_endtoend_encryption_to_keep_your_data_secure_from_the_moment_you_share_to_the_moment_your_file_is_opened_It_also_offers_security_c_KEY: |
+Firefox_Send_uses_endtoend_encryption_to_keep_your_data_secure_from_the_moment_you_share_to_the_moment_your_file_is_openedP_It_also_offers_security_c_317_KEY: |
   Firefox Send uses end-to-end encryption to keep your data secure from the moment you share to the moment your file is opened. It also offers security controls that you can set. You can choose when your file link expires, the number of downloads, and whether to add an optional password for an extra layer of security.
 
-httpssendfirefoxcom_KEY: |
+httpssendPfirefoxPcom_25_KEY: |
   https://send.firefox.com/
 
-httpsplaygooglecomstoreappsdetailsidorgmozillafirefoxsend_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidorgPmozillaPfirefoxsend_69_KEY: |
   https://play.google.com/store/apps/details?id=org.mozilla.firefoxsend
 
-httpsgithubcommozillasend_KEY: |
+httpsgithubPcommozillasend_31_KEY: |
   https://github.com/mozilla/send
 
-OnionShare_KEY: |
+OnionShare_10_KEY: |
   OnionShare
 
-OnionShare_is_an_opensource_tool_that_lets_you_securely_and_anonymously_share_a_file_of_any_size_It_works_by_starting_a_web_server_making_it_accessi_KEY: |
+OnionShare_is_an_opensource_tool_that_lets_you_securely_and_anonymously_share_a_file_of_any_sizeP_It_works_by_starting_a_web_server_making_it_accessi_287_KEY: |
   OnionShare is an open-source tool that lets you securely and anonymously share a file of any size. It works by starting a web server, making it accessible as a Tor onion service, and generating an unguessable URL for you to share so that the recipients can access and download the files.
 
-httpsonionshareorg_KEY: |
+httpsonionsharePorg_23_KEY: |
   https://onionshare.org/
 
-httpsonionshareorgdownloads_KEY: |
+httpsonionsharePorgdownloads_33_KEY: |
   https://onionshare.org/#downloads
 
-httpswwwfreshportsorgwwwonionshare_KEY: |
+httpswwwPfreshportsPorgwwwonionshare_42_KEY: |
   https://www.freshports.org/www/onionshare/
 
-httpopenportssenetonionshare_KEY: |
+httpopenportsPsenetonionshare_34_KEY: |
   http://openports.se/net/onionshare
 
-httpsgithubcommicahfleeonionshare_KEY: |
+httpsgithubPcommicahfleeonionshare_39_KEY: |
   https://github.com/micahflee/onionshare
 
-Magic_Wormhole_KEY: |
+Magic_Wormhole_14_KEY: |
   Magic Wormhole
 
-Magic_Wormhole_is_a_package_that_provides_a_library_and_a_commandline_tool_named_wormhole_which_makes_it_possible_to_get_arbitrarysized_files_and_di_KEY: |
+Magic_Wormhole_is_a_package_that_provides_a_library_and_a_commandline_tool_named_wormhole_which_makes_it_possible_to_get_arbitrarysized_files_and_di_280_KEY: |
   Magic Wormhole is a package that provides a library and a command-line tool named wormhole, which makes it possible to get arbitrary-sized files and directories (or short pieces of text) from one computer to another. Their motto: "Get things from one computer to another, safely."
 
-httpsmagicwormholereadthedocsio_KEY: |
+httpsmagicwormholePreadthedocsPio_37_KEY: |
   https://magic-wormhole.readthedocs.io
 
-httpsmagicwormholereadthedocsioenlatestwelcomehtmlinstallation_KEY: |
+httpsmagicwormholePreadthedocsPioenlatestwelcomePhtmlinstallation_73_KEY: |
   https://magic-wormhole.readthedocs.io/en/latest/welcome.html#installation
 
-httpswwwfreshportsorgnetpymagicwormhole_KEY: |
+httpswwwPfreshportsPorgnetpymagicwormhole_49_KEY: |
   https://www.freshports.org/net/py-magic-wormhole/
 
-httpspypiorgprojectmagicwormhole_KEY: |
+httpspypiPorgprojectmagicwormhole_40_KEY: |
   https://pypi.org/project/magic-wormhole/
 
-httpsgithubcomwarnermagicwormhole_KEY: |
+httpsgithubPcomwarnermagicwormhole_40_KEY: |
   https://github.com/warner/magic-wormhole
 
-httpsgithubcomschollzcroc_KEY: |
+httpsgithubPcomschollzcroc_32_KEY: |
   https://github.com/schollz/croc
 
-croc_KEY: |
+croc_5_KEY: |
   croc
 
-Easily_and_securely_send_things_from_one_computer_to_another_KEY: |
+Easily_and_securely_send_things_from_one_computer_to_anotherP_62_KEY: |
   Easily and securely send things from one computer to another.
 
-httpsfreedomboxorg_KEY: |
+httpsfreedomboxPorg_24_KEY: |
   https://freedombox.org/
 
-FreedomBox_KEY: |
+FreedomBox_11_KEY: |
   FreedomBox
 
-Designed_to_be_your_own_inexpensive_server_at_home_It_runs_free_software_and_offers_an_increasing_number_of_services_ranging_from_a_calendar_or_Jabber_KEY: |
+Designed_to_be_your_own_inexpensive_server_at_homeP_It_runs_free_software_and_offers_an_increasing_number_of_services_ranging_from_a_calendar_or_Jabber_179_KEY: |
   Designed to be your own inexpensive server at home. It runs free software and offers an increasing number of services ranging from a calendar or Jabber server, to a wiki, or VPN.
 
-Syncthing_KEY: |
+Syncthing_9_KEY: |
   Syncthing
 
-strongSyncthingstrong_replaces_proprietary_sync_and_cloud_services_with_something_open_trustworthy_and_decentralized_Your_data_is_your_data_alon_KEY: |
+strongSyncthingstrong_replaces_proprietary_sync_and_cloud_services_with_something_open_trustworthy_and_decentralizedP_Your_data_is_your_data_alon_280_KEY: |
   <strong>Syncthing</strong> replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third-party and how it's transmitted over the Internet.
 
-httpssyncthingnet_KEY: |
+httpssyncthingPnet_22_KEY: |
   https://syncthing.net/
 
-httpsgithubcomsyncthingsyncthinggtkreleaseslatest_KEY: |
+httpsgithubPcomsyncthingsyncthinggtkreleaseslatest_58_KEY: |
   https://github.com/syncthing/syncthing-gtk/releases/latest
 
-httpsgithubcomsyncthingsyncthingmacosreleaseslatest_KEY: |
+httpsgithubPcomsyncthingsyncthingmacosreleaseslatest_60_KEY: |
   https://github.com/syncthing/syncthing-macos/releases/latest
 
-httpsfdroidorgpackagescomgithubcatfriend1syncthingandroid_KEY: |
+httpsfdroidPorgpackagescomPgithubPcatfriend1Psyncthingandroid_68_KEY: |
   https://f-droid.org/packages/com.github.catfriend1.syncthingandroid/
 
-httpsplaygooglecomstoreappsdetailsidcomgithubcatfriend1syncthingandroid_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPgithubPcatfriend1Psyncthingandroid_84_KEY: |
   https://play.google.com/store/apps/details?id=com.github.catfriend1.syncthingandroid
 
-httpsgithubcomsyncthingtypesource_KEY: |
+httpsgithubPcomsyncthingQtypesource_40_KEY: |
   https://github.com/syncthing?type=source
 
-SparkleShare_KEY: |
+SparkleShare_12_KEY: |
   SparkleShare
 
-strongSparkleSharestrong_creates_a_special_folder_on_your_computer_You_can_add_remotely_hosted_folders_or_projects_to_this_folder_These_proj_KEY: |
+strongSparkleSharestrong_creates_a_special_folder_on_your_computerP_You_can_add_remotely_hosted_folders_or_projects_to_this_folderP_These_proj_275_KEY: |
   <strong>SparkleShare</strong> creates a special folder on your computer. You can add remotely hosted folders (or "projects") to this folder. These projects will be automatically kept in sync with both the host and all of your peers when someone adds, removes or edits a file.
 
-httpssparkleshareorg_KEY: |
+httpssparklesharePorg_25_KEY: |
   https://sparkleshare.org/
 
-httpsgithubcomhbonsSparkleSharereleases_KEY: |
+httpsgithubPcomhbonsSparkleSharereleases_47_KEY: |
   https://github.com/hbons/SparkleShare/releases/
 
-httpswwwsparkleshareorg_KEY: |
+httpswwwPsparklesharePorg_29_KEY: |
   https://www.sparkleshare.org/
 
-httpsgithubcomhbonsSparkleShare_KEY: |
+httpsgithubPcomhbonsSparkleShare_37_KEY: |
   https://github.com/hbons/SparkleShare
 
-httpsgitannexbranchablecom_KEY: |
+httpsgitannexPbranchablePcom_34_KEY: |
   https://git-annex.branchable.com/
 
-gitannex_KEY: |
+gitannex_10_KEY: |
   git-annex
 
-Allows_managing_files_with_git_without_checking_the_file_contents_into_git_While_that_may_seem_paradoxical_it_is_useful_when_dealing_with_files_larg_KEY: |
+Allows_managing_files_with_git_without_checking_the_file_contents_into_gitP_While_that_may_seem_paradoxical_it_is_useful_when_dealing_with_files_larg_251_KEY: |
   Allows managing files with git, without checking the file contents into git. While that may seem paradoxical, it is useful when dealing with files larger than git can currently easily handle, whether due to limitations in memory, time, or disk space.
 
-Secure_Hosting_Provider_KEY: |
+Secure_Hosting_Provider_24_KEY: |
   Secure Hosting Provider
 
-Data_Center_Bahnhof_KEY: |
+Data_Center_Bahnhof_20_KEY: |
   Data Center: Bahnhof
 
-Bahnhof_is_one_of_Swedens_largest_network_operators_founded_in_1994_They_specialize_in_innovative_data_center_construction_Extreme_security_coupled_KEY: |
+Bahnhof_is_one_of_Swedens_largest_network_operators_founded_in_1994P_They_specialize_in_innovative_data_center_construction_Extreme_security_coupled_206_KEY: |
   Bahnhof is one of Sweden’s largest network operators, founded in 1994. They specialize in innovative data center construction: Extreme security coupled with low-cost green energy has made them world famous.
 
-httpswwwbahnhofnet_KEY: |
+httpswwwPbahnhofPnet_24_KEY: |
   https://www.bahnhof.net/
 
-VPS__Domain_Njalla_KEY: |
+VPS__Domain_Njalla_20_KEY: |
   VPS & Domain: Njalla
 
-Njalla_is_a_privacyaware_domain_registration_service_and_VPS_provider_based_in_Nevis_with_VPS_data_centers_in_Sweden_It_is_created_by_people_from_T_KEY: |
+Njalla_is_a_privacyaware_domain_registration_service_and_VPS_provider_based_in_Nevis_with_VPS_data_centers_in_SwedenP_It_is_created_by_people_from_T_260_KEY: |
   Njalla is a privacy-aware domain registration service and VPS provider based in Nevis (with VPS data centers in Sweden). It is created by people from The Pirate Bay and IPredator VPN. Accepted payments: Bitcoin, Litecoin, Monero, DASH, Bitcoin Cash and PayPal.
 
-httpsnjalla_KEY: |
+httpsnjalPla_16_KEY: |
   https://njal.la/
 
-Colocation_DataCell_KEY: |
+Colocation_DataCell_20_KEY: |
   Colocation: DataCell
 
-DataCell_is_a_data_center_providing_secure_colocating_in_Switzerland_and_Iceland_KEY: |
+DataCell_is_a_data_center_providing_secure_colocating_in_Switzerland_and_IcelandP_81_KEY: |
   DataCell is a data center providing secure colocating in Switzerland and Iceland.
 
-httpsdatacellis_KEY: |
+httpsdatacellPis_20_KEY: |
   https://datacell.is/
 
-VPS_Hosting__Domain_Orange_Website_KEY: |
+VPS_Hosting__Domain_Orange_Website_38_KEY: |
   VPS, Hosting, & Domain: Orange Website
 
-Orange_Website_is_an_Icelandic_web_hosting_provider_that_prides_themselves_in_protecting_online_privacy_and_free_speech_KEY: |
+Orange_Website_is_an_Icelandic_web_hosting_provider_that_prides_themselves_in_protecting_online_privacy_and_free_speechP_120_KEY: |
   Orange Website is an Icelandic web hosting provider that prides themselves in protecting online privacy and free speech.
 
-httpswwworangewebsitecom_KEY: |
+httpswwwPorangewebsitePcom_30_KEY: |
   https://www.orangewebsite.com/
 
-New!_KEY: |
+NewE_5_KEY: |
   New!
 
-Financial_a_hrefhttpsopencollectivecomprivacytoolsio_classalertlinkcontributionsa_to__sitename__are_now_tax_deductible_in_the_US!_KEY: |
+Financial_a_hrefhttpsopencollectivePcomprivacytoolsio_classalertlinkcontributionsa_to__sitePname__are_now_tax_deductible_in_the_USE_151_KEY: |
   Financial <a href="https://opencollective.com/privacytoolsio" class="alert-link">contributions</a> to {{ site.name }} are now tax deductible in the US!
 
-Learn_more_KEY: |
+Learn_morePPP_14_KEY: |
   Learn more...
 
-You_are_being_watched_Private_and_statesponsored_organizations_are_monitoring_and_recording_your_online_activities__sitename__provides_services_KEY: |
+You_are_being_watchedP_Private_and_statesponsored_organizations_are_monitoring_and_recording_your_online_activitiesP__sitePname__provides_services_231_KEY: |
   You are being watched. Private and state-sponsored organizations are monitoring and recording your online activities. {{ site.name }} provides services, tools and knowledge to protect your privacy against global mass surveillance.
 
-Try__sitename__Search_a_PrivacyRespecting_Search_Engine_KEY: |
+Try__sitePname__Search_a_PrivacyRespecting_Search_Engine_63_KEY: |
   Try {{ site.name }} Search, a Privacy-Respecting Search Engine
 
-start_search_KEY: |
+start_search_13_KEY: |
   start search
 
-Privacy_Tools_KEY: |
+Privacy_Tools_14_KEY: |
   Privacy Tools
 
-Prefer_the_classic_site_View_a_singlepage_layout_KEY: |
+Prefer_the_classic_siteQ_View_a_singlepage_layoutP_51_KEY: |
   Prefer the classic site? View a single-page layout.
 
-Discover_privacycentric_online_services_including_email_providers_VPN_operators_DNS_administrators_and_more!_KEY: |
+Discover_privacycentric_online_services_including_email_providers_VPN_operators_DNS_administrators_and_moreE_113_KEY: |
   Discover privacy-centric online services, including email providers, VPN operators, DNS administrators, and more!
 
-Find_a_web_browser_that_respects_your_privacy_and_discover_how_to_harden_your_browser_against_tracking_and_leaks_KEY: |
+Find_a_web_browser_that_respects_your_privacy_and_discover_how_to_harden_your_browser_against_tracking_and_leaksP_114_KEY: |
   Find a web browser that respects your privacy, and discover how to harden your browser against tracking and leaks.
 
-Discover_a_variety_of_open_source_software_built_to_protect_your_privacy_and_keep_your_digital_data_secure_KEY: |
+Software_8_KEY: |
+  Software
+
+Discover_a_variety_of_open_source_software_built_to_protect_your_privacy_and_keep_your_digital_data_secureP_107_KEY: |
   Discover a variety of open source software built to protect your privacy and keep your digital data secure.
 
-Find_out_how_your_operating_system_is_compromising_your_privacy_and_what_simple_alternatives_exist_KEY: |
+Find_out_how_your_operating_system_is_compromising_your_privacy_and_what_simple_alternatives_existP_100_KEY: |
   Find out how your operating system is compromising your privacy, and what simple alternatives exist.
 
-PrivacyTools_Services_KEY: |
+PrivacyTools_Services_21_KEY: |
   PrivacyTools Services
 
-The_PrivacyTools_team_is_proud_to_launch_a_variety_of_privacycentric_online_services_including_a_Mastodon_instance_search_engine_and_more!_KEY: |
+The_PrivacyTools_team_is_proud_to_launch_a_variety_of_privacycentric_online_services_including_a_Mastodon_instance_search_engine_and_moreE_142_KEY: |
   The PrivacyTools team is proud to launch a variety of privacy-centric online services, including a Mastodon instance, search engine, and more!
 
-We_cant_operate_this_site_without_the_generous_contributions_we_receive_from_our_viewers_If_you_love_privacy_and_our_website_please_consider_donating_KEY: |
+Donate_6_KEY: |
+  Donate
+
+We_cant_operate_this_site_without_the_generous_contributions_we_receive_from_our_viewersP_If_you_love_privacy_and_our_website_please_consider_donating_152_KEY: |
   We can't operate this site without the generous contributions we receive from our viewers. If you love privacy and our website please consider donating.
 
-Showcase_your_brand_as_a_sponsor_of_PrivacyTools_here_and_support_our_mission_of_creating_a_world_free_of_mass_surveillance!_KEY: |
+Showcase_your_brand_as_a_sponsor_of_PrivacyTools_here_and_support_our_mission_of_creating_a_world_free_of_mass_surveillanceE_125_KEY: |
   Showcase your brand as a sponsor of PrivacyTools here and support our mission of creating a world free of mass surveillance!
 
-Privacy_I_dont_have_anything_to_hide_KEY: |
+PrivacyQ_I_dont_have_anything_to_hideP_40_KEY: |
   Privacy? I don't have anything to hide.
 
-httpswwwtedcomtalksglenn_greenwald_why_privacy_matters_KEY: |
+httpswwwPtedPcomtalksglenn_greenwald_why_privacy_matters_62_KEY: |
   https://www.ted.com/talks/glenn_greenwald_why_privacy_matters
 
-Glenn_Greenwald__Why_privacy_matters__TED_Talk_KEY: |
+Glenn_Greenwald__Why_privacy_matters__TED_Talk_49_KEY: |
   Glenn Greenwald - Why privacy matters - TED Talk
 
-Glenn_Greenwald_Why_privacy_matters_KEY: |
+Glenn_Greenwald_Why_privacy_matters_37_KEY: |
   Glenn Greenwald: Why privacy matters
 
-Over_the_last_16_months_as_Ive_debated_this_issue_around_the_world_every_single_time_somebody_has_said_to_me_I_dont_really_worry_about_invasions__KEY: |
+Over_the_last_16_months_as_Ive_debated_this_issue_around_the_world_every_single_time_somebody_has_said_to_me_I_dont_really_worry_about_invasions__805_KEY: |
   Over the last 16 months, as I've debated this issue around the world, every single time somebody has said to me, "I don't really worry about invasions of privacy because I don't have anything to hide." I always say the same thing to them. I get out a pen, I write down my email address. I say, "Here's my email address. What I want you to do when you get home is email me the passwords to all of your email accounts, not just the nice, respectable work one in your name, but all of them, because I want to be able to just troll through what it is you're doing online, read what I want to read and publish whatever I find interesting. After all, if you're not a bad person, if you're doing nothing wrong, you should have nothing to hide." <strong>Not a single person has taken me up on that offer.</strong>
 
-Glenn_Greenwald_in_cite_titleWhy_privacy_matters__TED_Talka_hrefhttpswwwtedcomtalksglenn_greenwald_why_privacy_mattersWhy_privacy_mat_KEY: |
+Glenn_Greenwald_in_cite_titleWhy_privacy_matters__TED_Talka_hrefhttpswwwPtedPcomtalksglenn_greenwald_why_privacy_mattersWhy_privacy_mat_177_KEY: |
   Glenn Greenwald in <cite title="Why privacy matters - TED Talk"><a href="https://www.ted.com/talks/glenn_greenwald_why_privacy_matters">Why privacy matters - TED Talk</a></cite>
 
-The_primary_reason_for_window_curtains_in_our_house_is_to_stop_people_from_being_able_to_see_in_The_reason_we_dont_want_them_to_see_in_is_because_we_KEY: |
+The_primary_reason_for_window_curtains_in_our_house_is_to_stop_people_from_being_able_to_see_inP_The_reason_we_dont_want_them_to_see_in_is_because_we_572_KEY: |
   The primary reason for window curtains in our house, is to stop people from being able to see in. The reason we don’t want them to see in is because we consider much of what we do inside our homes to be private. Whether that be having dinner at the table, watching a movie with your kids, or even engaging in intimate or sexual acts with your partner. None of these things are illegal by any means but even knowing this, we still keep the curtains and blinds on our windows. We clearly have this strong desire for privacy when it comes to our personal life and the public.
 
-Joshua_in_cite_titleThe_Crypto_Papera_hrefhttpsgithubcomcryptosebCryptoPaperletmeexplainfurtherThe_Crypto_Paperacite_KEY: |
+Joshua_in_cite_titleThe_Crypto_Papera_hrefhttpsgithubPcomcryptosebCryptoPaperletmeexplainfurtherThe_Crypto_Paperacite_142_KEY: |
   Joshua in <cite title="The Crypto Paper"><a href="https://github.com/cryptoseb/CryptoPaper#let-me-explain-further">The Crypto Paper</a></cite>
 
-Read_also_KEY: |
+Read_also_11_KEY: |
   Read also:
 
-httpsenwikipediaorgwikiNothing_to_hide_argument_KEY: |
+httpsenPwikipediaPorgwikiNothing_to_hide_argument_55_KEY: |
   https://en.wikipedia.org/wiki/Nothing_to_hide_argument
 
-Nothing_to_hide_argument_Wikipedia_KEY: |
+Nothing_to_hide_argument_Wikipedia_37_KEY: |
   Nothing to hide argument (Wikipedia)
 
-httpswwwredditcomrprivacycomments3hynvphow_do_you_counter_the_i_have_nothing_to_hide_KEY: |
+httpswwwPredditPcomrprivacycomments3hynvphow_do_you_counter_the_i_have_nothing_to_hide_96_KEY: |
   https://www.reddit.com/r/privacy/comments/3hynvp/how_do_you_counter_the_i_have_nothing_to_hide/
 
-How_do_you_counter_the_I_have_nothing_to_hide_argument_redditcom_KEY: |
+How_do_you_counter_the_I_have_nothing_to_hideQ_argumentQ_redditPcom_72_KEY: |
   How do you counter the "I have nothing to hide?" argument? (reddit.com)
 
-httpspapersssrncomsol3paperscfmabstract_id998565_KEY: |
+httpspapersPssrnPcomsol3papersPcfmQabstract_id998565_59_KEY: |
   https://papers.ssrn.com/sol3/papers.cfm?abstract_id=998565
 
-Ive_Got_Nothing_to_Hide_and_Other_Misunderstandings_of_Privacy_Daniel_J_Solove__San_Diego_Law_Review_KEY: |
+Ive_Got_Nothing_to_Hide_and_Other_Misunderstandings_of_Privacy_Daniel_JP_Solove__San_Diego_Law_Review_107_KEY: |
   'I've Got Nothing to Hide' and Other Misunderstandings of Privacy (Daniel J. Solove - San Diego Law Review)
 
-Quotes_KEY: |
+Quotes_7_KEY: |
   Quotes
 
-Arguing_that_you_dont_care_about_the_right_to_privacy_because_you_have_nothing_to_hide_is_no_different_than_saying_you_dont_care_about_free_speech_be_KEY: |
+Arguing_that_you_dont_care_about_the_right_to_privacy_because_you_have_nothing_to_hide_is_no_different_than_saying_you_dont_care_about_free_speech_be_181_KEY: |
   Arguing that you don't care about the right to privacy because you have nothing to hide is no different than saying you don't care about free speech because you have nothing to say.
 
-Edward_Snowden_on_cite_titleJust_days_left_to_kill_mass_surveillance_under_Section_215_of_the_Patriot_Act_We_are_Edward_Snowden_and_the_ACLUs_Jame_KEY: |
+Edward_Snowden_on_cite_titleJust_days_left_to_kill_mass_surveillance_under_Section_215_of_the_Patriot_ActP_We_are_Edward_Snowden_and_the_ACLUs_Jame_296_KEY: |
   Edward Snowden on <cite title="Just days left to kill mass surveillance under Section 215 of the Patriot Act. We are Edward Snowden and the ACLU's Jameel Jaffer. AUA."><a href="https://www.reddit.com/r/IAmA/comments/36ru89/just_days_left_to_kill_mass_surveillance_under/crglgh2">Reddit</a></cite>
 
-The_NSA_has_built_an_infrastructure_that_allows_it_to_intercept_almost_everything_With_this_capability_the_vast_majority_of_human_communications_are__KEY: |
+The_NSA_has_built_an_infrastructure_that_allows_it_to_intercept_almost_everythingP_With_this_capability_the_vast_majority_of_human_communications_are__550_KEY: |
   The NSA has built an infrastructure that allows it to intercept almost everything. With this capability, the vast majority of human communications are automatically ingested without targeting. If I wanted to see your emails or your wife's phone, all I have to do is use intercepts. I can get your emails, passwords, phone records, credit cards. I don't want to live in a society that does these sort of things... I do not want to live in a world where everything I do and say is recorded. That is not something I am willing to support or live under.
 
-Edward_Snowden_in_cite_titleEdward_Snowden_NSA_files_source_If_they_want_to_get_you_in_time_they_willa_hrefhttpswwwtheguardiancomwor_KEY: |
+Edward_Snowden_in_cite_titleEdward_Snowden_NSA_files_source_If_they_want_to_get_you_in_time_they_willa_hrefhttpswwwPtheguardianPcomwor_227_KEY: |
   Edward Snowden in <cite title="Edward Snowden, NSA files source: 'If they want to get you, in time they will'"><a href="https://www.theguardian.com/world/2013/jun/09/nsa-whistleblower-edward-snowden-why">The Guardian</a></cite>
 
-We_all_need_places_where_we_can_go_to_explore_without_the_judgmental_eyes_of_other_people_being_cast_upon_us_only_in_a_realm_where_were_not_being_wat_KEY: |
+We_all_need_places_where_we_can_go_to_explore_without_the_judgmental_eyes_of_other_people_being_cast_upon_us_only_in_a_realm_where_were_not_being_wat_296_KEY: |
   We all need places where we can go to explore without the judgmental eyes of other people being cast upon us, only in a realm where we're not being watched can we really test the limits of who we want to be. It's really in the private realm where dissent, creativity and personal exploration lie.
 
-Glenn_Greenwald_in_cite_titleGlenn_Greenwald_On_Why_Privacy_Is_Vital_Even_If_You_Have_Nothing_To_Hidea_hrefhttpswwwhuffingtonpostcom201_KEY: |
+Glenn_Greenwald_in_cite_titleGlenn_Greenwald_On_Why_Privacy_Is_Vital_Even_If_You_Have_Nothing_To_Hidea_hrefhttpswwwPhuffingtonpostPcom201_225_KEY: |
   Glenn Greenwald in <cite title="Glenn Greenwald On Why Privacy Is Vital, Even If You 'Have Nothing To Hide"><a href="https://www.huffingtonpost.com/2014/06/20/glenn-greenwald-privacy_n_5509704.html">Huffington Post</a></cite>
 
-More_Privacy_Resources_KEY: |
+More_Privacy_Resources_23_KEY: |
   More Privacy Resources
 
-Guides_KEY: |
+Guides_7_KEY: |
   Guides
 
-httpsssdefforg_KEY: |
+httpsssdPeffPorg_21_KEY: |
   https://ssd.eff.org/
 
-Surveillance_SelfDefense_by_EFF_KEY: |
+Surveillance_SelfDefense_by_EFF_33_KEY: |
   Surveillance Self-Defense by EFF
 
-Guide_to_defending_yourself_from_surveillance_by_using_secure_technology_and_developing_careful_practices_KEY: |
+Guide_to_defending_yourself_from_surveillance_by_using_secure_technology_and_developing_careful_practicesP_107_KEY: |
   Guide to defending yourself from surveillance by using secure technology and developing careful practices.
 
-httpsgithubcomcryptosebCryptoPaper_KEY: |
+httpsgithubPcomcryptosebCryptoPaper_41_KEY: |
   https://github.com/cryptoseb/CryptoPaper
 
-The_Crypto_Paper_KEY: |
+The_Crypto_Paper_17_KEY: |
   The Crypto Paper
 
-Privacy_Security_and_Anonymity_for_Every_Internet_User_KEY: |
+Privacy_Security_and_Anonymity_for_Every_Internet_UserP_57_KEY: |
   Privacy, Security and Anonymity for Every Internet User.
 
-httpsemailselfdefensefsforgen_KEY: |
+httpsemailselfdefensePfsfPorgen_37_KEY: |
   https://emailselfdefense.fsf.org/en/
 
-Email_SelfDefense_by_FSF_KEY: |
+Email_SelfDefense_by_FSF_26_KEY: |
   Email Self-Defense by FSF
 
-A_guide_to_fighting_surveillance_with_GnuPG_encryption_KEY: |
+A_guide_to_fighting_surveillance_with_GnuPG_encryptionP_56_KEY: |
   A guide to fighting surveillance with GnuPG encryption.
 
-httpswwwbestvpncomtheultimateprivacyguide_KEY: |
+httpswwwPbestvpnPcomtheultimateprivacyguide_52_KEY: |
   https://www.bestvpn.com/the-ultimate-privacy-guide/
 
-The_Ultimate_Privacy_Guide_KEY: |
+The_Ultimate_Privacy_Guide_27_KEY: |
   The Ultimate Privacy Guide
 
-Excellent_privacy_guide_written_by_the_creators_of_the_bestVPNcom_website_KEY: |
+Excellent_privacy_guide_written_by_the_creators_of_the_bestVPNPcom_websiteP_76_KEY: |
   Excellent privacy guide written by the creators of the bestVPN.com website.
 
-httpswwwivpnnetprivacyguides_KEY: |
+httpswwwPivpnPnetprivacyguides_36_KEY: |
   https://www.ivpn.net/privacy-guides
 
-IVPN_Privacy_Guides_KEY: |
+IVPN_Privacy_Guides_20_KEY: |
   IVPN Privacy Guides
 
-These_privacy_guides_explain_how_to_obtain_vastly_greater_freedom_privacy_and_anonymity_through_compartmentalization_and_isolation_KEY: |
+These_privacy_guides_explain_how_to_obtain_vastly_greater_freedom_privacy_and_anonymity_through_compartmentalization_and_isolationP_133_KEY: |
   These privacy guides explain how to obtain vastly greater freedom, privacy and anonymity through compartmentalization and isolation.
 
-httpsfriedcomprivacy_KEY: |
+httpsfriedPcomprivacy_26_KEY: |
   https://fried.com/privacy
 
-The_Ultimate_Guide_to_Online_Privacy_KEY: |
+The_Ultimate_Guide_to_Online_Privacy_37_KEY: |
   The Ultimate Guide to Online Privacy
 
-Comprehensive_Ninja_Privacy_Tips_and_150_tools_KEY: |
+Comprehensive_Ninja_Privacy_Tips_and_150_toolsP_51_KEY: |
   Comprehensive "Ninja Privacy Tips" and 150+ tools.
 
-Information_KEY: |
+Information_12_KEY: |
   Information
 
-httpsfreedompress_KEY: |
+httpsfreedomPpress_23_KEY: |
   https://freedom.press/
 
-Freedom_of_the_Press_Foundation_KEY: |
+Freedom_of_the_Press_Foundation_32_KEY: |
   Freedom of the Press Foundation
 
-Supporting_and_defending_journalism_dedicated_to_transparency_and_accountability_since_2012_KEY: |
+Supporting_and_defending_journalism_dedicated_to_transparency_and_accountability_since_2012P_93_KEY: |
   Supporting and defending journalism dedicated to transparency and accountability since 2012.
 
-httpswwwerfahrungencommitanonymisierungt_KEY: |
+httpswwwPerfahrungenPcommitanonymisierungt_50_KEY: |
   https://www.erfahrungen.com/mit/anonymisierung/t/
 
-Erfahrungencom_KEY: |
+ErfahrungenPcom_16_KEY: |
   Erfahrungen.com
 
-German_review_aggregator_website_of_privacyrelated_services_KEY: |
+German_review_aggregator_website_of_privacyrelated_servicesP_62_KEY: |
   German review aggregator website of privacy-related services.
 
-httpsopenwirelessorg_KEY: |
+httpsopenwirelessPorg_26_KEY: |
   https://openwireless.org/
 
-Open_Wireless_Movement_KEY: |
+Open_Wireless_Movement_23_KEY: |
   Open Wireless Movement
 
-a_coalition_of_Internet_freedom_advocates_companies_organizations_and_technologists_working_to_develop_new_wireless_technologies_and_to_inspire_a_mo_KEY: |
+a_coalition_of_Internet_freedom_advocates_companies_organizations_and_technologists_working_to_develop_new_wireless_technologies_and_to_inspire_a_mo_180_KEY: |
   a coalition of Internet freedom advocates, companies, organizations, and technologists working to develop new wireless technologies and to inspire a movement of Internet openness.
 
-httpsprivacynetusgovernmentsurveillancespyingdata_KEY: |
+httpsprivacyPnetusgovernmentsurveillancespyingdata_59_KEY: |
   https://privacy.net/us-government-surveillance-spying-data
 
-privacynet_KEY: |
+privacyPnet_12_KEY: |
   privacy.net
 
-What_does_the_US_government_know_about_you_KEY: |
+What_does_the_US_government_know_about_youQ_44_KEY: |
   What does the US government know about you?
 
-httpswwwredditcomrprivacytoolsIOwikiindex_KEY: |
+httpswwwPredditPcomrprivacytoolsIOwikiindex_51_KEY: |
   https://www.reddit.com/r/privacytoolsIO/wiki/index
 
-rprivacytoolsIO_Wiki_KEY: |
+rprivacytoolsIO_Wiki_22_KEY: |
   r/privacytoolsIO Wiki
 
-Our_Wiki_on_redditcom_KEY: |
+Our_Wiki_on_redditPcomP_24_KEY: |
   Our Wiki on reddit.com.
 
-httpswwwgrccomsecuritynowhtm_KEY: |
+httpswwwPgrcPcomsecuritynowPhtm_36_KEY: |
   https://www.grc.com/securitynow.htm
 
-Security_Now!_KEY: |
+Security_NowE_14_KEY: |
   Security Now!
 
-Weekly_Internet_Security_Podcast_by_Steve_Gibson_and_Leo_Laporte_KEY: |
+Weekly_Internet_Security_Podcast_by_Steve_Gibson_and_Leo_LaporteP_66_KEY: |
   Weekly Internet Security Podcast by Steve Gibson and Leo Laporte.
 
-httpswwwjupiterbroadcastingcomshowtechsnap_KEY: |
+httpswwwPjupiterbroadcastingPcomshowtechsnap_51_KEY: |
   https://www.jupiterbroadcasting.com/show/techsnap/
 
-TechSNAP_KEY: |
+TechSNAP_9_KEY: |
   TechSNAP
 
-Weekly_Systems_Network_and_Administration_Podcast_Every_week_TechSNAP_covers_the_stories_that_impact_those_of_us_in_the_tech_industry_KEY: |
+Weekly_Systems_Network_and_Administration_PodcastP_Every_week_TechSNAP_covers_the_stories_that_impact_those_of_us_in_the_tech_industryP_138_KEY: |
   Weekly Systems, Network, and Administration Podcast. Every week TechSNAP covers the stories that impact those of us in the tech industry.
 
-Terms_of_Service_Didnt_Read_KEY: |
+httpstosdrPorg_19_KEY: |
+  https://tosdr.org/
+
+Terms_of_Service_Didnt_Read_30_KEY: |
   Terms of Service; Didn't Read
 
-I_have_read_and_agree_to_the_Terms_is_the_biggest_lie_on_the_web_We_aim_to_fix_that_KEY: |
+I_have_read_and_agree_to_the_Terms_is_the_biggest_lie_on_the_webP_We_aim_to_fix_thatP_88_KEY: |
   "I have read and agree to the Terms" is the biggest lie on the web. We aim to fix that.
 
-The_Great_Cloudwall_KEY: |
+httpscodebergPorgcrimeflarecloudflaretor_47_KEY: |
+  https://codeberg.org/crimeflare/cloudflare-tor
+
+The_Great_Cloudwall_20_KEY: |
   The Great Cloudwall
 
-Critique_and_information_on_why_to_avoid_Cloudflare_a_big_company_with_a_huge_portion_of_the_internet_behind_it_KEY: |
+Critique_and_information_on_why_to_avoid_Cloudflare_a_big_company_with_a_huge_portion_of_the_internet_behind_itP_114_KEY: |
   Critique and information on why to avoid Cloudflare, a big company with a huge portion of the internet behind it.
 
-Tools_KEY: |
+Tools_6_KEY: |
   Tools
 
-ipleaknet_KEY: |
+httpsipleakPnet_20_KEY: |
+  https://ipleak.net/
+
+ipleakPnet_11_KEY: |
   ipleak.net
 
-IPDNS_Detect__What_is_your_IP_what_is_your_DNS_what_informations_you_send_to_websites_KEY: |
+IPDNS_Detect__What_is_your_IP_what_is_your_DNS_what_informations_you_send_to_websitesP_91_KEY: |
   IP/DNS Detect - What is your IP, what is your DNS, what informations you send to websites.
 
-httpswwwghacksnet20151228theultimateonlineprivacytestresourcelist_KEY: |
+httpswwwPghacksPnet20151228theultimateonlineprivacytestresourcelist_82_KEY: |
   https://www.ghacks.net/2015/12/28/the-ultimate-online-privacy-test-resource-list/
 
-The_ultimate_Online_Privacy_Test_Resource_List_KEY: |
+The_ultimate_Online_Privacy_Test_Resource_List_47_KEY: |
   The ultimate Online Privacy Test Resource List
 
-A_collection_of_Internet_sites_that_check_whether_your_web_browser_leaks_information_KEY: |
+A_collection_of_Internet_sites_that_check_whether_your_web_browser_leaks_informationP_86_KEY: |
   A collection of Internet sites that check whether your web browser leaks information.
 
-httpsprismbreakorg_KEY: |
+httpsprismbreakPorg_25_KEY: |
   https://prism-break.org/
 
-PRISM_Break_KEY: |
+PRISM_Break_12_KEY: |
   PRISM Break
 
-We_all_have_a_right_to_privacy_which_you_can_exercise_today_by_encrypting_your_communications_and_ending_your_reliance_on_proprietary_services_KEY: |
+We_all_have_a_right_to_privacy_which_you_can_exercise_today_by_encrypting_your_communications_and_ending_your_reliance_on_proprietary_servicesP_145_KEY: |
   We all have a right to privacy, which you can exercise today by encrypting your communications and ending your reliance on proprietary services.
 
-httpssecurityinaboxorg_KEY: |
+httpssecurityinaboxPorg_28_KEY: |
   https://securityinabox.org/
 
-Security_inaBox_KEY: |
+Security_inaBox_18_KEY: |
   Security in-a-Box
 
-A_guide_to_digital_security_for_activists_and_human_rights_defenders_throughout_the_world_KEY: |
+A_guide_to_digital_security_for_activists_and_human_rights_defenders_throughout_the_worldP_91_KEY: |
   A guide to digital security for activists and human rights defenders throughout the world.
 
-httpssecuredroporg_KEY: |
+httpssecuredropPorg_24_KEY: |
   https://securedrop.org/
 
-SecureDrop_KEY: |
+SecureDrop_11_KEY: |
   SecureDrop
 
-An_opensource_whistleblower_submission_system_that_media_organizations_can_use_to_securely_accept_documents_from_and_communicate_with_anonymous_source_KEY: |
+An_opensource_whistleblower_submission_system_that_media_organizations_can_use_to_securely_accept_documents_from_and_communicate_with_anonymous_source_266_KEY: |
   An open-source whistleblower submission system that media organizations can use to securely accept documents from and communicate with anonymous sources. It was originally created by the late Aaron Swartz and is currently managed by Freedom of the Press Foundation.
 
-httpspackresetthenetorg_KEY: |
+httpspackPresetthenetPorg_30_KEY: |
   https://pack.resetthenet.org/
 
-Reset_The_Net__Privacy_Pack_KEY: |
+Reset_The_Net__Privacy_Pack_29_KEY: |
   Reset The Net - Privacy Pack
 
-Help_fight_to_end_mass_surveillance_Get_these_tools_to_protect_yourself_and_your_friends_KEY: |
+Help_fight_to_end_mass_surveillanceP_Get_these_tools_to_protect_yourself_and_your_friendsP_91_KEY: |
   Help fight to end mass surveillance. Get these tools to protect yourself and your friends.
 
-httpssecfirstorg_KEY: |
+httpssecfirstPorg_22_KEY: |
   https://secfirst.org/
 
-Security_First_KEY: |
+Security_First_15_KEY: |
   Security First
 
-Umbrella_is_an_Android_app_that_provides_all_the_advice_needed_to_operate_safely_in_a_hostile_environment_KEY: |
+Umbrella_is_an_Android_app_that_provides_all_the_advice_needed_to_operate_safely_in_a_hostile_environmentP_107_KEY: |
   Umbrella is an Android app that provides all the advice needed to operate safely in a hostile environment.
 
-httpswwwosaltcom_KEY: |
+httpswwwPosaltPcom_23_KEY: |
   https://www.osalt.com/
 
-Osalt_KEY: |
+Osalt_6_KEY: |
   Osalt
 
-A_directory_to_help_you_find_open_source_alternatives_to_proprietary_tools_KEY: |
+A_directory_to_help_you_find_open_source_alternatives_to_proprietary_toolsP_76_KEY: |
   A directory to help you find open source alternatives to proprietary tools.
 
-httpsalternativetonet_KEY: |
+httpsalternativetoPnet_27_KEY: |
   https://alternativeto.net/
 
-AlternativeTo_KEY: |
+AlternativeTo_14_KEY: |
   AlternativeTo
 
-A_directory_to_help_find_alternatives_to_other_software_with_the_option_to_only_show_open_source_software_KEY: |
+A_directory_to_help_find_alternatives_to_other_software_with_the_option_to_only_show_open_source_software_107_KEY: |
   A directory to help find alternatives to other software, with the option to only show open source software
 
-Note_Just_being_open_source_does_not_make_software_secure!_KEY: |
+Note_Just_being_open_source_does_not_make_software_secureE_60_KEY: |
   Note: Just being open source does not make software secure!
 
-Participate_with_suggestions_and_constructive_criticism_KEY: |
+Participate_with_suggestions_and_constructive_criticism_55_KEY: |
   Participate with suggestions and constructive criticism
 
-Its_important_for_a_website_like__sitename__to_stay_uptodate_Keep_an_eye_on_software_updates_for_the_applications_listed_on_our_site_Follow_r_KEY: |
+Its_important_for_a_website_like__sitePname__to_stay_uptodateP_Keep_an_eye_on_software_updates_for_the_applications_listed_on_our_siteP_Follow_r_748_KEY: |
   It's important for a website like {{ site.name }} to stay up-to-date. Keep an eye on software updates for the applications listed on our site. Follow recent news about providers that we recommend. We try our best to keep up, but we're not perfect and the internet is changing fast. If you find an error, or you think a provider should not be listed here, or a qualified service provider is missing, or a browser plugin is not the best choice anymore, or anything else... <strong>Talk to us please.</strong> You can also find us on <a rel="me" href="https://social.privacytools.io/@privacytools">our own Mastodon instance</a> or on <a href="https://chat.privacytools.io">Matrix</a> at <code class="highlighter-rouge">#general:privacytools.io</code>.
 
-Reddit_KEY: |
+Reddit_7_KEY: |
   Reddit
 
-Contributor_List_KEY: |
+Contributor_List_17_KEY: |
   Contributor List
 
-Discourse__Reddit_KEY: |
+Discourse__Reddit_18_KEY: |
   Discourse & Reddit
 
-Join_our_Discourse_community_to_stay_up_to_date_on_privacy_news_or_make_suggestions!_KEY: |
+Join_our_Discourse_community_to_stay_up_to_date_on_privacy_news_or_make_suggestionsE_84_KEY: |
   Join our Discourse community to stay up to date on privacy news or make suggestions!
 
-httpsforumprivacytoolsio_KEY: |
+httpsforumPprivacytoolsPio_30_KEY: |
   https://forum.privacytools.io/
 
-Discourse_KEY: |
+Discourse_9_KEY: |
   Discourse
 
-Follow_on_Mastodon__Twitter_KEY: |
+Follow_on_Mastodon__Twitter_28_KEY: |
   Follow on Mastodon & Twitter
 
-Get_the_latest_privacyrelated_updates_from_our_Mastodon_Feed_Follow_us_today!_KEY: |
+Get_the_latest_privacyrelated_updates_from_our_Mastodon_FeedP_Follow_us_todayE_79_KEY: |
   Get the latest privacy-related updates from our Mastodon Feed. Follow us today!
 
-httpssocialprivacytoolsio_KEY: |
+httpssocialPprivacytoolsPio_31_KEY: |
   https://social.privacytools.io/
 
-Develop_on_GitHub_KEY: |
+Mastodon_8_KEY: |
+  Mastodon
+
+Develop_on_GitHub_17_KEY: |
   Develop on GitHub
 
-The_complete_website_source_code_is_available_on_GitHub_Join_our_developer_team!_KEY: |
+The_complete_website_source_code_is_available_on_GitHubP_Join_our_developer_teamE_81_KEY: |
   The complete website source code is available on GitHub. Join our developer team!
 
-httpsgithubcomprivacytoolsIOprivacytoolsio_KEY: |
+httpsgithubPcomprivacytoolsIOprivacytoolsPio_49_KEY: |
   https://github.com/privacytoolsIO/privacytools.io
 
-GitHub_KEY: |
+GitHub_6_KEY: |
   GitHub
 
-This_is_a_community_project_aiming_to_deliver_the_best_information_available_to_improve_privacy_online_Thank_you_for_participating_This_project_needs_KEY: |
+This_is_a_community_project_aiming_to_deliver_the_best_information_available_to_improve_privacy_onlineP_Thank_you_for_participatingP_This_project_needs_157_KEY: |
   This is a community project aiming to deliver the best information available to improve privacy online. Thank you for participating. This project needs you.
 
-If_you_are_currently_browsing_a_hrefhttpsenwikipediaorgwikiSurface_Webclearneta_and_want_to_access_the_a_hrefhttpsenwikipediaorg_KEY: |
+If_you_are_currently_browsing_a_hrefhttpsenPwikipediaPorgwikiSurface_Webclearneta_and_want_to_access_the_a_hrefhttpsenPwikipediaPorg_206_KEY: |
   If you are currently browsing <a href="https://en.wikipedia.org/wiki/Surface_Web">clearnet</a> and want to access the <a href="https://en.wikipedia.org/wiki/Dark_web">dark web</a>, this section is for you.
 
-The_Tor_network_is_a_group_of_volunteeroperated_servers_that_allows_people_to_improve_their_privacy_and_security_on_the_Internet_Tors_users_employ_t_KEY: |
+Tor_3_KEY: |
+  Tor
+
+The_Tor_network_is_a_group_of_volunteeroperated_servers_that_allows_people_to_improve_their_privacy_and_security_on_the_InternetP_Tors_users_employ_t_430_KEY: |
   The Tor network is a group of volunteer-operated servers that allows people to improve their privacy and security on the Internet. Tor's users employ this network by connecting through a series of virtual tunnels rather than making a direct connection, thus allowing both organizations and individuals to share information over public networks without compromising their privacy. Tor is an effective censorship circumvention tool.
 
-httpswwwfreshportsorgsecuritytor_KEY: |
+httpswwwPfreshportsPorgsecuritytor_39_KEY: |
   https://www.freshports.org/security/tor
 
-httpopenportssenettor_KEY: |
+httpopenportsPsenettor_27_KEY: |
   http://openports.se/net/tor
 
-httppkgsrcsenettor_KEY: |
+httppkgsrcPsenettor_24_KEY: |
   http://pkgsrc.se/net/tor
 
-httpssupporttorprojectorgtormobiletormobile7_KEY: |
+httpssupportPtorprojectPorgtormobiletormobile7_53_KEY: |
   https://support.torproject.org/tormobile/tormobile-7/
 
-httpsgitwebtorprojectorgtorgit_KEY: |
+httpsgitwebPtorprojectPorgtorPgit_37_KEY: |
   https://gitweb.torproject.org/tor.git
 
-I2P_Anonymous_Network_KEY: |
+I2P_Anonymous_Network_21_KEY: |
   I2P Anonymous Network
 
-The_Invisible_Internet_Project_I2P_is_a_computer_network_layer_that_allows_applications_to_send_messages_to_each_other_pseudonymously_and_securely_U_KEY: |
+The_Invisible_Internet_Project_I2P_is_a_computer_network_layer_that_allows_applications_to_send_messages_to_each_other_pseudonymously_and_securelyP_U_418_KEY: |
   The Invisible Internet Project (I2P) is a computer network layer that allows applications to send messages to each other pseudonymously and securely. Uses include anonymous Web surfing, chatting, blogging, and file transfers. The software that implements this layer is called an I2P router and a computer running I2P is called an I2P node. The software is free and open-source and is published under multiple licenses.
 
-httpsgeti2pnet_KEY: |
+httpsgeti2pPnet_19_KEY: |
   https://geti2p.net/
 
-Requires_specific_software_to_access_geti2pnet_KEY: |
+Requires_specific_software_to_access_geti2pPnet_49_KEY: |
   Requires specific software to access: geti2p.net
 
-httpsgeti2pnetendownloadwindows_KEY: |
+httpsgeti2pPnetendownloadwindows_38_KEY: |
   https://geti2p.net/en/download#windows
 
-httpsgeti2pnetendownloadmac_KEY: |
+httpsgeti2pPnetendownloadmac_34_KEY: |
   https://geti2p.net/en/download#mac
 
-httpsgeti2pnetendownloadunix_KEY: |
+httpsgeti2pPnetendownloadunix_35_KEY: |
   https://geti2p.net/en/download#unix
 
-httpswwwfreshportsorgsecurityi2p_KEY: |
+httpswwwPfreshportsPorgsecurityi2p_40_KEY: |
   https://www.freshports.org/security/i2p/
 
-httpopenportsseneti2pd_KEY: |
+httpopenportsPseneti2pd_28_KEY: |
   http://openports.se/net/i2pd
 
-httppkgsrcsewipi2pd_KEY: |
+httppkgsrcPsewipi2pd_25_KEY: |
   http://pkgsrc.se/wip/i2pd
 
-httpsfdroidorgappneti2pandroidrouter_KEY: |
+httpsfdroidPorgappnetPi2pPandroidProuter_46_KEY: |
   https://f-droid.org/app/net.i2p.android.router
 
-httpsplaygooglecomstoreappsdetailsidneti2pandroid_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidnetPi2pPandroid_61_KEY: |
   https://play.google.com/store/apps/details?id=net.i2p.android
 
-httpsdownloadi2p2deandroidcurrent_KEY: |
+httpsdownloadPi2p2Pdeandroidcurrent_41_KEY: |
   https://download.i2p2.de/android/current/
 
-httpsgeti2pnetengetinvolvedguidesnewdevelopersgettingthei2pcode_KEY: |
+httpsgeti2pPnetengetinvolvedguidesnewdevelopersgettingthei2pcode_77_KEY: |
   https://geti2p.net/en/get-involved/guides/new-developers#getting-the-i2p-code
 
-The_Freenet_Project_KEY: |
+The_Freenet_Project_19_KEY: |
   The Freenet Project
 
-Freenet_is_a_peertopeer_platform_for_censorshipresistant_communication_It_uses_a_decentralized_distributed_data_store_to_keep_and_deliver_informati_KEY: |
+Freenet_is_a_peertopeer_platform_for_censorshipresistant_communicationP_It_uses_a_decentralized_distributed_data_store_to_keep_and_deliver_informati_453_KEY: |
   Freenet is a peer-to-peer platform for censorship-resistant communication. It uses a decentralized distributed data store to keep and deliver information, and has a suite of free software for publishing and communicating on the Web without fear of censorship. Both Freenet and some of its associated tools were originally designed by Ian Clarke, who defined Freenet's goal as providing freedom of speech on the Internet with strong anonymity protection.
 
-httpsfreenetprojectorg_KEY: |
+httpsfreenetprojectPorg_27_KEY: |
   https://freenetproject.org/
 
-httpsfreenetprojectorgpagesdownloadhtmlwindows_KEY: |
+httpsfreenetprojectPorgpagesdownloadPhtmlwindows_54_KEY: |
   https://freenetproject.org/pages/download.html#windows
 
-httpsfreenetprojectorgpagesdownloadhtmlosx_KEY: |
+httpsfreenetprojectPorgpagesdownloadPhtmlosx_51_KEY: |
   https://freenetproject.org/pages/download.html#os-x
 
-httpsfreenetprojectorgpagesdownloadhtmlgnulinuxposix_KEY: |
+httpsfreenetprojectPorgpagesdownloadPhtmlgnulinuxposix_61_KEY: |
   https://freenetproject.org/pages/download.html#gnulinux-posix
 
-httpsgithubcomfreenet_KEY: |
+httpsgithubPcomfreenet_27_KEY: |
   https://github.com/freenet/
 
-httpsdarknetdiariescom_KEY: |
+httpsdarknetdiariesPcom_28_KEY: |
   https://darknetdiaries.com/
 
-darknetdiariescom_KEY: |
+darknetdiariesPcom_19_KEY: |
   darknetdiaries.com
 
-True_stories_from_the_dark_side_of_the_Internet_KEY: |
+True_stories_from_the_dark_side_of_the_InternetP_49_KEY: |
   True stories from the dark side of the Internet.
 
-httpszeronetio_KEY: |
+httpszeronetPio_20_KEY: |
   https://zeronet.io/
 
-ZeroNet_KEY: |
+ZeroNet_8_KEY: |
   ZeroNet
 
-Open_free_and_uncensorable_websites_using_Bitcoin_cryptography_and_BitTorrent_network_KEY: |
+Open_free_and_uncensorable_websites_using_Bitcoin_cryptography_and_BitTorrent_networkP_89_KEY: |
   Open, free, and uncensorable websites, using Bitcoin cryptography and BitTorrent network.
 
-Your_IP_address_isnt_hidden_by_default_and_wont_be_unless_you_enforce_Tor_usage_KEY: |
+Your_IP_address_isnt_hidden_by_default_and_wont_be_unless_you_enforce_Tor_usageP_84_KEY: |
   Your IP address isn't hidden by default and won't be, unless you enforce Tor usage.
 
-privacy_warning_KEY: |
+privacy_warning_16_KEY: |
   privacy warning
 
-An_open_source_crossplatform_friendtofriend_secure_and_decentralized_communication_platform_KEY: |
+httpsretrosharePcc_23_KEY: |
+  https://retroshare.cc/
+
+RetroShare_11_KEY: |
+  RetroShare
+
+An_open_source_crossplatform_friendtofriend_secure_and_decentralized_communication_platformP_100_KEY: |
   An open source, cross-platform, friend-to-friend, secure, and decentralized communication platform.
 
-httpsgnunetorg_KEY: |
+httpsgnunetPorg_20_KEY: |
   https://gnunet.org/
 
-GNUnet_KEY: |
+GNUnet_7_KEY: |
   GNUnet
 
-GNUnet_provides_a_strong_foundation_of_free_software_for_a_global_distributed_network_that_provides_security_and_privacy_KEY: |
+GNUnet_provides_a_strong_foundation_of_free_software_for_a_global_distributed_network_that_provides_security_and_privacyP_123_KEY: |
   GNUnet provides a strong foundation of free software for a global, distributed network that provides security and privacy.
 
-httpsipfsioIPFSa_emandem_a_hrefhttpsgithubcomipfsshipyardipfscompanionIPFS_Companiona_KEY: |
+httpsipfsPioIPFSa_emandem_a_hrefhttpsgithubPcomipfsshipyardipfscompanionIPFS_Companiona_116_KEY: |
   https://ipfs.io/">IPFS</a> <em>and</em> <a href="https://github.com/ipfs-shipyard/ipfs-companion">IPFS Companion</a>
 
-A_peertopeer_hypermedia_protocol_to_make_the_web_faster_safer_and_more_open_IPFS_Companion_is_a_browser_extension_for_redirecting_queries_to_a_gat_KEY: |
+A_peertopeer_hypermedia_protocol_to_make_the_web_faster_safer_and_more_openP_IPFS_Companion_is_a_browser_extension_for_redirecting_queries_to_a_gat_189_KEY: |
   A peer-to-peer hypermedia protocol to make the web faster, safer, and more open. IPFS Companion is a browser extension for redirecting queries to a gateway of your choice (generally local).
 
-Important_privacy_warning_KEY: |
+Important_privacy_warning_26_KEY: |
   Important privacy warning
 
-httpsyggdrasilnetworkgithubio_KEY: |
+httpsyggdrasilnetworkPgithubPio_37_KEY: |
   https://yggdrasil-network.github.io/
 
-Yggdrasil_KEY: |
+Yggdrasil_10_KEY: |
   Yggdrasil
 
-An_earlystage_implementation_of_a_fully_endtoend_encrypted_IPv6_network_It_is_lightweight_selfarranging_supported_on_multiple_platforms_and_all_KEY: |
+An_earlystage_implementation_of_a_fully_endtoend_encrypted_IPv6_networkP_It_is_lightweight_selfarranging_supported_on_multiple_platforms_and_all_340_KEY: |
   An early-stage implementation of a fully end-to-end encrypted IPv6 network. It is lightweight, self-arranging, supported on multiple platforms, and allows pretty much any IPv6-capable application to communicate securely with other Yggdrasil nodes. Yggdrasil does not require you to have IPv6 Internet connectivity - it also works over IPv4.
 
-The_project_is_currently_in_early_stages_but_it_is_being_actively_developed_KEY: |
+The_project_is_currently_in_early_stages_but_it_is_being_actively_developedP_77_KEY: |
   The project is currently in early stages but it is being actively developed.
 
-experimental_KEY: |
+experimental_13_KEY: |
   experimental
 
-Yggdrasil_doesnt_have_a_goal_of_providing_anonymity_and_your_peers_know_your_IP_address_unless_you_are_only_using_TorI2P_peers_KEY: |
+Yggdrasil_doesnt_have_a_goal_of_providing_anonymity_and_your_peers_know_your_IP_address_unless_you_are_only_using_TorI2P_peersP_130_KEY: |
   Yggdrasil doesn't have a goal of providing anonymity and your peers know your IP address unless you are only using Tor/I2P peers.
 
-If_you_are_currently_using_an_application_like_Evernote_Google_Keep_or_Microsoft_OneNote_you_should_pick_an_alternative_here_KEY: |
+privacy_warning_15_KEY: |
+  privacy warning
+
+If_you_are_currently_using_an_application_like_Evernote_Google_Keep_or_Microsoft_OneNote_you_should_pick_an_alternative_hereP_129_KEY: |
   If you are currently using an application like Evernote, Google Keep, or Microsoft OneNote, you should pick an alternative here.
 
-Joplin_KEY: |
+Joplin_6_KEY: |
   Joplin
 
-Joplin_is_a_free_opensource_and_fullyfeatured_notetaking_and_todo_application_which_can_handle_a_large_number_of_markdown_notes_organized_into_no_KEY: |
+Joplin_is_a_free_opensource_and_fullyfeatured_notetaking_and_todo_application_which_can_handle_a_large_number_of_markdown_notes_organized_into_no_314_KEY: |
   Joplin is a free, open-source, and fully-featured note-taking and to-do application which can handle a large number of markdown notes organized into notebooks and tags. It offers end-to-end encryption and can sync through Nextcloud, Dropbox, and more. It also offers easy import from Evernote and plain-text notes.
 
-httpsjoplinapporg_KEY: |
+httpsjoplinappPorg_22_KEY: |
   https://joplinapp.org/
 
-httpsjoplinapporgdesktopapplications_KEY: |
+httpsjoplinappPorgdesktopapplications_43_KEY: |
   https://joplinapp.org/#desktop-applications
 
-httpswwwnpmjscompackagejoplin_KEY: |
+httpswwwPnpmjsPcompackagejoplin_36_KEY: |
   https://www.npmjs.com/package/joplin
 
-httpsaddonsmozillaorgenUSfirefoxaddonjoplinwebclipper_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonjoplinwebclipper_66_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/joplin-web-clipper/
 
-httpschromegooglecomwebstoredetailjoplinwebclipperalofnhikmmkdbbbgpnglcpdollgjjfek_KEY: |
+httpschromePgooglePcomwebstoredetailjoplinwebclipperalofnhikmmkdbbbgpnglcpdollgjjfek_93_KEY: |
   https://chrome.google.com/webstore/detail/joplin-web-clipper/alofnhikmmkdbbbgpnglcpdollgjjfek
 
-httpsjoplinapporgimagesBadgeAndroidpng_KEY: |
+httpsjoplinappPorgimagesBadgeAndroidPpng_45_KEY: |
   https://joplinapp.org/images/BadgeAndroid.png
 
-httpsjoplinapporgmobileapplications_KEY: |
+httpsjoplinappPorgmobileapplications_42_KEY: |
   https://joplinapp.org/#mobile-applications
 
-httpsitunesapplecomusappjoplinid1315599797_KEY: |
+httpsitunesPapplePcomusappjoplinid1315599797_51_KEY: |
   https://itunes.apple.com/us/app/joplin/id1315599797
 
-httpsgithubcomlaurent22joplin_KEY: |
+httpsgithubPcomlaurent22joplin_35_KEY: |
   https://github.com/laurent22/joplin
 
-Standard_Notes_KEY: |
+Standard_Notes_14_KEY: |
   Standard Notes
 
-Standard_Notes_is_a_simple_and_private_notes_app_that_makes_your_notes_easy_and_available_everywhere_you_are_Features_endtoend_encryption_on_every_p_KEY: |
+Standard_Notes_is_a_simple_and_private_notes_app_that_makes_your_notes_easy_and_available_everywhere_you_areP_Features_endtoend_encryption_on_every_p_354_KEY: |
   Standard Notes is a simple and private notes app that makes your notes easy and available everywhere you are. Features end-to-end encryption on every platform, and a powerful desktop experience with themes and custom editors. It has also been <a href="https://s3.amazonaws.com/standard-notes/security/Report-SN-Audit.pdf">independently audited (PDF)</a>.
 
-httpsstandardnotesorg_KEY: |
+httpsstandardnotesPorg_26_KEY: |
   https://standardnotes.org/
 
-httpsstandardnotesorggetstarted_KEY: |
+httpsstandardnotesPorggetstarted_38_KEY: |
   https://standardnotes.org/#get-started
 
-httpsfdroidorgpackagescomstandardnotes_KEY: |
+httpsfdroidPorgpackagescomPstandardnotes_47_KEY: |
   https://f-droid.org/packages/com.standardnotes/
 
-httpsplaygooglecomstoreappsdetailsidcomstandardnotes_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPstandardnotes_63_KEY: |
   https://play.google.com/store/apps/details?id=com.standardnotes
 
-httpsitunesapplecomusappstandardnotesid1285392450_KEY: |
+httpsitunesPapplePcomusappstandardnotesid1285392450_59_KEY: |
   https://itunes.apple.com/us/app/standard-notes/id1285392450
 
-httpsappstandardnotesorg_KEY: |
+httpsappPstandardnotesPorg_30_KEY: |
   https://app.standardnotes.org/
 
-httpsgithubcomstandardnotes_KEY: |
+httpsgithubPcomstandardnotes_32_KEY: |
   https://github.com/standardnotes
 
-Turtl_KEY: |
+Turtl_5_KEY: |
   Turtl
 
-Turtl_lets_you_take_notes_bookmark_websites_and_store_documents_for_sensitive_projects_From_sharing_passwords_with_your_coworkers_to_tracking_resear_KEY: |
+Turtl_lets_you_take_notes_bookmark_websites_and_store_documents_for_sensitive_projectsP_From_sharing_passwords_with_your_coworkers_to_tracking_resear_255_KEY: |
   Turtl lets you take notes, bookmark websites, and store documents for sensitive projects. From sharing passwords with your coworkers to tracking research on an article you're writing, Turtl keeps it all safe from everyone but you and those you share with.
 
-httpsturtlappcom_KEY: |
+httpsturtlappPcom_21_KEY: |
   https://turtlapp.com/
 
-httpsturtlappcomdownload_KEY: |
+httpsturtlappPcomdownload_30_KEY: |
   https://turtlapp.com/download/
 
-httpsaddonsmozillaorgenUSfirefoxaddonturtlbookmarking_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonturtlbookmarking_65_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/turtl-bookmarking/
 
-httpschromegooglecomwebstoredetailturtldgcojenhfdjhieoglmiaheihjadlpcml_KEY: |
+httpschromePgooglePcomwebstoredetailturtldgcojenhfdjhieoglmiaheihjadlpcml_80_KEY: |
   https://chrome.google.com/webstore/detail/turtl/dgcojenhfdjhieoglmiaheihjadlpcml
 
-httpsplaygooglecomstoreappsdetailsidcomlyonbrosturtl_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPlyonbrosPturtl_64_KEY: |
   https://play.google.com/store/apps/details?id=com.lyonbros.turtl
 
-httpsgithubcomturtl_KEY: |
+httpsgithubPcomturtl_24_KEY: |
   https://github.com/turtl
 
-Warning_KEY: |
+Warning_8_KEY: |
   Warning
 
-Note_As_of_Dec_2018_Joplin_does_not_support_passwordpin_protection_for_the_application_itself_or_individual_notesnotebooks_Data_is_still_encrypted_KEY: |
+Note_As_of_Dec_2018_Joplin_does_not_support_passwordpin_protection_for_the_application_itself_or_individual_notesnotebooksP_Data_is_still_encrypted_206_KEY: |
   Note: As of Dec 2018, Joplin does not support password/pin protection for the application itself or individual notes/notebooks. Data is still encrypted in transit and at sync location using your master key.
 
-See_a_hrefhttpsgithubcomlaurent22joplinissues289open_issuea_KEY: |
+See_a_hrefhttpsgithubPcomlaurent22joplinissues289open_issueaP_77_KEY: |
   See <a href='https://github.com/laurent22/joplin/issues/289'>open issue</a>.
 
-httpsgithubcomnotablenotable_KEY: |
+httpsgithubPcomnotablenotable_35_KEY: |
   https://github.com/notable/notable
 
-Notable_KEY: |
+Notable_8_KEY: |
   Notable
 
-The_markdownbased_notetaking_app_that_doesnt_suck_KEY: |
+The_markdownbased_notetaking_app_that_doesnt_suckP_54_KEY: |
   The markdown-based note-taking app that doesn't suck.
 
-httpspaperworkcloud_KEY: |
+httpspaperworkPcloud_25_KEY: |
   https://paperwork.cloud/
 
-Paperwork_KEY: |
+Paperwork_10_KEY: |
   Paperwork
 
-An_opensource_and_selfhosted_solution_For_PHP__MySQL_servers_KEY: |
+An_opensource_and_selfhosted_solutionP_For_PHP__MySQL_serversP_66_KEY: |
   An open-source and self-hosted solution. For PHP / MySQL servers.
 
-httpsorgmodeorg_KEY: |
+httpsorgmodePorg_20_KEY: |
   https://orgmode.org
 
-Orgmode_KEY: |
+Orgmode_9_KEY: |
   Org-mode
 
-A_major_mode_for_GNU_Emacs_Orgmode_is_for_keeping_notes_maintaining_TODO_lists_planning_projects_and_authoring_documents_with_a_fast_and_effective_KEY: |
+A_major_mode_for_GNU_EmacsP_Orgmode_is_for_keeping_notes_maintaining_TODO_lists_planning_projects_and_authoring_documents_with_a_fast_and_effective_171_KEY: |
   A major mode for GNU Emacs. Org-mode is for keeping notes, maintaining TODO lists, planning projects, and authoring documents with a fast and effective plain-text system.
 
-Global_Mass_Surveillance__The_Fourteen_Eyes_KEY: |
+Global_Mass_Surveillance__The_Fourteen_Eyes_45_KEY: |
   Global Mass Surveillance - The Fourteen Eyes
 
-UKUSA_Agreement_KEY: |
+UKUSA_Agreement_16_KEY: |
   UKUSA Agreement
 
-The_UKUSA_Agreement_is_an_agreement_between_the_United_Kingdom_United_States_Australia_Canada_and_New_Zealand_to_cooperatively_collect_analyze_an_KEY: |
+The_UKUSA_Agreement_is_an_agreement_between_the_United_Kingdom_United_States_Australia_Canada_and_New_Zealand_to_cooperatively_collect_analyze_an_1246_KEY: |
   The UKUSA Agreement is an agreement between the United Kingdom, United States, Australia, Canada, and New Zealand to cooperatively collect, analyze, and share intelligence. Members of this group, known as the <a href="https://www.giswatch.org/en/communications-surveillance/unmasking-five-eyes-global-surveillance-practices">Five Eyes</a>, focus on gathering and analyzing intelligence from different parts of the world. While Five Eyes countries have agreed to <a href="https://www.pbs.org/newshour/world/an-exclusive-club-the-five-countries-that-dont-spy-on-each-other">not spy on each other</a> as adversaries, leaks by Snowden have revealed that some Five Eyes members monitor each other's citizens and <a href="https://www.theguardian.com/uk/2013/jun/21/gchq-cables-secret-world-communications-nsa">share intelligence</a> to <a href="https://www.theguardian.com/politics/2013/jun/10/nsa-offers-intelligence-british-counterparts-blunkett">avoid breaking domestic laws</a> that prohibit them from spying on their own citizens. The Five Eyes alliance also cooperates with groups of third-party countries to share intelligence (forming the Nine Eyes and Fourteen Eyes); however, Five Eyes and third-party countries can and do spy on each other.
 
-Australia_KEY: |
+Australia_10_KEY: |
   Australia
 
-Canada_KEY: |
+Canada_7_KEY: |
   Canada
 
-New_Zealand_KEY: |
+New_Zealand_12_KEY: |
   New Zealand
 
-United_Kingdom_KEY: |
+United_Kingdom_15_KEY: |
   United Kingdom
 
-United_States_of_America_KEY: |
+United_States_of_America_25_KEY: |
   United States of America
 
-Five_Eyes_KEY: |
+Five_Eyes_9_KEY: |
   Five Eyes
 
-France_KEY: |
+France_7_KEY: |
   France
 
-Nine_Eyes_KEY: |
+Nine_Eyes_9_KEY: |
   Nine Eyes
 
-Italy_KEY: |
+Italy_6_KEY: |
   Italy
 
-Spain_KEY: |
+Spain_6_KEY: |
   Spain
 
-Sweden_KEY: |
+Sweden_7_KEY: |
   Sweden
 
-Fourteen_Eyes_KEY: |
+Fourteen_Eyes_13_KEY: |
   Fourteen Eyes
 
-Key_Disclosure_Law_KEY: |
+Key_Disclosure_Law_19_KEY: |
   Key Disclosure Law
 
-Who_is_required_to_hand_over_the_encryption_keys_to_authorities_KEY: |
+Who_is_required_to_hand_over_the_encryption_keys_to_authoritiesQ_65_KEY: |
   Who is required to hand over the encryption keys to authorities?
 
-Mandatory_a_hrefhttpsenwikipediaorgwikiKey_disclosure_lawkey_disclosure_lawsa_require_individuals_to_turn_over_encryption_keys_to_law_en_KEY: |
+Mandatory_a_hrefhttpsenPwikipediaPorgwikiKey_disclosure_lawkey_disclosure_lawsa_require_individuals_to_turn_over_encryption_keys_to_law_en_981_KEY: |
   Mandatory <a href="https://en.wikipedia.org/wiki/Key_disclosure_law">key disclosure laws</a> require individuals to turn over encryption keys to law enforcement conducting a criminal investigation. How these laws are implemented (who may be legally compelled to assist) vary from nation to nation, but a warrant is generally required. Defenses against key disclosure laws include steganography and encrypting data in a way that provides plausible deniability.</p>  <p><a href="https://en.wikipedia.org/wiki/Steganography">Steganography</a> involves hiding sensitive information (which may be encrypted) inside of ordinary data (for example, encrypting an image file and then hiding it in an audio file). With plausible deniability, data is encrypted in a way that prevents an adversary from being able to prove that the information they are after exists (for example, one password may decrypt benign data and another password, used on the same file, could decrypt sensitive data).
 
-httpsenwikipediaorgwikiKey_disclosure_lawAntigua_and_Barbuda_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawAntigua_and_Barbuda_69_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Antigua_and_Barbuda
 
-Antigua_and_Barbuda_KEY: |
+Antigua_and_Barbuda_20_KEY: |
   Antigua and Barbuda
 
-httpsenwikipediaorgwikiKey_disclosure_lawAustralia_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawAustralia_59_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Australia
 
-httpsenwikipediaorgwikiKey_disclosure_lawCanada_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawCanada_56_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Canada
 
-httpsenwikipediaorgwikiKey_disclosure_lawFrance_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawFrance_56_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#France
 
-httpsenwikipediaorgwikiKey_disclosure_lawIndia_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawIndia_55_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#India
 
-India_KEY: |
+India_6_KEY: |
   India
 
-httpsenwikipediaorgwikiKey_disclosure_lawIreland_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawIreland_57_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Ireland
 
-Ireland_KEY: |
+Ireland_8_KEY: |
   Ireland
 
-httpsedriorgnorwayintroducesforcedbiometricauthentication_KEY: |
+httpsedriPorgnorwayintroducesforcedbiometricauthentication_68_KEY: |
   https://edri.org/norway-introduces-forced-biometric-authentication/
 
-httpswwwbloombergcomnewsarticles20180320telegramlosesbidtostoprussiafromgettingencryptionkeys_KEY: |
+httpswwwPbloombergPcomnewsarticles20180320telegramlosesbidtostoprussiafromgettingencryptionkeys_114_KEY: |
   https://www.bloomberg.com/news/articles/2018-03-20/telegram-loses-bid-to-stop-russia-from-getting-encryption-keys
 
-Russia_KEY: |
+Russia_7_KEY: |
   Russia
 
-httpsenwikipediaorgwikiKey_disclosure_lawSouth_Africa_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawSouth_Africa_62_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#South_Africa
 
-South_Africa_KEY: |
+South_Africa_13_KEY: |
   South Africa
 
-httpsenwikipediaorgwikiKey_disclosure_lawUnited_Kingdom_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawUnited_Kingdom_64_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#United_Kingdom
 
-Key_disclosure_laws_apply_KEY: |
+Key_disclosure_laws_apply_25_KEY: |
   Key disclosure laws apply
 
-httpsenwikipediaorgwikiKey_disclosure_lawBelgium_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawBelgium_57_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Belgium
 
-Belgium__KEY: |
+Belgium__10_KEY: |
   Belgium *
 
-httpswwwriigiteatajaeeakt106012016019_KEY: |
+httpswwwPriigiteatajaPeeakt106012016019_45_KEY: |
   https://www.riigiteataja.ee/akt/106012016019
 
-Estonia_KEY: |
+Estonia_8_KEY: |
   Estonia
 
-httpsenwikipediaorgwikiKey_disclosure_lawFinland_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawFinland_57_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Finland
 
-Finland__KEY: |
+Finland__10_KEY: |
   Finland *
 
-httpsenwikipediaorgwikiKey_disclosure_lawNew_Zealand_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawNew_Zealand_61_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#New_Zealand
 
-unclear_KEY: |
+unclear_8_KEY: |
   unclear
 
-httpsenwikipediaorgwikiKey_disclosure_lawThe_Netherlands_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawThe_Netherlands_65_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#The_Netherlands
 
-The_Netherlands__KEY: |
+The_Netherlands__18_KEY: |
   The Netherlands *
 
-httpsenwikipediaorgwikiKey_disclosure_lawUnited_States_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawUnited_States_63_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#United_States
 
-United_States_KEY: |
+United_States_14_KEY: |
   United States
 
-see_related_info_KEY: |
+see_related_info_17_KEY: |
   see related info
 
-Key_disclosure_laws_may_apply_KEY: |
+Key_disclosure_laws_may_apply_29_KEY: |
   Key disclosure laws may apply
 
-httpsenwikipediaorgwikiKey_disclosure_lawCzech_Republic_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawCzech_Republic_64_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Czech_Republic
 
-httpsenwikipediaorgwikiKey_disclosure_lawGermany_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawGermany_57_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Germany
 
-httpsenwikipediaorgwikiKey_disclosure_lawIceland_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawIceland_57_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Iceland
 
-Iceland_KEY: |
+Iceland_8_KEY: |
   Iceland
 
-httpsiclgcompracticeareascybersecuritylawsandregulationsitaly_KEY: |
+httpsiclgPcompracticeareascybersecuritylawsandregulationsitaly_73_KEY: |
   https://iclg.com/practice-areas/cybersecurity-laws-and-regulations/italy
 
-httpsenwikipediaorgwikiKey_disclosure_lawPoland_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawPoland_56_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Poland
 
-Poland_KEY: |
+Poland_7_KEY: |
   Poland
 
-httpsenwikipediaorgwikiKey_disclosure_lawSweden_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_lawSweden_56_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law#Sweden
 
-proposed_KEY: |
+proposed_9_KEY: |
   proposed
 
-httpswwwwikipediaorgwikiKey_disclosure_lawSwitzerland_KEY: |
+httpswwwPwikipediaPorgwikiKey_disclosure_lawSwitzerland_62_KEY: |
   https://www.wikipedia.org/wiki/Key_disclosure_law#Switzerland
 
-Key_disclosure_laws_dont_apply_KEY: |
+Key_disclosure_laws_dont_apply_31_KEY: |
   Key disclosure laws don't apply
 
-_people_who_know_how_to_access_a_system_may_be_ordered_to_share_their_knowledge_stronghowever_this_doesnt_apply_to_the_suspect_itself_or_family__KEY: |
+_people_who_know_how_to_access_a_system_may_be_ordered_to_share_their_knowledge_stronghowever_this_doesnt_apply_to_the_suspect_itself_or_family__170_KEY: |
   * (people who know how to access a system may be ordered to share their knowledge, <strong>however, this doesn't apply to the suspect itself or family members.</strong>)
 
-httpsenwikipediaorgwikiKey_disclosure_law_KEY: |
+httpsenPwikipediaPorgwikiKey_disclosure_law_49_KEY: |
   https://en.wikipedia.org/wiki/Key_disclosure_law
 
-Wikipedia_page_on_key_disclosure_law_KEY: |
+Wikipedia_page_on_key_disclosure_law_37_KEY: |
   Wikipedia page on key disclosure law
 
-httpslawstackexchangecomquestions1523canauscitizenberequiredtoprovidetheauthenticationkeyforencrypteddat_KEY: |
+httpslawPstackexchangePcomquestions1523canauscitizenberequiredtoprovidetheauthenticationkeyforencrypteddat_126_KEY: |
   https://law.stackexchange.com/questions/1523/can-a-us-citizen-be-required-to-provide-the-authentication-key-for-encrypted-dat
 
-lawstackexchangecom_question_about_key_disclosure_law_in_US_KEY: |
+lawPstackexchangePcom_question_about_key_disclosure_law_in_US_62_KEY: |
   law.stackexchange.com question about key disclosure law in US
 
-httpspeertubemastodonhostvideoswatche09915eb59624830a02f8da5c2b59e71_KEY: |
+httpspeertubePmastodonPhostvideoswatche09915eb59624830a02f8da5c2b59e71_81_KEY: |
   https://peertube.mastodon.host/videos/watch/e09915eb-5962-4830-a02f-8da5c2b59e71
 
-DEFCON_20_Crypto_and_the_Cops_the_Law_of_Key_Disclosure_and_Forced_Decryption_KEY: |
+DEFCON_20_Crypto_and_the_Cops_the_Law_of_Key_Disclosure_and_Forced_Decryption_80_KEY: |
   DEFCON 20: Crypto and the Cops: the Law of Key Disclosure and Forced Decryption
 
-Why_is_it_not_recommended_to_choose_a_USbased_service_KEY: |
+Why_is_it_not_recommended_to_choose_a_USbased_serviceQ_56_KEY: |
   Why is it not recommended to choose a US-based service?
 
-USA_KEY: |
+USA_4_KEY: |
   USA
 
-Services_based_in_the_United_States_are_not_recommended_because_of_the_countrys_surveillance_programs_and_use_of_a_hrefhttpswwwefforgissuesn_KEY: |
+Services_based_in_the_United_States_are_not_recommended_because_of_the_countrys_surveillance_programs_and_use_of_a_hrefhttpswwwPeffPorgissuesn_558_KEY: |
   Services based in the United States are not recommended because of the country's surveillance programs and use of <a href="https://www.eff.org/issues/national-security-letters/faq">National Security Letters</a> (NSLs) with accompanying gag orders, which forbid the recipient from talking about the request. This combination allows the government to <a href="https://www.schneier.com/blog/archives/2013/08/more_on_the_nsa.html">secretly force</a> companies to grant complete access to customer data and transform the service into a tool of mass surveillance.
 
-An_example_of_this_is_a_hrefhttpsenwikipediaorgwikiLavabitSuspension_and_gag_orderLavabita__a_secure_email_service_created_by_Ladar_Le_KEY: |
+An_example_of_this_is_a_hrefhttpsenPwikipediaPorgwikiLavabitSuspension_and_gag_orderLavabita__a_secure_email_service_created_by_Ladar_Le_676_KEY: |
   An example of this is <a href="https://en.wikipedia.org/wiki/Lavabit#Suspension_and_gag_order">Lavabit</a> – a secure email service created by Ladar Levison. The FBI <a href="https://www.vice.com/en_us/article/nzz888/lavabit-founder-ladar-levison-discusses-his-federal-battle-for-privacy">requested</a> Snowden's records after finding out that he used the service. Since Lavabit did not keep logs and email content was stored encrypted, the FBI served a subpoena (with a gag order) for the service's SSL keys. Having the SSL keys would allow them to access communications (both metadata and unencrypted content) in real time for all of Lavabit's customers, not just Snowden's.
 
-Ultimately_Levison_turned_over_the_SSL_keys_and_a_hrefhttpswwwtheguardiancomcommentisfree2014may20whydidlavabitshutdownsnowdenemail_KEY: |
+Ultimately_Levison_turned_over_the_SSL_keys_and_a_hrefhttpswwwPtheguardianPcomcommentisfree2014may20whydidlavabitshutdownsnowdenemail_374_KEY: |
   Ultimately, Levison turned over the SSL keys and <a href="https://www.theguardian.com/commentisfree/2014/may/20/why-did-lavabit-shut-down-snowden-email">shut down</a> the service at the same time. The US government then <a href="https://www.cnbc.com/id/100962389">threatened Levison with arrest</a>, saying that shutting down the service was a violation of the court order.
 
-httpswwwbestvpncomtheultimateprivacyguideavoidus_KEY: |
+httpswwwPbestvpnPcomtheultimateprivacyguideavoidus_60_KEY: |
   https://www.bestvpn.com/the-ultimate-privacy-guide/#avoidus
 
-Avoid_all_US_and_UK_based_services_KEY: |
+Avoid_all_US_and_UK_based_services_35_KEY: |
   Avoid all US and UK based services
 
-httpsenwikipediaorgwikiSurespotHistory_KEY: |
+httpsenPwikipediaPorgwikiSurespotHistory_47_KEY: |
   https://en.wikipedia.org/wiki/Surespot#History
 
-Proof_that_warrant_canaries_work_based_on_the_surespot_example_KEY: |
+Proof_that_warrant_canaries_work_based_on_the_surespot_exampleP_64_KEY: |
   Proof that warrant canaries work based on the surespot example.
 
-httpsenwikipediaorgwikiUKUSA_Agreement_KEY: |
+httpsenPwikipediaPorgwikiUKUSA_Agreement_46_KEY: |
   https://en.wikipedia.org/wiki/UKUSA_Agreement
 
-The_United_Kingdom__United_States_of_America_Agreement_UKUSA_KEY: |
+The_United_Kingdom__United_States_of_America_Agreement_UKUSA_64_KEY: |
   The United Kingdom – United States of America Agreement (UKUSA)
 
-httpsenwikipediaorgwikiLavabitSuspension_and_gag_order_KEY: |
+httpsenPwikipediaPorgwikiLavabitSuspension_and_gag_order_63_KEY: |
   https://en.wikipedia.org/wiki/Lavabit#Suspension_and_gag_order
 
-Lavabit_Suspension_and_gag_order_KEY: |
+Lavabit_Suspension_and_gag_order_34_KEY: |
   Lavabit: Suspension and gag order
 
-Key_disclosure_law_KEY: |
+Key_disclosure_law_19_KEY: |
   Key disclosure law
 
-httpsenwikipediaorgwikiPortalMass_surveillance_KEY: |
+httpsenPwikipediaPorgwikiPortalMass_surveillance_55_KEY: |
   https://en.wikipedia.org/wiki/Portal:Mass_surveillance
 
-Wikipedia_Portal_Mass_surveillance_KEY: |
+Wikipedia_Portal_Mass_surveillance_36_KEY: |
   Wikipedia Portal: Mass_surveillance
 
-Recommended_VPN_Service_KEY: |
+Recommended_VPN_Service_24_KEY: |
   Recommended VPN Service
 
-Our_recommended_provider_is_outside_the_US_uses_encryption_accepts_Bitcoin_supports_OpenVPN_and_has_a_no_logging_policy_a_hrefcriteriaRead_o_KEY: |
+Our_recommended_provider_is_outside_the_US_uses_encryption_accepts_Bitcoin_supports_OpenVPN_and_has_a_no_logging_policyP_a_hrefcriteriaRead_o_202_KEY: |
   Our recommended provider is outside the US, uses encryption, accepts Bitcoin, supports OpenVPN, and has a no logging policy. <a href="#criteria">Read our full list of criteria for more information</a>.
 
-Mullvad_KEY: |
+Mullvad_8_KEY: |
   Mullvad
 
-EUR_KEY: |
+EUR_4_KEY: |
   EUR
 
-60Year_KEY: |
+60Year_9_KEY: |
   €60/Year
 
-strongMullvadstrong_is_a_fast_and_inexpensive_VPN_with_a_serious_focus_on_transparency_and_security_They_have_been_in_operation_since_strong200_KEY: |
+strongMullvadstrong_is_a_fast_and_inexpensive_VPN_with_a_serious_focus_on_transparency_and_securityP_They_have_been_in_operation_since_strong200_424_KEY: |
   <strong>Mullvad</strong> is a fast and inexpensive VPN with a serious focus on transparency and security. They have been in operation since <strong>2009</strong>. It is the only VPN provider that currently meets our criteria for recommendation. Mullvad is based in <span class="flag-icon flag-icon-se"></span> Sweden and does not have a free trial. Visit <a href="https://mullvad.net/">mullvad.net</a> to create an account.
 
-406_Servers_KEY: |
+406_Servers_13_KEY: |
   406+ Servers
 
-Mullvad_has_409_servers_in_39_countries_at_the_time_of_writing_this_page_Typically_the_more_servers_a_provider_offers_the_better_With_hundreds_of_se_KEY: |
+Mullvad_has_409_servers_in_39_countries_at_the_time_of_writing_this_pageP_Typically_the_more_servers_a_provider_offers_the_better_With_hundreds_of_se_265_KEY: |
   Mullvad has 409 servers in 39 countries at the time of writing this page. Typically the more servers a provider offers, the better: With hundreds of servers in operation, you are far more likely to find a fast connection and a server geographically closest to you.
 
-WireGuard_Support_KEY: |
+WireGuard_Support_18_KEY: |
   WireGuard Support
 
-In_addition_to_standard_OpenVPN_connections_Mullvad_supports_WireGuard_WireGuard_is_an_experimental_protocol_with_theoretically_better_security_and_h_KEY: |
+In_addition_to_standard_OpenVPN_connections_Mullvad_supports_WireGuardP_WireGuard_is_an_experimental_protocol_with_theoretically_better_security_and_h_231_KEY: |
   In addition to standard OpenVPN connections, Mullvad supports WireGuard. WireGuard is an experimental protocol with theoretically better security and higher reliability, although it is not currently recommended for production use.
 
-Independently_Audited_KEY: |
+Independently_Audited_22_KEY: |
   Independently Audited
 
-Mullvads_VPN_clients_have_been_audited_by_Cure53_and_Assured_AB_in_a_pentest_report_a_hrefhttpscure53depentestreport_mullvad_v2pdfpublishe_KEY: |
+Mullvads_VPN_clients_have_been_audited_by_Cure53_and_Assured_AB_in_a_pentest_report_a_hrefhttpscure53Pdepentestreport_mullvad_v2Ppdfpublishe_170_KEY: |
   Mullvad's VPN clients have been audited by Cure53 and Assured AB in a pentest report <a href="https://cure53.de/pentest-report_mullvad_v2.pdf">published at cure53.de</a>.
 
-The_security_researchers_concluded_KEY: |
+The_security_researchers_concluded_36_KEY: |
   The security researchers concluded:
 
-Cure53_and_Assured_AB_are_happy_with_the_results_of_the_audit_and_the_software_leaves_an_overall_positive_impression_With_security_dedication_of_th_KEY: |
+PPPCure53_and_Assured_AB_are_happy_with_the_results_of_the_audit_and_the_software_leaves_an_overall_positive_impressionP_With_security_dedication_of_th_294_KEY: |
   ...Cure53 and Assured AB are happy with the results of the audit and the software leaves an overall positive impression. With security dedication of the in-house team at the Mullvad VPN compound, the testers have no doubts about the project being on the right track from a security standpoint.
 
-Accepts_Bitcoin_KEY: |
+Accepts_Bitcoin_16_KEY: |
   Accepts Bitcoin
 
-Mullvad_in_addition_to_accepting_creditdebit_cards_and_PayPal_accepts_strongBitcoinstrong_strongBitcoin_Cashstrong_and_strongcashlocal_KEY: |
+Mullvad_in_addition_to_accepting_creditdebit_cards_and_PayPal_accepts_strongBitcoinstrong_strongBitcoin_Cashstrong_and_strongcashlocal_249_KEY: |
   Mullvad in addition to accepting credit/debit cards and PayPal, accepts <strong>Bitcoin</strong>, <strong>Bitcoin Cash</strong>, and <strong>cash/local currency</strong> as anonymous forms of payment. They also accept Swish and bank wire transfers.
 
-No_Mobile_Clients_KEY: |
+No_Mobile_Clients_18_KEY: |
   No Mobile Clients
 
-While_iOS_and_Android_clients_are_reportedly_in_the_works_mobile_users_will_need_to_use_a_traditional_OpenVPN_client_and_configuration_files_which_ar_KEY: |
+While_iOS_and_Android_clients_are_reportedly_in_the_works_mobile_users_will_need_to_use_a_traditional_OpenVPN_client_and_configuration_files_which_ar_188_KEY: |
   While iOS and Android clients are reportedly in the works, mobile users will need to use a traditional OpenVPN client and configuration files, which are a bit more difficult to configure.
 
-Extra_Functionality_KEY: |
+Extra_Functionality_20_KEY: |
   Extra Functionality
 
-The_Mullvad_VPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPN_They_also_are_able_to_automatically_start_on_boot_KEY: |
+The_Mullvad_VPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPNP_They_also_are_able_to_automatically_start_on_bootP_271_KEY: |
   The Mullvad VPN clients have a built-in killswitch to block internet connections outside of the VPN. They also are able to automatically start on boot. The Mullvad website is also accessible via Tor at <a href="http://xcln5hkbriyklr6n.onion/">xcln5hkbriyklr6n.onion</a>.
 
-Note_Using_a_VPN_provider_will_not_make_you_anonymous_but_it_will_give_you_better_privacy_in_certain_situations_A_VPN_is_not_a_tool_for_illegal_acti_KEY: |
+Note_Using_a_VPN_provider_will_not_make_you_anonymous_but_it_will_give_you_better_privacy_in_certain_situationsP_A_VPN_is_not_a_tool_for_illegal_acti_192_KEY: |
   Note: Using a VPN provider will not make you anonymous, but it will give you better privacy in certain situations. A VPN is not a tool for illegal activities. Don't rely on a "no log" policy.
 
-Other_Providers_Worth_Mentioning_KEY: |
+Other_Providers_Worth_Mentioning_33_KEY: |
   Other Providers Worth Mentioning
 
-ProtonVPN_KEY: |
+ProtonVPN_10_KEY: |
   ProtonVPN
 
-USD_KEY: |
+USD_4_KEY: |
   USD
 
-96year_KEY: |
+96year_9_KEY: |
   $96/year
 
-strongProtonVPNstrong_is_a_strong_contender_in_the_VPN_space_and_they_have_been_in_operation_since_strong2016strong_ProtonVPN_is_based_in__KEY: |
+strongProtonVPNstrong_is_a_strong_contender_in_the_VPN_space_and_they_have_been_in_operation_since_strong2016strongP_ProtonVPN_is_based_in__418_KEY: |
   <strong>ProtonVPN</strong> is a strong contender in the VPN space, and they have been in operation since <strong>2016</strong>. ProtonVPN is based in <span class="flag-icon flag-icon-ch"></span> Switzerland and offers a limited free pricing tier, as well as premium options. Unfortunately due to its lack of an independent security audit it does not meet the complete criteria for recommendation, see our notes below.
 
-Not_Audited_KEY: |
+Not_Audited_12_KEY: |
   Not Audited
 
-ProtonVPN_has_not_undergone_a_security_audit_by_an_independent_third_party_and_therefore_cannot_be_strongly_recommended_at_this_time_We_have_still_ch_KEY: |
+ProtonVPN_has_not_undergone_a_security_audit_by_an_independent_third_party_and_therefore_cannot_be_strongly_recommended_at_this_timeP_We_have_still_ch_237_KEY: |
   ProtonVPN has not undergone a security audit by an independent third party, and therefore cannot be strongly recommended at this time. We have still chosen to list it on this page with the assumption that an audit will be published soon
 
-We_are_currently_undergoing_a_complete_security_audit_of_our_VPN_applications_by_a_reputable_Swiss_security_company_The_results_of_the_audit_will_be_s_KEY: |
+We_are_currently_undergoing_a_complete_security_audit_of_our_VPN_applications_by_a_reputable_Swiss_security_companyP_The_results_of_the_audit_will_be_s_201_KEY: |
   We are currently undergoing a complete security audit of our VPN applications by a reputable Swiss security company. The results of the audit will be summarized in a public report for cases like this.
 
-Marc_Loebekken_ProtonVPN_AG_Legal_counsel_KEY: |
+Marc_Loebekken_ProtonVPN_AG_Legal_counsel_43_KEY: |
   Marc Loebekken, ProtonVPN AG Legal counsel
 
-We_will_reevaluate_this_listing_at_the_end_of_2019_or_when_the_aforementioned_report_has_been_published_whichever_is_sooner_KEY: |
+We_will_reevaluate_this_listing_at_the_end_of_2019_or_when_the_aforementioned_report_has_been_published_whichever_is_soonerP_126_KEY: |
   We will reevaluate this listing at the end of 2019 or when the aforementioned report has been published, whichever is sooner.
 
-526_Servers_KEY: |
+526_Servers_13_KEY: |
   526+ Servers
 
-ProtonVPN_has_526_servers_in_42_countries_at_the_time_of_writing_this_page_Typically_the_more_servers_a_provider_offers_the_better_With_hundreds_of__KEY: |
+ProtonVPN_has_526_servers_in_42_countries_at_the_time_of_writing_this_pageP_Typically_the_more_servers_a_provider_offers_the_better_With_hundreds_of__267_KEY: |
   ProtonVPN has 526 servers in 42 countries at the time of writing this page. Typically the more servers a provider offers, the better: With hundreds of servers in operation, you are far more likely to find a fast connection and a server geographically closest to you.
 
-ProtonVPN_does_technically_accept_Bitcoin_payments_however_you_either_need_to_have_an_existing_account_or_contact_their_support_team_in_advance_to_r_KEY: |
+ProtonVPN_does_technically_accept_Bitcoin_payments_however_you_either_need_to_have_an_existing_account_or_contact_their_support_team_in_advance_to_r_173_KEY: |
   ProtonVPN does technically accept Bitcoin payments; however, you either need to have an existing account, or contact their support team in advance to register with Bitcoin.
 
-Mobile_Clients_KEY: |
+Mobile_Clients_15_KEY: |
   Mobile Clients
 
-In_addition_to_providing_standard_OpenVPN_configuration_files_ProtonVPN_has_mobile_clients_for_iOS_or_Android_allowing_for_easy_connections_to_their_s_KEY: |
+In_addition_to_providing_standard_OpenVPN_configuration_files_ProtonVPN_has_mobile_clients_for_iOS_or_Android_allowing_for_easy_connections_to_their_s_159_KEY: |
   In addition to providing standard OpenVPN configuration files, ProtonVPN has mobile clients for iOS or Android allowing for easy connections to their servers.
 
-The_ProtonVPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPN_They_also_are_able_to_automatically_start_on_boot_P_KEY: |
+The_ProtonVPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPNP_They_also_are_able_to_automatically_start_on_bootP_P_314_KEY: |
   The ProtonVPN clients have a built-in killswitch to block internet connections outside of the VPN. They also are able to automatically start on boot. ProtonVPN also offers "Tor" servers allowing you to easily connect to onion sites, but we still strongly recommend using the official Tor Browser for this purpose.
 
-IVPN_KEY: |
+IVPN_5_KEY: |
   IVPN
 
-100Year_KEY: |
+100Year_10_KEY: |
   $100/Year
 
-strongIVPNstrong_is_another_strong_premium_VPN_provider_and_they_have_been_in_operation_since_strong2009strong_IVPN_is_based_in_span_class_KEY: |
+strongIVPNstrong_is_another_strong_premium_VPN_provider_and_they_have_been_in_operation_since_strong2009strongP_IVPN_is_based_in_span_class_371_KEY: |
   <strong>IVPN</strong> is another strong premium VPN provider, and they have been in operation since <strong>2009</strong>. IVPN is based in <span class="flag-icon flag-icon-gi"></span> Gibraltar and offers a 3 day free trial. Unfortunately, due to its lack of an independent security audit, it does not meet the complete criteria for recommendation, see our notes below.
 
-No_Security_Audit_KEY: |
+No_Security_Audit_18_KEY: |
   No Security Audit
 
-IVPN_has_undergone_a_a_hrefhttpscure53deauditreport_ivpnpdfnologging_audit_from_Cure53a_which_concluded_in_agreement_with_IVPNs_nolog_KEY: |
+IVPN_has_undergone_a_a_hrefhttpscure53Pdeauditreport_ivpnPpdfnologging_audit_from_Cure53a_which_concluded_in_agreement_with_IVPNs_nolog_561_KEY: |
   IVPN has undergone a <a href="https://cure53.de/audit-report_ivpn.pdf">no-logging audit from Cure53</a> which concluded in agreement with IVPN's no-logging claim. However, IVPN has not undergone a more comprehensive security audit by an independent third party, and therefore cannot be strongly recommended at this time. We have still chosen to list it on this page with the assumption that an audit will be published soon: The IVPN team <a href="https://twitter.com/yaelwrites/status/1161796418220089344">reportedly plans to begin the process in September</a>.
 
-77_Servers_KEY: |
+77_Servers_12_KEY: |
   77+ Servers
 
-IVPN_has_77_servers_in_31_countries_at_the_time_of_writing_this_page_Typically_the_more_servers_a_provider_offers_the_better_IVPN_has_a_decent_but__KEY: |
+IVPN_has_77_servers_in_31_countries_at_the_time_of_writing_this_pageP_Typically_the_more_servers_a_provider_offers_the_betterP_IVPN_has_a_decent_but__244_KEY: |
   IVPN has 77 servers in 31 countries at the time of writing this page. Typically the more servers a provider offers, the better. IVPN has a decent (but not exceptional) server count that will most likely provide adequate coverage to most users.
 
-In_addition_to_accepting_creditdebit_cards_and_PayPal_IVPN_accepts_strongBitcoinstrong_and_strongcashlocal_currencystrong_on_annual_plans_KEY: |
+In_addition_to_accepting_creditdebit_cards_and_PayPal_IVPN_accepts_strongBitcoinstrong_and_strongcashlocal_currencystrong_on_annual_plans_184_KEY: |
   In addition to accepting credit/debit cards and PayPal, IVPN accepts <strong>Bitcoin</strong> and <strong>cash/local currency</strong> (on annual plans) as anonymous forms of payment.
 
-In_addition_to_providing_standard_OpenVPN_configuration_files_IVPN_has_mobile_clients_for_iOS_or_Android_allowing_for_easy_connections_to_their_server_KEY: |
+In_addition_to_providing_standard_OpenVPN_configuration_files_IVPN_has_mobile_clients_for_iOS_or_Android_allowing_for_easy_connections_to_their_server_154_KEY: |
   In addition to providing standard OpenVPN configuration files, IVPN has mobile clients for iOS or Android allowing for easy connections to their servers.
 
-The_IVPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPN_They_also_are_able_to_automatically_start_on_boot_IVPN_a_KEY: |
+The_IVPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPNP_They_also_are_able_to_automatically_start_on_bootP_IVPN_a_264_KEY: |
   The IVPN clients have a built-in killswitch to block internet connections outside of the VPN. They also are able to automatically start on boot. IVPN also provides "AntiTracker" functionality, which blocks advertising networks and trackers from the network level.
 
-What_is_a_warrant_canary_KEY: |
+What_is_a_warrant_canaryQ_26_KEY: |
   What is a warrant canary?
 
-Warrant_Canary_Example_KEY: |
+Warrant_Canary_Example_23_KEY: |
   Warrant Canary Example
 
-A_warrant_canary_is_a_posted_document_stating_that_an_organization_has_not_received_any_secret_subpoenas_during_a_specific_period_of_time_If_this_docu_KEY: |
+A_warrant_canary_is_a_posted_document_stating_that_an_organization_has_not_received_any_secret_subpoenas_during_a_specific_period_of_timeP_If_this_docu_310_KEY: |
   A warrant canary is a posted document stating that an organization has not received any secret subpoenas during a specific period of time. If this document fails to be updated during the specified time then the user is to assume that the service has received such a subpoena and should stop using the service.
 
-Warrant_Canary_Examples_KEY: |
+Warrant_Canary_Examples_25_KEY: |
   Warrant Canary Examples:
 
-httpsproxyshcanary_KEY: |
+httpsproxyPshcanary_24_KEY: |
   https://proxy.sh/canary
 
-httpswwwivpnnetresourcescanarytxt_KEY: |
+httpswwwPivpnPnetresourcescanaryPtxt_42_KEY: |
   https://www.ivpn.net/resources/canary.txt
 
-httpswwwbolehvpnnetcanarytxt_KEY: |
+httpswwwPbolehvpnPnetcanaryPtxt_36_KEY: |
   https://www.bolehvpn.net/canary.txt
 
-httpswwwipredatorsestaticdownloadscanarytxt_KEY: |
+httpswwwPipredatorPsestaticdownloadscanaryPtxt_53_KEY: |
   https://www.ipredator.se/static/downloads/canary.txt
 
-Related_Warrant_Canary_Information_KEY: |
+Related_Warrant_Canary_Information_35_KEY: |
   Related Warrant Canary Information
 
-httpswwwefforgdeeplinks201404warrantcanaryfaq_KEY: |
+httpswwwPeffPorgdeeplinks201404warrantcanaryfaq_57_KEY: |
   https://www.eff.org/deeplinks/2014/04/warrant-canary-faq
 
-Warrant_Canary_Frequently_Asked_Questions_KEY: |
+Warrant_Canary_Frequently_Asked_Questions_42_KEY: |
   Warrant Canary Frequently Asked Questions
 
-httpsenwikipediaorgwikiWarrant_canaryCompanies_and_organizations_with_warrant_canaries_KEY: |
+httpsenPwikipediaPorgwikiWarrant_canaryCompanies_and_organizations_with_warrant_canaries_95_KEY: |
   https://en.wikipedia.org/wiki/Warrant_canary#Companies_and_organizations_with_warrant_canaries
 
-Companies_and_organizations_with_warrant_canaries_KEY: |
+Companies_and_organizations_with_warrant_canaries_50_KEY: |
   Companies and organizations with warrant canaries
 
-httpswwwschneiercomblogarchives201503australia_outlahtml_KEY: |
+httpswwwPschneierPcomblogarchives201503australia_outlaPhtml_68_KEY: |
   https://www.schneier.com/blog/archives/2015/03/australia_outla.html
 
-Warrant_canary_criticism_by_Bruce_Schneier_and_an_example_of_a_law_against_warrant_canaries_KEY: |
+Warrant_canary_criticism_by_Bruce_Schneier_and_an_example_of_a_law_against_warrant_canariesP_93_KEY: |
   Warrant canary criticism by Bruce Schneier and an example of a law against warrant canaries.
 
-PrivacyRespecting_Search_Engines_KEY: |
+PrivacyRespecting_Search_Engines_34_KEY: |
   Privacy-Respecting Search Engines
 
-If_you_are_currently_using_search_engines_like_Google_Bing_or_Yahoo_you_should_pick_an_alternative_here_KEY: |
+If_you_are_currently_using_search_engines_like_Google_Bing_or_Yahoo_you_should_pick_an_alternative_hereP_107_KEY: |
   If you are currently using search engines like Google, Bing, or Yahoo, you should pick an alternative here.
 
-searx__Decentral_KEY: |
+searx__Decentral_17_KEY: |
   searx - Decentral
 
-searx_is_an_a_hrefhttpsgithubcomasciimoosearxopensourcea_metasearch_engine_aggregating_the_results_of_other_search_engines_while_not_st_KEY: |
+searx_is_an_a_hrefhttpsgithubPcomasciimoosearxopensourcea_metasearch_engine_aggregating_the_results_of_other_search_engines_while_not_st_409_KEY: |
   searx is an <a href="https://github.com/asciimoo/searx">open-source</a> metasearch engine, aggregating the results of other search engines while not storing information about its users. No logs, no ads and no tracking. There is a <a href="https://github.com/asciimoo/searx/wiki/Searx-instances">list of public instances</a>, or you can try <a href="https://search.privacytools.io/">the PrivacyTools Search</a>
 
-httpssearxme_KEY: |
+httpssearxPme_17_KEY: |
   https://searx.me/
 
-httpsgithubcomasciimoosearx_KEY: |
+httpsgithubPcomasciimoosearx_33_KEY: |
   https://github.com/asciimoo/searx
 
-DuckDuckGo__USA_KEY: |
+DuckDuckGo__USA_16_KEY: |
   DuckDuckGo - USA
 
-DuckDuckGo_is_a_search_engine_that_doesnt_track_you_Some_of_DuckDuckGos_code_is_free_software_hosted_at_GitHub_but_the_core_is_proprietary_span_KEY: |
+DuckDuckGo_is_a_search_engine_that_doesnt_track_youP_Some_of_DuckDuckGos_code_is_free_software_hosted_at_GitHub_but_the_core_is_proprietaryP_span_260_KEY: |
   DuckDuckGo is a "search engine that doesn't track you." Some of DuckDuckGo's code is free software hosted at GitHub, but the core is proprietary. <span class="flag-icon flag-icon-us"></span> <a href="../../providers/#ukusa">The company is based in the USA.</a>
 
-httpsduckduckgocom_KEY: |
+httpsduckduckgoPcom_23_KEY: |
   https://duckduckgo.com/
 
-httpsgithubcomduckduckgo_KEY: |
+httpsgithubPcomduckduckgo_29_KEY: |
   https://github.com/duckduckgo
 
-Qwant__France_KEY: |
+Qwant__France_14_KEY: |
   Qwant - France
 
-Qwant_is_a_search_engine_with_its_philosophy_based_on_two_principles_no_user_tracking_and_no_filter_bubble_Qwant_was_launched_in_France_in_February_2_KEY: |
+Qwant_is_a_search_engine_with_its_philosophy_based_on_two_principles_no_user_tracking_and_no_filter_bubbleP_Qwant_was_launched_in_France_in_February_2_155_KEY: |
   Qwant is a search engine with its philosophy based on two principles: no user tracking and no filter bubble. Qwant was launched in France in February 2013.
 
-httpswwwqwantcom_KEY: |
+httpswwwPqwantPcom_22_KEY: |
   https://www.qwant.com/
 
-httpsgithubcomQwant_KEY: |
+httpsgithubPcomQwant_25_KEY: |
   https://github.com/Qwant/
 
-Firefox_Addon_KEY: |
+Firefox_Addon_14_KEY: |
   Firefox Addon
 
-httpsaddonsmozillaorgfirefoxaddongooglesearchlinkfix_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddongooglesearchlinkfix_64_KEY: |
   https://addons.mozilla.org/firefox/addon/google-search-link-fix/
 
-Google_search_link_fix_KEY: |
+Google_search_link_fix_23_KEY: |
   Google search link fix
 
-Firefox_extension_that_prevents_Google_and_Yandex_search_pages_from_modifying_search_result_links_when_you_click_them_This_is_useful_when_copying_link_KEY: |
+Firefox_extension_that_prevents_Google_and_Yandex_search_pages_from_modifying_search_result_links_when_you_click_themP_This_is_useful_when_copying_link_239_KEY: |
   Firefox extension that prevents Google and Yandex search pages from modifying search result links when you click them. This is useful when copying links but it also helps privacy by preventing the search engines from recording your clicks.
 
-Open_Source_KEY: |
+Open_Source_12_KEY: |
   Open Source
 
-httpsyacynet_KEY: |
+httpsyacyPnet_17_KEY: |
   https://yacy.net/
 
-YaCy_KEY: |
+YaCy_5_KEY: |
   YaCy
 
-A_freesoftware_P2P_search_engine_powered_by_its_users_KEY: |
+A_freesoftware_P2P_search_engine_powered_by_its_usersP_56_KEY: |
   A free-software P2P search engine powered by its users.
 
-httpsjivesearchcom_KEY: |
+httpsjivesearchPcom_23_KEY: |
   https://jivesearch.com/
 
-Jive_Search_KEY: |
+Jive_Search_12_KEY: |
   Jive Search
 
-A_freesoftware_search_engine_with_a_similar_look_and_feel_to_Google_KEY: |
+A_freesoftware_search_engine_with_a_similar_look_and_feel_to_GoogleP_70_KEY: |
   A free-software search engine with a similar look and feel to Google.
 
-httpsmetagerdeen_KEY: |
+httpsmetagerPdeen_22_KEY: |
   https://metager.de/en/
 
-MetaGer_KEY: |
+MetaGer_8_KEY: |
   MetaGer
 
-An_opensource_metasearch_engine_which_is_based_in_Germany_It_focuses_on_protecting_the_users_privacy_KEY: |
+An_opensource_metasearch_engine_which_is_based_in_GermanyP_It_focuses_on_protecting_the_users_privacyP_106_KEY: |
   An open-source metasearch engine, which is based in Germany. It focuses on protecting the user's privacy.
 
-httpswwwmojeekcom_KEY: |
+httpswwwPmojeekPcom_24_KEY: |
   https://www.mojeek.com/
 
-Mojeek_KEY: |
+Mojeek_7_KEY: |
   Mojeek
 
-Independent_and_unbiased_search_results_with_no_user_tracking_KEY: |
+Independent_and_unbiased_search_results_with_no_user_trackingP_63_KEY: |
   Independent and unbiased search results with no user tracking.
 
-Encrypted_Instant_Messenger_KEY: |
+Encrypted_Instant_Messenger_28_KEY: |
   Encrypted Instant Messenger
 
-If_you_are_currently_using_an_Instant_Messenger_like_Telegram_LINE_Viber_a_hrefhttpswwwefforgdeeplinks201610wherewhatsappwentwrongef_KEY: |
+If_you_are_currently_using_an_Instant_Messenger_like_Telegram_LINE_Viber_a_hrefhttpswwwPeffPorgdeeplinks201610wherewhatsappwentwrongef_250_KEY: |
   If you are currently using an Instant Messenger like Telegram, LINE, Viber, <a href="https://www.eff.org/deeplinks/2016/10/where-whatsapp-went-wrong-effs-four-biggest-security-concerns">WhatsApp</a>, or plain SMS you should pick an alternative here.
 
-Signal_KEY: |
+Signal_6_KEY: |
   Signal
 
-Signal_is_a_mobile_app_developed_by_Open_Whisper_Systems_The_app_provides_instant_messaging_as_well_as_voice_and_video_calling_All_communications_ar_KEY: |
+Signal_is_a_mobile_app_developed_by_Open_Whisper_SystemsP_The_app_provides_instant_messaging_as_well_as_voice_and_video_callingP_All_communications_ar_206_KEY: |
   Signal is a mobile app developed by Open Whisper Systems. The app provides instant messaging, as well as voice and video calling. All communications are end-to-end encrypted. Signal is free and open source.
 
-VoIP_KEY: |
+VoIP_4_KEY: |
   VoIP
 
-httpssignalorg_KEY: |
+httpssignalPorg_19_KEY: |
   https://signal.org/
 
-httpssignalorgdownload_KEY: |
+httpssignalPorgdownload_28_KEY: |
   https://signal.org/download/
 
-httpsplaygooglecomstoreappsdetailsidorgthoughtcrimesecuresms_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidorgPthoughtcrimePsecuresms_72_KEY: |
   https://play.google.com/store/apps/details?id=org.thoughtcrime.securesms
 
-httpssignalorgandroidapkapkdanger_KEY: |
+httpssignalPorgandroidapkapkdanger_42_KEY: |
   https://signal.org/android/apk/#apk-danger
 
-httpsappsapplecomusappsignalprivatemessengerid874139669_KEY: |
+httpsappsPapplePcomusappsignalprivatemessengerid874139669_66_KEY: |
   https://apps.apple.com/us/app/signal-private-messenger/id874139669
 
-httpsgithubcomsignalapp_KEY: |
+httpsgithubPcomsignalapp_28_KEY: |
   https://github.com/signalapp
 
-Complete_Comparison_KEY: |
+Complete_Comparison_20_KEY: |
   Complete Comparison
 
-httpssecurechatguideorgeffguidehtml_KEY: |
+httpssecurechatguidePorgeffguidePhtml_42_KEY: |
   https://securechatguide.org/effguide.html
 
-securechatguideorg_KEY: |
+securechatguidePorg_20_KEY: |
   securechatguide.org
 
-Guide_to_Choosing_a_Messenger_KEY: |
+Guide_to_Choosing_a_MessengerP_31_KEY: |
   Guide to Choosing a Messenger.
 
-httpswwwsecuremessagingappscom_KEY: |
+httpswwwPsecuremessagingappsPcom_37_KEY: |
   https://www.securemessagingapps.com/
 
-securemessagingappscom_KEY: |
+securemessagingappsPcom_24_KEY: |
   securemessagingapps.com
 
-Secure_Messaging_Apps_Comparison_KEY: |
+Secure_Messaging_Apps_ComparisonP_34_KEY: |
   Secure Messaging Apps Comparison.
 
-httpswwwthinkprivacyiomessengershtml_KEY: |
+httpswwwPthinkprivacyPiomessengersPhtml_44_KEY: |
   https://www.thinkprivacy.io/messengers.html
 
-thinkprivacyio_KEY: |
+thinkprivacyPio_16_KEY: |
   thinkprivacy.io
 
-Simple_Secure_Messaging_Apps_Comparison_KEY: |
+Simple_Secure_Messaging_Apps_ComparisonP_41_KEY: |
   Simple Secure Messaging Apps Comparison.
 
-httpsbriarprojectorg_KEY: |
+httpsbriarprojectPorg_26_KEY: |
   https://briarproject.org/
 
-Briar_KEY: |
+Briar_6_KEY: |
   Briar
 
-An_ultrasecure_peertopeer_instant_messenger_that_connects_to_contacts_via_Direct_WiFi_Bluetooth_or_Tor_over_the_internet_keeping_its_users_prote_KEY: |
+An_ultrasecure_peertopeer_instant_messenger_that_connects_to_contacts_via_Direct_WiFi_Bluetooth_or_Tor_over_the_internet_keeping_its_users_prote_190_KEY: |
   An ultra-secure peer-to-peer instant messenger that connects to contacts via Direct Wi-Fi, Bluetooth, or Tor over the internet, keeping its users protected from surveillance and censorship.
 
-httpsaboutriotim_KEY: |
+httpsaboutPriotPim_23_KEY: |
   https://about.riot.im/
 
-Riot_KEY: |
+Riot_5_KEY: |
   Riot
 
-An_opensource_federated_messenger_that_utilizes_the_Matrix_protocol_This_application_is_primarily_recommended_as_a_large_groupteam_chat_solution_W_KEY: |
+An_opensource_federated_messenger_that_utilizes_the_Matrix_protocolP_This_application_is_primarily_recommended_as_a_large_groupteam_chat_solutionP_W_275_KEY: |
   An open-source, federated messenger that utilizes the Matrix protocol. This application is primarily recommended as a large group/team chat solution. While Riot has the ability to perform 1-on-1 communications we believe there are better solutions for direct communications.
 
-An_endtoend_encrypted_instant_messaging_and_voicevideo_call_client_RetroShare_supports_both_TOR_and_I2P_KEY: |
+An_endtoend_encrypted_instant_messaging_and_voicevideo_call_clientP_RetroShare_supports_both_TOR_and_I2PP_110_KEY: |
   An end-to-end encrypted instant messaging and voice/video call client. RetroShare supports both TOR and I2P.
 
-httpsxmpporg_KEY: |
+httpsxmppPorg_18_KEY: |
   https://xmpp.org/
 
-XMPP_KEY: |
+XMPP_5_KEY: |
   XMPP
 
-Federated_instant_messaging_protocol_with_a_hrefhttpsconversationsimomemoOMEMOa_OTR_or_OpenPGP_endtoend_encryption_KEY: |
+Federated_instant_messaging_protocol_with_a_hrefhttpsconversationsPimomemoOMEMOa_OTR_or_OpenPGP_endtoend_encryption_134_KEY: |
   Federated instant messaging protocol with <a href="https://conversations.im/omemo/">OMEMO</a>, OTR, or OpenPGP end-to-end encryption:
 
-httpsconversationsim_KEY: |
+httpsconversationsPim_26_KEY: |
   https://conversations.im/
 
-Conversations_KEY: |
+Conversations_14_KEY: |
   Conversations
 
-Android_KEY: |
+Android_8_KEY: |
   Android
 
-An_opensource_JabberXMPP_client_for_Android_44_smartphones_KEY: |
+An_opensource_JabberXMPP_client_for_Android_4P4_smartphonesP_64_KEY: |
   An open-source Jabber/XMPP client for Android 4.4+ smartphones.
 
-OMEMO_KEY: |
+OMEMO_6_KEY: |
   OMEMO
 
-httpsgajimorg_KEY: |
+httpsgajimPorg_19_KEY: |
   https://gajim.org/
 
-Gajim_KEY: |
+Gajim_6_KEY: |
   Gajim
 
-FreeBSD_Linux_Windows_KEY: |
+FreeBSD_Linux_Windows_24_KEY: |
   FreeBSD, Linux, Windows
 
-An_opensource_fully_featured_XMPP_client_KEY: |
+An_opensource_fully_featured_XMPP_clientP_42_KEY: |
   An open-source fully featured XMPP client.
 
-httpsmonalim_KEY: |
+httpsmonalPim_18_KEY: |
   https://monal.im/
 
-Monal_KEY: |
+Monal_6_KEY: |
   Monal
 
-iOS_MacOS_KEY: |
+iOS_MacOS_11_KEY: |
   iOS, MacOS
 
-An_XMPP_client_in_active_development_KEY: |
+An_XMPP_client_in_active_developmentP_38_KEY: |
   An XMPP client in active development.
 
-httpsomemotop_KEY: |
+VoIP_5_KEY: |
+  VoIP
+
+httpsomemoPtop_19_KEY: |
   https://omemo.top/
 
-Other_OMEMOready_clients_KEY: |
+Other_OMEMOready_clients_26_KEY: |
   Other OMEMO-ready clients
 
-httpswwwkontalkorg_KEY: |
+httpswwwPkontalkPorg_25_KEY: |
   https://www.kontalk.org/
 
-Kontalk_KEY: |
+Kontalk_8_KEY: |
   Kontalk
 
-A_communitydriven_instant_messaging_network_Supports_endtoend_encryption_Both_clienttoserver_and_servertoserver_channels_are_fully_encrypted_KEY: |
+A_communitydriven_instant_messaging_networkP_Supports_endtoend_encryptionP_Both_clienttoserver_and_servertoserver_channels_are_fully_encryptedP_151_KEY: |
   A community-driven instant messaging network. Supports end-to-end encryption. Both client-to-server and server-to-server channels are fully encrypted.
 
-httpskeybaseio_KEY: |
+httpskeybasePio_20_KEY: |
   https://keybase.io/
 
-Keybase_KEY: |
+Keybase_8_KEY: |
   Keybase
 
-This_software_relies_on_a_closedsource_central_server_KEY: |
+This_software_relies_on_a_closedsource_central_serverP_56_KEY: |
   This software relies on a closed-source central server.
 
-Endtoend_encrypted_messaging_with_social_verification_KEY: |
+Endtoend_encrypted_messaging_with_social_verificationP_57_KEY: |
   End-to-end encrypted messaging with social verification.
 
-httpsstatusim_KEY: |
+httpsstatusPim_19_KEY: |
   https://status.im/
 
-Status_KEY: |
+Status_7_KEY: |
   Status
 
-Experimental_KEY: |
+Experimental_13_KEY: |
   Experimental
 
-A_free_and_opensource_peertopeer_encrypted_instant_messanger_with_support_for_DAPPs_KEY: |
+A_free_and_opensource_peertopeer_encrypted_instant_messanger_with_support_for_DAPPsP_90_KEY: |
   A free and open-source, peer-to-peer, encrypted instant messanger with support for DAPPs.
 
-httpstoxchat_KEY: |
+httpstoxPchat_18_KEY: |
   https://tox.chat/
 
-Tox_KEY: |
+Tox_4_KEY: |
   Tox
 
-A_free_and_opensource_peertopeer_encrypted_instant_messaging_and_video_calling_software_KEY: |
+A_free_and_opensource_peertopeer_encrypted_instant_messaging_and_video_calling_softwareP_94_KEY: |
   A free and open-source, peer-to-peer, encrypted instant messaging, and video calling software.
 
-httpsjaminet_KEY: |
+httpsjamiPnet_18_KEY: |
   https://jami.net/
 
-Jami_formerly_RingSFLphone_KEY: |
+Jami_formerly_RingSFLphone_30_KEY: |
   Jami (formerly Ring/SFLphone)
 
-Gives_you_full_control_over_your_communications_and_an_unmatched_level_of_privacy_Jami_has_text_messaging_video_and_audio_calls_file_transfer_and_v_KEY: |
+Gives_you_full_control_over_your_communications_and_an_unmatched_level_of_privacyP_Jami_has_text_messaging_video_and_audio_calls_file_transfer_and_v_170_KEY: |
   Gives you full control over your communications and an unmatched level of privacy. Jami has text messaging, video and audio calls, file transfer, and video conferencing.
 
-Chatting_in_Secret_While_Were_All_Being_Watched__firstlookorg_KEY: |
+Chatting_in_Secret_While_Were_All_Being_Watched__firstlookPorg_65_KEY: |
   Chatting in Secret While We're All Being Watched - firstlook.org
 
-Advanced_users_with_special_needs_can_download_the_Signal_APK_directly_Most_users_should_not_do_this_under_normal_circumstances_KEY: |
+Advanced_users_with_special_needs_can_download_the_Signal_APK_directlyP_Most_users_should_not_do_this_under_normal_circumstancesP_130_KEY: |
   Advanced users with special needs can download the Signal APK directly. Most users should not do this under normal circumstances.
 
-Independent_security_audits_KEY: |
+Independent_security_audits_28_KEY: |
   Independent security audits
 
-a_hrefhttpseprintiacrorg20161013pdfA_Formal_Security_Analysis_of_the_Signal_Messaging_Protocol_2019a_by_Katriel_CohnGordon_Cas_Crem_KEY: |
+a_hrefhttpseprintPiacrPorg20161013PpdfA_Formal_Security_Analysis_of_the_Signal_Messaging_Protocol_2019a_by_Katriel_CohnGordon_Cas_Crem_207_KEY: |
   <a href="https://eprint.iacr.org/2016/1013.pdf">A Formal Security Analysis of the Signal Messaging Protocol (2019)</a> by Katriel Cohn-Gordon, Cas Cremers, Benjamin Dowling, Luke Garratt and Douglas Stebila
 
-a_hrefhttpskeybaseiodocsassetsblogNCC_Group_Keybase_KB2018_Public_Report_20190227_v13pdfKeybases_Protocol_Security_Review_2019a__KEY: |
+a_hrefhttpskeybasePiodocsassetsblogNCC_Group_Keybase_KB2018_Public_Report_20190227_v1P3PpdfKeybases_Protocol_Security_Review_2019a__206_KEY: |
   <a href="https://keybase.io/docs-assets/blog/NCC_Group_Keybase_KB2018_Public_Report_2019-02-27_v1.3.pdf">Keybase's Protocol Security Review (2019)</a> by <a href="https://www.nccgroup.trust/">NCC Group</a>
 
-VideoVoice_Calling_KEY: |
+VideoVoice_Calling_20_KEY: |
   Video/Voice Calling
 
-If_you_are_currently_using_a_VideoVoice_Calling_app_like_Skype_Viber_or_Google_Hangouts_you_should_pick_an_alternative_here_KEY: |
+If_you_are_currently_using_a_VideoVoice_Calling_app_like_Skype_Viber_or_Google_Hangouts_you_should_pick_an_alternative_hereP_127_KEY: |
   If you are currently using a Video/Voice Calling app like Skype, Viber or Google Hangouts, you should pick an alternative here.
 
-Please_note_that_many_of_the_above_instant_messengers_also_support_span_classbadge_badgesuccessVoIPspan_The_software_listed_below_are_empri_KEY: |
+Please_note_that_many_of_the_above_instant_messengers_also_support_span_classbadge_badgesuccessVoIPspanP_The_software_listed_below_are_empri_183_KEY: |
   Please note that many of the above instant messengers also support <span class="badge badge-success">VoIP</span>. The software listed below are <em>primarily</em> Voice/Video focused.
 
-Linphone_KEY: |
+Linphone_8_KEY: |
   Linphone
 
-Linphone_is_an_opensource_SIP_Phone_and_a_free_voice_over_IP_service_available_on_mobile_and_desktop_environments_and_on_web_browsers_It_supports_ZR_KEY: |
+Linphone_is_an_opensource_SIP_Phone_and_a_free_voice_over_IP_service_available_on_mobile_and_desktop_environments_and_on_web_browsersP_It_supports_ZR_209_KEY: |
   Linphone is an open-source SIP Phone and a free voice over IP service, available on mobile and desktop environments and on web browsers. It supports ZRTP for end-to-end encrypted voice and video communication.
 
-httpswwwlinphoneorg_KEY: |
+httpswwwPlinphonePorg_25_KEY: |
   https://www.linphone.org/
 
-httpswwwlinphoneorgtechnicalcornerlinphoneqttechnical_corner2qttechnical_corner_KEY: |
+httpswwwPlinphonePorgtechnicalcornerlinphoneQqttechnical_corner2qttechnical_corner_92_KEY: |
   https://www.linphone.org/technical-corner/linphone?qt-technical_corner=2#qt-technical_corner
 
-httpsfdroidorgpackagesorglinphone_KEY: |
+httpsfdroidPorgpackagesorgPlinphone_41_KEY: |
   https://f-droid.org/packages/org.linphone
 
-httpsplaygooglecomstoreappsdetailsidorglinphone_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidorgPlinphone_58_KEY: |
   https://play.google.com/store/apps/details?id=org.linphone
 
-httpsitunesapplecomusapplinphoneid360065638mt8_KEY: |
+httpsitunesPapplePcomusapplinphoneid360065638Qmt8_57_KEY: |
   https://itunes.apple.com/us/app/linphone/id360065638?mt=8
 
-httpsgithubcomBelledonneCommunications_KEY: |
+httpsgithubPcomBelledonneCommunications_43_KEY: |
   https://github.com/BelledonneCommunications
 
-Mumble_KEY: |
+Mumble_6_KEY: |
   Mumble
 
-Mumble_is_an_opensource_lowlatency_and_high_quality_voice_chat_application_primarily_intended_for_use_while_gaming_Note_that_while_Mumble_doesnt__KEY: |
+Mumble_is_an_opensource_lowlatency_and_high_quality_voice_chat_application_primarily_intended_for_use_while_gamingP_Note_that_while_Mumble_doesnt__317_KEY: |
   Mumble is an open-source, low-latency, and high quality voice chat application primarily intended for use while gaming. Note that while Mumble doesn't log messages or record by default, <a href="https://github.com/mumble-voip/mumble/issues/1813">it's missing end-to-end encryption</a>, so self-hosting is recommended.
 
-httpsmumbleinfo_KEY: |
+httpsmumblePinfo_20_KEY: |
   https://mumble.info/
 
-httpswwwmumbleinfodownloads_KEY: |
+httpswwwPmumblePinfodownloads_33_KEY: |
   https://www.mumble.info/downloads
 
-httpswwwmumbleinfodownloadsthirdpartyclients_KEY: |
+httpswwwPmumblePinfodownloadsthirdpartyclients_54_KEY: |
   https://www.mumble.info/downloads/#third-party-clients
 
-httpsappsapplecomusappmumbleid443472808ls1_KEY: |
+httpsappsPapplePcomusappmumbleid443472808Qls1_53_KEY: |
   https://apps.apple.com/us/app/mumble/id443472808?ls=1
 
-httpsgithubcommumblevoip_KEY: |
+httpsgithubPcommumblevoip_31_KEY: |
   https://github.com/mumble-voip/
 
-httpsjitsiorg_KEY: |
+httpsjitsiPorg_19_KEY: |
   https://jitsi.org/
 
-Jitsi_Meet_KEY: |
+Jitsi_Meet_11_KEY: |
   Jitsi Meet
 
-Jitsi_Meet_is_a_free_and_opensource_multiplatform_voice_VoIP_video_conferencing_and_instant_messaging_application_KEY: |
+Jitsi_Meet_is_a_free_and_opensource_multiplatform_voice_VoIP_video_conferencing_and_instant_messaging_applicationP_120_KEY: |
   Jitsi Meet is a free and open-source multiplatform voice (VoIP), video conferencing, and instant messaging application.
 
-Our_Firefox_tweaks_recommend_disabling_WebRTC_as_it_can_be_used_to_leak_your_IP_address_even_behind_a_VPN_which_is_why_Tor_Browser_disables_it_KEY: |
+Our_Firefox_tweaks_recommend_disabling_WebRTC_as_it_can_be_used_to_leak_your_IP_address_even_behind_a_VPN_which_is_why_Tor_Browser_disables_itP_145_KEY: |
   Our Firefox tweaks recommend disabling WebRTC as it can be used to leak your IP address even behind a VPN, which is why Tor Browser disables it.
 
-Requires_WebRTC_KEY: |
+Requires_WebRTC_16_KEY: |
   Requires WebRTC
 
-More_information_about_Mumble_KEY: |
+More_information_about_Mumble_31_KEY: |
   More information about Mumble:
 
-a_href_httpswikimumbleinfowikiRunning_MurmurRunning_Mumble_Servera_and_a_hrefhttpswikimumbleinfowikiMurmuriniits_config_fil_KEY: |
+a_href_httpswikiPmumblePinfowikiRunning_MurmurRunning_Mumble_Servera_and_a_hrefhttpswikiPmumblePinfowikiMurmurPiniits_config_fil_352_KEY: |
   <a href=" https://wiki.mumble.info/wiki/Running_Murmur">Running Mumble Server</a> and <a href="https://wiki.mumble.info/wiki/Murmur.ini">its config file</a>, particularly <a href="https://wiki.mumble.info/wiki/Murmur.ini#obfuscate">obfuscating IPv4 addresses</a> and <a href="https://wiki.mumble.info/wiki/Murmur.ini#Process_Administrivia">logging</a>
 
-a_hrefhttpstractorprojectorgprojectstorwikidocTorifyHOWTOMumbleTorifying_Mumble_KEY: |
+a_hrefhttpstracPtorprojectPorgprojectstorwikidocTorifyHOWTOMumbleTorifying_Mumble_96_KEY: |
   <a href="https://trac.torproject.org/projects/tor/wiki/doc/TorifyHOWTO/Mumble">Torifying Mumble
 
-Team_Chat_Platforms_KEY: |
+Team_Chat_Platforms_20_KEY: |
   Team Chat Platforms
 
-If_your_project_or_organization_currently_uses_a_platform_like_a_hrefhttpstosdrorgdiscordDiscorda_or_a_hrefhttpsdrewdevaultcom201_KEY: |
+If_your_project_or_organization_currently_uses_a_platform_like_a_hrefhttpstosdrPorgdiscordDiscorda_or_a_hrefhttpsdrewdevaultPcom201_236_KEY: |
   If your project or organization currently uses a platform like <a href="https://tosdr.org/#discord">Discord</a> or <a href="https://drewdevault.com/2015/11/01/Please-stop-using-slack.html">Slack</a> you should pick an alternative here.
 
-Riotim_Matrix_KEY: |
+RiotPim_Matrix_16_KEY: |
   Riot.im (Matrix)
 
-Riotim_is_a_federated_freesoftware_messaging_application_based_on_the_a_hrefhttpsmatrixorgMatrixa_protocol_a_recent_open_protocol_for_re_KEY: |
+RiotPim_is_a_federated_freesoftware_messaging_application_based_on_the_a_hrefhttpsmatrixPorgMatrixa_protocol_a_recent_open_protocol_for_re_315_KEY: |
   Riot.im is a federated free-software messaging application based on the <a href"https://matrix.org/">Matrix</a> protocol, a recent open protocol for real-time communication offering optional E2E encryption. It also has bridging functionality, allowing you to connect to other chat protocols such as IRC or Telegram.
 
-The_endtoend_encryption_is_currently_in_beta_and_the_mobile_client_states_Endtoend_encryption_is_in_beta_and_may_not_be_reliable_You_should_not__KEY: |
+The_endtoend_encryption_is_currently_in_beta_and_the_mobile_client_states_Endtoend_encryption_is_in_beta_and_may_not_be_reliableP_You_should_not__180_KEY: |
   The end-to-end encryption is currently in beta, and the mobile client states 'End-to-end encryption is in beta and may not be reliable. You should not yet trust it to secure data.'
 
-a_hrefgithubcomvectorimriotwebissues6779Experimental_E2EEa_KEY: |
+a_hrefgithubPcomvectorimriotwebissues6779Experimental_E2EEa_73_KEY: |
   <a href=//github.com/vector-im/riot-web/issues/6779>Experimental E2EE</a>
 
-httpsriotimdownloaddesktop_KEY: |
+httpsaboutPriotPim_22_KEY: |
+  https://about.riot.im/
+
+httpsriotPimdownloaddesktop_33_KEY: |
   https://riot.im/download/desktop/
 
-httpsfdroidorgrepositorybrowsefdidimvectoralpha_KEY: |
+httpsfdroidPorgrepositorybrowseQfdidimPvectorPalpha_59_KEY: |
   https://f-droid.org/repository/browse/?fdid=im.vector.alpha
 
-httpsplaygooglecomstoreappsdetailsidimvectorapp_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidimPvectorPapp_59_KEY: |
   https://play.google.com/store/apps/details?id=im.vector.app
 
-httpsitunesapplecomusappvectorimid1083446067_KEY: |
+httpsitunesPapplePcomusappvectorPimid1083446067_54_KEY: |
   https://itunes.apple.com/us/app/vector.im/id1083446067
 
-httpsriotimapp_KEY: |
+httpsriotPimapp_20_KEY: |
   https://riot.im/app/
 
-httpsgithubcomvectorimriotweb_KEY: |
+httpsgithubPcomvectorimriotweb_38_KEY: |
   https://github.com/vector-im/riot-web/
 
-Rocketchat_KEY: |
+RocketPchat_11_KEY: |
   Rocket.chat
 
-Rocketchat_is_an_selfhostable_open_source_platform_for_team_communication_It_has_optional_federation_and_experimental_E2EE_KEY: |
+RocketPchat_is_an_selfhostable_open_source_platform_for_team_communicationP_It_has_optional_federation_and_experimental_E2EEP_126_KEY: |
   Rocket.chat is an self-hostable open source platform for team communication. It has optional federation and experimental E2EE.
 
-Regarding_E2EE_their_documentation_states_This_feature_is_currently_in_alpha_Its_also_not_yet_supported_on_mobile_There_is_no_forward_secrecy_so_c_KEY: |
+Regarding_E2EE_their_documentation_states_This_feature_is_currently_in_alphaP_Its_also_not_yet_supported_on_mobileP_There_is_no_forward_secrecy_so_c_283_KEY: |
   Regarding E2EE their documentation states 'This feature is currently in alpha. It's also not yet supported on mobile'. There is no forward secrecy so compromised decryption password would leak all messages. Federation was also added afterwards, potentially causing room for mistakes.
 
-a_hrefrocketchatdocsuserguidesendtoendencryptionExperimental_E2EEa_KEY: |
+a_hrefrocketPchatdocsuserguidesendtoendencryptionExperimental_E2EEa_83_KEY: |
   <a href=//rocket.chat/docs/user-guides/end-to-end-encryption/>Experimental E2EE</a>
 
-httpsrocketchat_KEY: |
+httpsrocketPchat_20_KEY: |
   https://rocket.chat/
 
-httpsrocketchatinstall_KEY: |
+httpsrocketPchatinstall_27_KEY: |
   https://rocket.chat/install
 
-httpsitunesapplecomusapprocketchatid1086818840_KEY: |
+httpsitunesPapplePcomusapprocketchatid1086818840_56_KEY: |
   https://itunes.apple.com/us/app/rocket-chat/id1086818840
 
-httpsfdroidorgpackageschatrocketandroid_KEY: |
+httpsfdroidPorgpackageschatProcketPandroid_48_KEY: |
   https://f-droid.org/packages/chat.rocket.android
 
-httpsplaygooglecomstoreappsdetailsidchatrocketandroid_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidchatProcketPandroid_65_KEY: |
   https://play.google.com/store/apps/details?id=chat.rocket.android
 
-httpsitunesapplecomapprocketchatid1148741252_KEY: |
+httpsitunesPapplePcomapprocketchatid1148741252_53_KEY: |
   https://itunes.apple.com/app/rocket-chat/id1148741252
 
-httpsgithubcomrocketchat_KEY: |
+httpsgithubPcomrocketchat_30_KEY: |
   https://github.com/rocketchat/
 
-Keybase_provides_a_hosted_team_chat_with_endtoend_encryption_It_has_also_been_a_hrefhttpskeybaseiodocsassetsblogNCC_Group_Keybase_KB2018__KEY: |
+Keybase_7_KEY: |
+  Keybase
+
+Keybase_provides_a_hosted_team_chat_with_endtoend_encryptionP_It_has_also_been_a_hrefhttpskeybasePiodocsassetsblogNCC_Group_Keybase_KB2018__218_KEY: |
   Keybase provides a hosted team chat with end-to-end encryption. It has also been <a href="https://keybase.io/docs-assets/blog/NCC_Group_Keybase_KB2018_Public_Report_2019-02-27_v1.3.pdf">independently audited (PDF)</a>.
 
-The_server_side_of_Keybase_runs_on_proprietary_code_and_is_centralized_KEY: |
+The_server_side_of_Keybase_runs_on_proprietary_code_and_is_centralizedP_71_KEY: |
   The server side of Keybase runs on proprietary code and is centralized.
 
-a_hrefgithubcomkeybaseclientissues6374Warninga_KEY: |
+a_hrefgithubPcomkeybaseclientissues6374Warninga_59_KEY: |
   <a href=//github.com/keybase/client/issues/6374>Warning</a>
 
-httpskeybaseiodocsthe_appinstall_windows_KEY: |
+httpskeybasePio_19_KEY: |
+  https://keybase.io/
+
+httpskeybasePiodocsthe_appinstall_windows_47_KEY: |
   https://keybase.io/docs/the_app/install_windows
 
-httpskeybaseiodocsthe_appinstall_macos_KEY: |
+httpskeybasePiodocsthe_appinstall_macos_45_KEY: |
   https://keybase.io/docs/the_app/install_macos
 
-httpskeybaseiodocsthe_appinstall_linux_KEY: |
+httpskeybasePiodocsthe_appinstall_linux_45_KEY: |
   https://keybase.io/docs/the_app/install_linux
 
-httpswwwfreshportsorgsecuritykeybase_KEY: |
+httpswwwPfreshportsPorgsecuritykeybase_44_KEY: |
   https://www.freshports.org/security/keybase/
 
-httpsaddonsmozillaorgenUSfirefoxaddonkeybaseforfirefox_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonkeybaseforfirefox_67_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/keybase-for-firefox/
 
-httpschromegooglecomwebstoredetailkeybaseforredditognfafcpbkogffpmmdglhbjboeojlefj_KEY: |
+httpschromePgooglePcomwebstoredetailkeybaseforredditognfafcpbkogffpmmdglhbjboeojlefj_93_KEY: |
   https://chrome.google.com/webstore/detail/keybase-for-reddit/ognfafcpbkogffpmmdglhbjboeojlefj
 
-httpsplaygooglecomstoreappsdetailsidiokeybaseossifragehlen_US_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidioPkeybasePossifragehlen_US_75_KEY: |
   https://play.google.com/store/apps/details?id=io.keybase.ossifrage&hl=en_US
 
-httpskeybaseio_downloadkeybaseforios_KEY: |
+httpskeybasePio_downloadkeybaseforios_45_KEY: |
   https://keybase.io/_/download/keybase-for-ios
 
-httpsgithubcomKeybase_KEY: |
+httpsgithubPcomKeybase_26_KEY: |
   https://github.com/Keybase
 
-Encrypted_Cloud_Storage_Services_KEY: |
+Encrypted_Cloud_Storage_Services_32_KEY: |
   Encrypted Cloud Storage Services
 
-If_you_are_currently_using_Dropbox_Google_Drive_Microsoft_OneDrive_or_Apple_iCloud_you_should_pick_an_alternative_here_KEY: |
+If_you_are_currently_using_Dropbox_Google_Drive_Microsoft_OneDrive_or_Apple_iCloud_you_should_pick_an_alternative_hereP_122_KEY: |
   If you are currently using Dropbox, Google Drive, Microsoft OneDrive or Apple iCloud, you should pick an alternative here.
 
-Nextcloud__Choose_your_hoster_KEY: |
+Nextcloud__Choose_your_hoster_30_KEY: |
   Nextcloud - Choose your hoster
 
-Nextcloud_is_similar_in_functionality_to_the_widelyused_Dropbox_with_the_difference_being_that_Nextcloud_is_free_and_opensource_thereby_allowing_an_KEY: |
+Nextcloud_is_similar_in_functionality_to_the_widelyused_Dropbox_with_the_difference_being_that_Nextcloud_is_free_and_opensource_thereby_allowing_an_285_KEY: |
   Nextcloud is similar in functionality to the widely-used Dropbox, with the difference being that Nextcloud is free and open-source, thereby allowing anyone to install and operate it without charge on a private server, with no limits on storage space or the number of connected clients.
 
-httpscryptpadfr_KEY: |
+Worth_Mentioning_16_KEY: |
+  Worth Mentioning
+
+Free_clientside_AES_encryption_for_your_cloud_filesP_Open_source_software_No_backdoors_no_registrationP_107_KEY: |
+  Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.
+
+Cryptomators_mobile_apps_are_not_opensourceP_46_KEY: |
+  Cryptomator's mobile apps are not open-source.
+
+httpscryptpadPfr_20_KEY: |
   https://cryptpad.fr
 
-Free_and_endtoend_encrypted_real_time_collaboration_sharing_folders_media_and_documents_KEY: |
+Free_and_endtoend_encrypted_real_time_collaboration_sharing_folders_media_and_documentsP_93_KEY: |
   Free and end-to-end encrypted real time collaboration sharing folders, media, and documents.
 
-Password_Manager_Software_KEY: |
+Password_Manager_Software_26_KEY: |
   Password Manager Software
 
-If_you_are_currently_using_a_password_manager_software_like_1Password_LastPass_Roboform_or_iCloud_Keychain_you_should_pick_an_alternative_here_KEY: |
+If_you_are_currently_using_a_password_manager_software_like_1Password_LastPass_Roboform_or_iCloud_Keychain_you_should_pick_an_alternative_hereP_148_KEY: |
   If you are currently using a password manager software like 1Password, LastPass, Roboform, or iCloud Keychain, you should pick an alternative here.
 
-Bitwarden__CloudSelfhost_KEY: |
+Bitwarden__CloudSelfhost_27_KEY: |
   Bitwarden - Cloud/Self-host
 
-strongBitwardenstrong_is_a_free_and_opensource_password_manager_It_aims_to_solve_password_management_problems_for_individuals_teams_and_busine_KEY: |
+strongBitwardenstrong_is_a_free_and_opensource_password_managerP_It_aims_to_solve_password_management_problems_for_individuals_teams_and_busine_423_KEY: |
   <strong>Bitwarden</strong> is a free and open-source password manager. It aims to solve password management problems for individuals, teams, and business organizations. Bitwarden is among the easiest and safest solutions to store all of your logins and passwords while conveniently keeping them synced between all of your devices. If you don't want to use the Bitwarden cloud, you can easily host your own Bitwarden server.
 
-httpsbitwardencom_KEY: |
+httpsbitwardenPcom_22_KEY: |
   https://bitwarden.com/
 
-httpsbitwardencomdownload_KEY: |
+httpsbitwardenPcomdownload_31_KEY: |
   https://bitwarden.com/#download
 
-httpswwwnpmjscompackagebitwardencli_KEY: |
+httpswwwPnpmjsPcompackagebitwardencli_44_KEY: |
   https://www.npmjs.com/package/@bitwarden/cli
 
-httpsaddonsmozillaorgfirefoxaddonbitwardenpasswordmanager_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddonbitwardenpasswordmanager_68_KEY: |
   https://addons.mozilla.org/firefox/addon/bitwarden-password-manager/
 
-httpschromegooglecomwebstoredetailbitwardenfreepasswordmnngceckbapebfimnlniiiahkandclblb_KEY: |
+httpschromePgooglePcomwebstoredetailbitwardenfreepasswordmnngceckbapebfimnlniiiahkandclblb_100_KEY: |
   https://chrome.google.com/webstore/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb
 
-httpssafariextensionsapplecomdetailsidcombitwardensafariLTZ2PFU5D6_KEY: |
+httpssafariextensionsPapplePcomdetailsQidcomPbitwardenPsafariLTZ2PFU5D6_79_KEY: |
   https://safari-extensions.apple.com/details/?id=com.bitwarden.safari-LTZ2PFU5D6
 
-httpsaddonsoperacomextensionsdetailsbitwardenfreepasswordmanager_KEY: |
+httpsaddonsPoperaPcomextensionsdetailsbitwardenfreepasswordmanager_76_KEY: |
   https://addons.opera.com/extensions/details/bitwarden-free-password-manager/
 
-httpswwwmicrosoftcomstoreapps9P6KXL0SVNNL_KEY: |
+httpswwwPmicrosoftPcomstoreapps9P6KXL0SVNNL_49_KEY: |
   https://www.microsoft.com/store/apps/9P6KXL0SVNNL
 
-httpsmobileappbitwardencomfdroid_KEY: |
+httpsmobileappPbitwardenPcomfdroid_39_KEY: |
   https://mobileapp.bitwarden.com/fdroid/
 
-httpsplaygooglecomstoreappsdetailsidcomx8bitbitwarden_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPx8bitPbitwarden_65_KEY: |
   https://play.google.com/store/apps/details?id=com.x8bit.bitwarden
 
-httpsitunesapplecomappbitwardenfreepasswordmanagerid1137397744mt8_KEY: |
+httpsitunesPapplePcomappbitwardenfreepasswordmanagerid1137397744Qmt8_78_KEY: |
   https://itunes.apple.com/app/bitwarden-free-password-manager/id1137397744?mt=8
 
-httpsvaultbitwardencom_KEY: |
+httpsvaultPbitwardenPcom_30_KEY: |
   https://vault.bitwarden.com/#/
 
-httpsgithubcombitwarden_KEY: |
+httpsgithubPcombitwarden_28_KEY: |
   https://github.com/bitwarden
 
-KeePassXC__Local_KEY: |
+KeePassXC__Local_17_KEY: |
   KeePassXC - Local
 
-strongKeePassXCstrong_is_a_community_fork_of_KeePassX_a_native_crossplatform_port_of_KeePass_Password_Safe_with_the_goal_to_extend_and_improve__KEY: |
+strongKeePassXCstrong_is_a_community_fork_of_KeePassX_a_native_crossplatform_port_of_KeePass_Password_Safe_with_the_goal_to_extend_and_improve__273_KEY: |
   <strong>KeePassXC</strong> is a community fork of KeePassX, a native cross-platform port of KeePass Password Safe, with the goal to extend and improve it with new features and bugfixes to provide a feature-rich, fully cross-platform and modern open-source password manager.
 
-httpskeepassxcorg_KEY: |
+httpskeepassxcPorg_22_KEY: |
   https://keepassxc.org/
 
-httpskeepassxcorgdownloadwindows_KEY: |
+httpskeepassxcPorgdownloadwindows_39_KEY: |
   https://keepassxc.org/download/#windows
 
-httpskeepassxcorgdownloadmac_KEY: |
+httpskeepassxcPorgdownloadmac_35_KEY: |
   https://keepassxc.org/download/#mac
 
-httpskeepassxcorgdownloadlinux_KEY: |
+httpskeepassxcPorgdownloadlinux_37_KEY: |
   https://keepassxc.org/download/#linux
 
-httpswwwfreshportsorgsecuritykeepassxc_KEY: |
+httpswwwPfreshportsPorgsecuritykeepassxc_46_KEY: |
   https://www.freshports.org/security/keepassxc/
 
-httpopenportssesecuritykeepassxc_KEY: |
+httpopenportsPsesecuritykeepassxc_38_KEY: |
   http://openports.se/security/keepassxc
 
-httppkgsrcsesecuritykeepassxc_KEY: |
+httppkgsrcPsesecuritykeepassxc_35_KEY: |
   http://pkgsrc.se/security/keepassxc
 
-httpsaddonsmozillaorgenUSfirefoxaddonkeepassxcbrowser_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonkeepassxcbrowser_64_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser
 
-httpschromegooglecomwebstoredetailkeepassxcbrowseroboonakemofpalcgghocfoadofidjkkk_KEY: |
+httpschromePgooglePcomwebstoredetailkeepassxcbrowseroboonakemofpalcgghocfoadofidjkkk_92_KEY: |
   https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk
 
-httpsfdroidorgpackagescomkunzisoftkeepasslibre_KEY: |
+httpsfdroidPorgpackagescomPkunzisoftPkeepassPlibre_57_KEY: |
   https://f-droid.org/packages/com.kunzisoft.keepass.libre/
 
-httpsplaygooglecomstoreappsdetailsidcomkunzisoftkeepassfree_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPkunzisoftPkeepassPfree_72_KEY: |
   https://play.google.com/store/apps/details?id=com.kunzisoft.keepass.free
 
-httpsgithubcomkeepassxrebootkeepassxc_KEY: |
+httpsgithubPcomkeepassxrebootkeepassxc_43_KEY: |
   https://github.com/keepassxreboot/keepassxc
 
-LessPass__Browser_KEY: |
+LessPass__Browser_18_KEY: |
   LessPass - Browser
 
-strongLessPassstrong_is_a_free_and_opensource_password_manager_that_generates_unique_passwords_for_websites_email_accounts_or_anything_else_bas_KEY: |
+strongLessPassstrong_is_a_free_and_opensource_password_manager_that_generates_unique_passwords_for_websites_email_accounts_or_anything_else_bas_299_KEY: |
   <strong>LessPass</strong> is a free and open-source password manager that generates unique passwords for websites, email accounts, or anything else based on a master password and information you know. No sync needed. Uses PBKDF2 and SHA-256. It's advised to use the browser addons for more security.
 
-httpslesspasscom_KEY: |
+httpslesspassPcom_21_KEY: |
   https://lesspass.com/
 
-httpspypiorgprojectlesspass_KEY: |
+httpspypiPorgprojectlesspass_34_KEY: |
   https://pypi.org/project/lesspass/
 
-httpsaddonsmozillaorgenUSfirefoxaddonlesspass_KEY: |
+httpsaddonsPmozillaPorgenUSfirefoxaddonlesspass_56_KEY: |
   https://addons.mozilla.org/en-US/firefox/addon/lesspass/
 
-httpschromegooglecomwebstoredetaillesspasslcmbpoclaodbgkbjafnkbbinogcbnjih_KEY: |
+httpschromePgooglePcomwebstoredetaillesspasslcmbpoclaodbgkbjafnkbbinogcbnjih_83_KEY: |
   https://chrome.google.com/webstore/detail/lesspass/lcmbpoclaodbgkbjafnkbbinogcbnjih
 
-httpsfdroidorgpackagescomlesspassandroid_KEY: |
+httpsfdroidPorgpackagescomPlesspassPandroid_49_KEY: |
   https://f-droid.org/packages/com.lesspass.android
 
-httpsplaygooglecomstoreappsdetailsidcomlesspassandroid_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPlesspassPandroid_66_KEY: |
   https://play.google.com/store/apps/details?id=com.lesspass.android
 
-httpsgithubcomlesspasslesspass_KEY: |
+httpsgithubPcomlesspasslesspass_36_KEY: |
   https://github.com/lesspass/lesspass
 
-httpsmasterpasswordapp_KEY: |
+httpsmasterpasswordPapp_27_KEY: |
   https://masterpassword.app
 
-Master_Password_KEY: |
+Master_Password_16_KEY: |
   Master Password
 
-A_password_manager_based_on_an_ingenious_passwordgeneration_algorithm_that_guarantees_your_passwords_can_never_be_lost_Its_passwords_arent_stored_t_KEY: |
+A_password_manager_based_on_an_ingenious_passwordgeneration_algorithm_that_guarantees_your_passwords_can_never_be_lostP_Its_passwords_arent_stored_t_279_KEY: |
   A password manager based on an ingenious password-generation algorithm that guarantees your passwords can never be lost. Its passwords aren't stored: they are generated on-demand from your name, the site, and your master password. No syncing, backups, or internet access needed.
 
-httpspsonocom_KEY: |
+httpspsonoPcom_19_KEY: |
   https://psono.com/
 
-Psono_KEY: |
+Psono_6_KEY: |
   Psono
 
-Free_and_open_source_password_manager_for_teams_with_client_side_encryption_and_secure_sharing_of_passwords_files_bookmarks_emails_All_secrets_are__KEY: |
+Free_and_open_source_password_manager_for_teams_with_client_side_encryption_and_secure_sharing_of_passwords_files_bookmarks_emailsP_All_secrets_are__289_KEY: |
   Free and open source password manager for teams with client side encryption and secure sharing of passwords, files, bookmarks, emails. All secrets are protected by a master password. Uses <a href="https://nacl.cr.yp.to/">NACL Crypto</a>, a combination of Curve25519, Salsa20 and Poly1305.
 
-httpspwsafeorg_KEY: |
+httpspwsafePorg_20_KEY: |
   https://pwsafe.org/
 
-Password_Safe_KEY: |
+Password_Safe_14_KEY: |
   Password Safe
 
-Whether_the_answer_is_one_or_hundreds_Password_Safe_allows_you_to_safely_and_easily_create_a_secured_and_encrypted_usernamepassword_list_With_Passwo_KEY: |
+Whether_the_answer_is_one_or_hundreds_Password_Safe_allows_you_to_safely_and_easily_create_a_secured_and_encrypted_usernamepassword_listP_With_Passwo_309_KEY: |
   Whether the answer is one or hundreds, Password Safe allows you to safely and easily create a secured and encrypted username/password list. With Password Safe all you have to do is create and remember a single "Master Password" of your choice in order to unlock and access your entire username/password list.
 
-httpspeertubemastodonhostvideoswatch4cdedd90a5b44022b93d828e85ed58cd_KEY: |
+httpspeertubePmastodonPhostvideoswatch4cdedd90a5b44022b93d828e85ed58cd_81_KEY: |
   https://peertube.mastodon.host/videos/watch/4cdedd90-a5b4-4022-b93d-828e85ed58cd
 
-Edward_Snowden_on_Passwords_on_Peertube_KEY: |
+Edward_Snowden_on_Passwords_on_Peertube_40_KEY: |
   Edward Snowden on Passwords on Peertube
 
-Decentralized_Social_Networks_KEY: |
+Decentralized_Social_Networks_30_KEY: |
   Decentralized Social Networks
 
-If_you_are_currently_using_Social_Networks_like_Facebook_or_Twitter_you_should_pick_an_alternative_here_KEY: |
+If_you_are_currently_using_Social_Networks_like_Facebook_or_Twitter_you_should_pick_an_alternative_hereP_105_KEY: |
   If you are currently using Social Networks like Facebook or Twitter, you should pick an alternative here.
 
-Mastodon__Twitter_Alternative_KEY: |
+Mastodon__Twitter_Alternative_30_KEY: |
   Mastodon - Twitter Alternative
 
-Mastodon_is_a_social_network_based_on_open_web_protocols_and_free_opensource_software_It_is_decentralized_like_email_It_also_has_the_most_users_an_KEY: |
+Mastodon_is_a_social_network_based_on_open_web_protocols_and_free_opensource_softwareP_It_is_decentralized_like_emailP_It_also_has_the_most_users_an_345_KEY: |
   Mastodon is a social network based on open web protocols and free, open-source software. It is decentralized like email. It also has the most users, and the most diverse (in terms of interests) users; looks good; and is easy to setup. Feel welcome to join our hosted instance: <a href="https://social.privacytools.io/">social.privacytools.io</a>
 
-httpsjoinmastodonorg_KEY: |
+httpsjoinmastodonPorg_25_KEY: |
   https://joinmastodon.org/
 
-httpsjoinmastodonorgapps_KEY: |
+httpsjoinmastodonPorgapps_29_KEY: |
   https://joinmastodon.org/apps
 
-httpsjoinmastodonorggettingstarted_KEY: |
+httpsjoinmastodonPorggettingstarted_41_KEY: |
   https://joinmastodon.org/#getting-started
 
-httpsgithubcomtootsuitemastodon_KEY: |
+httpsgithubPcomtootsuitemastodon_37_KEY: |
   https://github.com/tootsuite/mastodon
 
-diaspora__Google_Alternative_KEY: |
+diaspora__Google_Alternative_31_KEY: |
   diaspora* - Google+ Alternative
 
-diaspora_is_based_on_three_key_philosophies_Decentralization_freedom_and_privacy_It_is_intended_to_address_privacy_concerns_related_to_centralized__KEY: |
+diaspora_is_based_on_three_key_philosophies_Decentralization_freedom_and_privacyP_It_is_intended_to_address_privacy_concerns_related_to_centralized__320_KEY: |
   diaspora* is based on three key philosophies: Decentralization, freedom and privacy. It is intended to address privacy concerns related to centralized social networks by allowing users set up their own server (or "pod") to host content; pods can then interact to share status updates, photographs, and other social data.
 
-httpsdiasporafoundationorg_KEY: |
+httpsdiasporafoundationPorg_31_KEY: |
   https://diasporafoundation.org/
 
-httpswikidiasporafoundationorgTools_to_use_with_DiasporaAndroid_KEY: |
+httpswikiPdiasporafoundationPorgTools_to_use_with_DiasporaAndroid_70_KEY: |
   https://wiki.diasporafoundation.org/Tools_to_use_with_Diaspora#Android
 
-httpsgithubcomdiasporadiaspora_KEY: |
+httpsgithubPcomdiasporadiaspora_36_KEY: |
   https://github.com/diaspora/diaspora
 
-Friendica__Facebook_Alternative_KEY: |
+Friendica__Facebook_Alternative_32_KEY: |
   Friendica - Facebook Alternative
 
-Friendica_has_an_emphasis_on_extensive_privacy_settings_and_easy_server_installation_It_aims_to_federate_with_as_many_other_social_networks_as_possibl_KEY: |
+Friendica_has_an_emphasis_on_extensive_privacy_settings_and_easy_server_installationP_It_aims_to_federate_with_as_many_other_social_networks_as_possibl_310_KEY: |
   Friendica has an emphasis on extensive privacy settings and easy server installation. It aims to federate with as many other social networks as possible. Currently, Friendica users can integrate contacts from Facebook, Twitter, Diaspora, GNU social, App.net, Pump.io and other services in their social streams.
 
-httpsfriendica_KEY: |
+httpsfriendiPca_19_KEY: |
   https://friendi.ca/
 
-httpsfriendicaresourcesmobileclients_KEY: |
+httpsfriendiPcaresourcesmobileclients_44_KEY: |
   https://friendi.ca/resources/mobile-clients/
 
-httpsgithubcomfriendicafriendica_KEY: |
+httpsgithubPcomfriendicafriendica_38_KEY: |
   https://github.com/friendica/friendica
 
-PixelFed__Instagram_Alternative_KEY: |
+PixelFed__Instagram_Alternative_32_KEY: |
   PixelFed - Instagram Alternative
 
-PixelFed_is_a_free_and_ethical_photo_sharing_platform_powered_by_ActivityPub_federation_Pixelfed_is_an_opensource_federated_platform_You_can_run_y_KEY: |
+PixelFed_is_a_free_and_ethical_photo_sharing_platform_powered_by_ActivityPub_federationP_Pixelfed_is_an_opensource_federated_platformP_You_can_run_y_231_KEY: |
   PixelFed is a free and ethical photo sharing platform, powered by ActivityPub federation. Pixelfed is an open-source, federated platform. You can run your own instance or <a href="https://fediverse.party/en/pixelfed/">join one.</a>
 
-httpspixelfedorg_KEY: |
+httpspixelfedPorg_21_KEY: |
   https://pixelfed.org/
 
-httpsgithubcompixelfed_KEY: |
+httpsgithubPcompixelfed_27_KEY: |
   https://github.com/pixelfed
 
-GNU_social__Twitter_Alternative_KEY: |
+GNU_social__Twitter_Alternative_32_KEY: |
   GNU social - Twitter Alternative
 
-GNU_social_is_socialcommunication_software_for_both_public_and_private_communications_It_is_widely_supported_and_has_a_large_userbase_It_is_already__KEY: |
+GNU_social_is_socialcommunication_software_for_both_public_and_private_communicationsP_It_is_widely_supported_and_has_a_large_userbaseP_It_is_already__188_KEY: |
   GNU social is social-communication software for both public and private communications. It is widely supported and has a large userbase. It is already used by the Free Software Foundation.
 
-httpsgnuiosocial_KEY: |
+httpsgnuPiosocial_22_KEY: |
   https://gnu.io/social/
 
-httpsgitgnuiognugnusocial_KEY: |
+httpsgitPgnuPiognugnusocial_34_KEY: |
   https://git.gnu.io/gnu/gnu-social/
 
-httpswwwmindscom_KEY: |
+httpswwwPmindsPcom_23_KEY: |
   https://www.minds.com/
 
-Minds_KEY: |
+Minds_6_KEY: |
   Minds
 
-An_a_hrefhttpsgitlabcommindsopensourcea_and_distributed_social_networking_service_integrating_the_blockchain_to_reward_the_community_KEY: |
+An_a_hrefhttpsgitlabPcommindsopensourcea_and_distributed_social_networking_service_integrating_the_blockchain_to_reward_the_communityP_149_KEY: |
   An <a href="https://gitlab.com/minds">open-source</a> and distributed social networking service, integrating the blockchain to reward the community.
 
-httpsmovimeu_KEY: |
+httpsmovimPeu_18_KEY: |
   https://movim.eu/
 
-Movim_KEY: |
+Movim_6_KEY: |
   Movim
 
-A_federated_social_platform_that_relies_on_the_XMPP_standard_and_therefore_allows_you_to_exchange_with_many_other_clients_on_all_devices_KEY: |
+A_federated_social_platform_that_relies_on_the_XMPP_standard_and_therefore_allows_you_to_exchange_with_many_other_clients_on_all_devicesP_138_KEY: |
   A federated social platform that relies on the XMPP standard and therefore allows you to exchange with many other clients on all devices.
 
-httpsaddonsmozillaorgfirefoxaddonmastodonsimplifiedfederation_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddonmastodonsimplifiedfederation_73_KEY: |
   https://addons.mozilla.org/firefox/addon/mastodon-simplified-federation/
 
-Mastodon_Simplified_Federation_KEY: |
+Mastodon_Simplified_Federation_32_KEY: |
   Mastodon: Simplified Federation
 
-Firefox_Extension_to_improve_usability_for_remote_Mastodon_instances_KEY: |
+Firefox_Extension_to_improve_usability_for_remote_Mastodon_instancesP_70_KEY: |
   Firefox Extension to improve usability for remote Mastodon instances.
 
-httpsjustdeletemexyz_KEY: |
+httpsjustdeletemePxyz_26_KEY: |
   https://justdeleteme.xyz/
 
-JustDeleteMe_KEY: |
+JustDeleteMe_13_KEY: |
   JustDeleteMe
 
-A_directory_of_direct_links_to_delete_your_account_from_web_services_KEY: |
+A_directory_of_direct_links_to_delete_your_account_from_web_servicesP_70_KEY: |
   A directory of direct links to delete your account from web services.
 
-httpsforgetcodlfr_KEY: |
+httpsforgetPcodlPfr_24_KEY: |
   https://forget.codl.fr/
 
-Forget_KEY: |
+Forget_7_KEY: |
   Forget
 
-A_service_that_automatically_deletes_your_old_posts_on_Twitter_and_Mastodon_that_everyone_has_forgotten_about_KEY: |
+A_service_that_automatically_deletes_your_old_posts_on_Twitter_and_Mastodon_that_everyone_has_forgotten_aboutP_111_KEY: |
   A service that automatically deletes your old posts on Twitter and Mastodon that everyone has forgotten about.
 
-Facebook_Related_KEY: |
+Facebook_Related_17_KEY: |
   Facebook Related
 
-httpswwwfacebookcomhelpdelete_account_KEY: |
+httpswwwPfacebookPcomhelpdelete_account_45_KEY: |
   https://www.facebook.com/help/delete_account
 
-Delete_your_Facebook_account_KEY: |
+Delete_your_Facebook_account_29_KEY: |
   Delete your Facebook account
 
-Direct_link_to_delete_your_Facebook_account_without_being_able_to_reactivate_it_again_KEY: |
+Direct_link_to_delete_your_Facebook_account_without_being_able_to_reactivate_it_againP_87_KEY: |
   Direct link to delete your Facebook account without being able to reactivate it again.
 
-httpsdeletefacebookcom_KEY: |
+httpsdeletefacebookPcom_28_KEY: |
   https://deletefacebook.com/
 
-How_To_Permanently_Delete_A_Facebook_Account_KEY: |
+How_To_Permanently_Delete_A_Facebook_Account_45_KEY: |
   How To Permanently Delete A Facebook Account
 
-This_guide_will_take_you_through_a_smooth_and_successful_Facebook_account_deletion_KEY: |
+This_guide_will_take_you_through_a_smooth_and_successful_Facebook_account_deletionP_84_KEY: |
   This guide will take you through a smooth and successful Facebook account deletion.
 
-httpsaddonsmozillaorgfirefoxaddonfacebookcontainer_KEY: |
+httpsaddonsPmozillaPorgfirefoxaddonfacebookcontainer_61_KEY: |
   https://addons.mozilla.org/firefox/addon/facebook-container/
 
-Facebook_Container_by_Mozilla_KEY: |
+Facebook_Container_by_Mozilla_30_KEY: |
   Facebook Container by Mozilla
 
-Prevent_Facebook_from_tracking_you_around_the_web_KEY: |
+Prevent_Facebook_from_tracking_you_around_the_webP_51_KEY: |
   Prevent Facebook from tracking you around the web.
 
-httpswwwstopusingfacebookco_KEY: |
+httpswwwPstopusingfacebookPco_34_KEY: |
   https://www.stopusingfacebook.co/
 
-Stop_using_Facebook_KEY: |
+Stop_using_Facebook_20_KEY: |
   Stop using Facebook
 
-A_curated_list_of_reasons_to_stop_using_Facebook_and_how_to_do_it_KEY: |
+A_curated_list_of_reasons_to_stop_using_Facebook_and_how_to_do_itP_67_KEY: |
   A curated list of reasons to stop using Facebook and how to do it.
 
-If_you_are_currently_using_a_online_bulletin_board_like_Reddit_you_should_pick_an_alternative_here_KEY: |
+If_you_are_currently_using_a_online_bulletin_board_like_Reddit_you_should_pick_an_alternative_hereP_100_KEY: |
   If you are currently using a online bulletin board like Reddit, you should pick an alternative here.
 
-Aether_KEY: |
+Aether_6_KEY: |
   Aether
 
-a_hrefhttpsgithubcomnehbitaetherblobmasterLICENSEmdAether_is_a_free_and_opensourcea_decentralized_social_news_aggregator_with_a_buil_KEY: |
+a_hrefhttpsgithubPcomnehbitaetherblobmasterLICENSEPmdAether_is_a_free_and_opensourcea_decentralized_social_news_aggregator_with_a_buil_170_KEY: |
   <a href="https://github.com/nehbit/aether/blob/master/LICENSE.md">Aether is a free and open-source</a> decentralized social news aggregator with a built-in voting system.
 
-httpsgetaethernet_KEY: |
+httpsgetaetherPnet_22_KEY: |
   https://getaether.net/
 
-httpsgetaethernetdownload_KEY: |
+httpsgetaetherPnetdownload_31_KEY: |
   https://getaether.net/download/
 
-httpsgithubcomnehbitaether_KEY: |
+httpsgithubPcomnehbitaether_32_KEY: |
   https://github.com/nehbit/aether
 
-Tildes_KEY: |
+Tildes_6_KEY: |
   Tildes
 
-Tildes_is_a_webbased_selfhostable_online_bulletin_board_It_is_licensed_under_a_hrefhttpsgitlabcomtildestildesblobmasterLICENSEGPL_30_KEY: |
+Tildes_is_a_webbased_selfhostable_online_bulletin_boardP_It_is_licensed_under_a_hrefhttpsgitlabPcomtildestildesblobmasterLICENSEGPL_3P0_155_KEY: |
   Tildes is a web-based self-hostable online bulletin board. It is licensed under <a href="https://gitlab.com/tildes/tildes/blob/master/LICENSE">GPL 3.0</a>.
 
-httpstildesnet_KEY: |
+httpstildesPnet_18_KEY: |
   https://tildes.net
 
-httpsgitlabcomtildestildes_KEY: |
+httpsgitlabPcomtildestildes_32_KEY: |
   https://gitlab.com/tildes/tildes
 
-Raddle_KEY: |
+Raddle_6_KEY: |
   Raddle
 
-Raddle_is_a_public_Postmill_instance_focused_on_privacy_and_anticensorship_KEY: |
+Raddle_is_a_public_Postmill_instance_focused_on_privacy_and_anticensorshipP_76_KEY: |
   Raddle is a public Postmill instance focused on privacy and anti-censorship.
 
-httpsraddleme_KEY: |
+httpsraddlePme_17_KEY: |
   https://raddle.me
 
-httpsgitlabcompostmill_KEY: |
+httpsgitlabPcompostmill_28_KEY: |
   https://gitlab.com/postmill/
 
-httpsbetaakashaworld_KEY: |
+httpsbetaPakashaPworld_27_KEY: |
   https://beta.akasha.world/
 
-Akasha_KEY: |
+Akasha_7_KEY: |
   Akasha
 
-A_decentralized_online_bulletin_board_using_a_hrefhttpswwwwikipediaorgwikiInterPlanetary_File_SystemIPFSa_and_a_hrefhttpswwwwikip_KEY: |
+A_decentralized_online_bulletin_board_using_a_hrefhttpswwwPwikipediaPorgwikiInterPlanetary_File_SystemIPFSa_and_a_hrefhttpswwwPwikip_189_KEY: |
   A decentralized online bulletin board using <a href="https://www.wikipedia.org/wiki/InterPlanetary_File_System">IPFS</a> and <a href="https://www.wikipedia.org/wiki/Ethereum">Ethereum</a>.
 
-httpsdevlemmyml_KEY: |
+httpsdevPlemmyPml_22_KEY: |
   https://dev.lemmy.ml/
 
-Lemmy_KEY: |
+Lemmy_6_KEY: |
   Lemmy
 
-An_a_hrefhttpsgithubcomdessalineslemmyblobmasterLICENSEAGPLalicensed_selfhostable_link_aggregator_intended_to_work_in_the_a_hrefh_KEY: |
+An_a_hrefhttpsgithubPcomdessalineslemmyblobmasterLICENSEAGPLalicensed_selfhostable_link_aggregator_intended_to_work_in_the_a_hrefh_207_KEY: |
   An <a href="https://github.com/dessalines/lemmy/blob/master/LICENSE">AGPL</a>-licensed self-hostable link aggregator intended to work in the <a href="https://www.wikipedia.org/wiki/Fediverse">Fediverse</a>.
 
-httpsnotabugio_KEY: |
+httpsnotabugPio_20_KEY: |
   https://notabug.io/
 
-notabugio_KEY: |
+notabugPio_11_KEY: |
   notabug.io
 
-A_a_hrefhttpsgithubcomnotabugionotabugblobmasterLICENSEmdfree_and_opensourcea_P2P_link_aggregator_with_a_strong_resemblance_to_oldr_KEY: |
+A_a_hrefhttpsgithubPcomnotabugionotabugblobmasterLICENSEPmdfree_and_opensourcea_P2P_link_aggregator_with_a_strong_resemblance_to_oldPr_235_KEY: |
   A <a href="https://github.com/notabugio/notabug/blob/master/LICENSE.md">free and open-source</a> P2P link aggregator with a strong resemblance to old.reddit.com (not to be confused with <a href="https://notabug.org/">NotABug.org</a>).
 
-Pastebin_Services_KEY: |
+Pastebin_Services_18_KEY: |
   Pastebin Services
 
-PrivateBin_KEY: |
+PrivateBin_10_KEY: |
   PrivateBin
 
-PrivateBin_is_a_minimalist_opensource_online_pastebin_where_the_server_has_zero_knowledge_of_pasted_data_Data_is_encrypteddecrypted_in_the_browser__KEY: |
+PrivateBin_is_a_minimalist_opensource_online_pastebin_where_the_server_has_zero_knowledge_of_pasted_dataP_Data_is_encrypteddecrypted_in_the_browser__208_KEY: |
   PrivateBin is a minimalist, open-source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted in the browser using 256-bit AES. It is the improved version of ZeroBin.
 
-httpsprivatebininfo_KEY: |
+httpsprivatebinPinfo_24_KEY: |
   https://privatebin.info/
 
-httpsgithubcomPrivateBinPrivateBin_KEY: |
+httpsgithubPcomPrivateBinPrivateBin_40_KEY: |
   https://github.com/PrivateBin/PrivateBin
 
-CryptPad_is_an_opensource_zero_knowledge_and_realtime_collaborative_editor_Data_is_encrypteddecrypted_in_the_browser_using_Salsa20_with_Poly1305_KEY: |
+CryptPad_8_KEY: |
+  CryptPad
+
+CryptPad_is_an_opensource_zero_knowledge_and_realtime_collaborative_editorP_Data_is_encrypteddecrypted_in_the_browser_using_Salsa20_with_Poly1305_168_KEY: |
   CryptPad is an open-source, zero knowledge, and real-time collaborative editor. Data is encrypted/decrypted in the browser, using Salsa20 with Poly1305 to encrypt pads.
 
-httpscryptpadfrpad_KEY: |
+httpscryptpadPfrpad_24_KEY: |
   https://cryptpad.fr/pad/
 
-strongCryptPadstrong_is_a_privatebydesign_alternative_to_popular_office_tools_and_cloud_services_All_content_is_endtoend_encrypted_It_is_fre_KEY: |
+httpsgithubPcomxwikilabscryptpad_38_KEY: |
+  https://github.com/xwiki-labs/cryptpad
+
+strongCryptPadstrong_is_a_privatebydesign_alternative_to_popular_office_tools_and_cloud_servicesP_All_content_is_endtoend_encryptedP_It_is_fre_366_KEY: |
   <strong>CryptPad</strong> is a private-by-design alternative to popular office tools and cloud services. All content is end-to-end encrypted. It is free and open-source, enabling anyone to verify its security by auditing the code. The development team is supported by donations and grants. No registration is required, and it can be used anonymously via Tor Browser.
 
-Etherpad_KEY: |
+Etherpad_8_KEY: |
   Etherpad
 
-strongEtherpadstrong_is_a_highly_customizable_opensource_online_editor_providing_collaborative_editing_in_real_time_a_hrefhttpsgithubcome_KEY: |
+strongEtherpadstrong_is_a_highly_customizable_opensource_online_editor_providing_collaborative_editing_in_real_timeP_a_hrefhttpsgithubPcome_246_KEY: |
   <strong>Etherpad</strong> is a highly customizable open-source online editor providing collaborative editing in real time. <a href=https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad>Here are a list of sites that run Etherpad</a>.
 
-httpsetherpadorg_KEY: |
+httpsetherpadPorg_21_KEY: |
   https://etherpad.org/
 
-httpsgithubcometheretherpadlitewindows_KEY: |
+httpsgithubPcometheretherpadlitewindows_46_KEY: |
   https://github.com/ether/etherpad-lite#windows
 
-httpsgithubcometheretherpadlitegnulinuxandotherunixlikesystems_KEY: |
+httpsgithubPcometheretherpadlitegnulinuxandotherunixlikesystems_75_KEY: |
   https://github.com/ether/etherpad-lite#gnulinux-and-other-unix-like-systems
 
-httpsgithubcometheretherpadliteinstallation_KEY: |
+httpsgithubPcometheretherpadliteinstallation_51_KEY: |
   https://github.com/ether/etherpad-lite#installation
 
-httpsgithubcometheretherpadlitewikiSitesthatrunEtherpad_KEY: |
+httpsgithubPcometheretherpadlitewikiSitesthatrunEtherpad_67_KEY: |
   https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad
 
-httpsgithubcometheretherpadlite_KEY: |
+httpsgithubPcometheretherpadlite_38_KEY: |
   https://github.com/ether/etherpad-lite
 
-Writeas_KEY: |
+WritePas_8_KEY: |
   Write.as
 
-strongWriteasstrong_is_a_crossplatform_privacyoriented_blogging_platform_Its_anonymous_by_default_letting_you_publish_without_signing_up_I_KEY: |
+strongWritePasstrong_is_a_crossplatform_privacyoriented_blogging_platformP_Its_anonymous_by_default_letting_you_publish_without_signing_upP_I_289_KEY: |
   <strong>Write.as</strong> is a cross-platform, privacy-oriented blogging platform. It's anonymous by default, letting you publish without signing up. If you create an account, it doesn't require any personal information. No ads, distraction-free, and built on a sustainable business model.
 
-httpswriteas_KEY: |
+httpswritePas_17_KEY: |
   https://write.as/
 
-httpsgithubcomwriteaswriteascli_KEY: |
+httpsgithubPcomwriteaswriteascli_38_KEY: |
   https://github.com/writeas/writeas-cli
 
-httpswriteasapps_KEY: |
+httpswritePasapps_21_KEY: |
   https://write.as/apps
 
-httpsplaygooglecomstoreappsdetailsidcomabunchtellwriteas_KEY: |
+httpsplayPgooglePcomstoreappsdetailsQidcomPabunchtellPwriteas_68_KEY: |
   https://play.google.com/store/apps/details?id=com.abunchtell.writeas
 
-httpsitunesapplecomappapplestoreid1000755153_KEY: |
+httpsitunesPapplePcomappapplestoreid1000755153_53_KEY: |
   https://itunes.apple.com/app/apple-store/id1000755153
 
-httpswriteaspad_KEY: |
+httpswritePaspad_20_KEY: |
   https://write.as/pad
 
-httpscodeaswriteas_KEY: |
+httpscodePaswriteas_23_KEY: |
   https://code.as/writeas
 
-httpscryptee_KEY: |
+httpscryptPee_18_KEY: |
   https://crypt.ee/
 
-Cryptee_KEY: |
+Cryptee_8_KEY: |
   Cryptee
 
-Free_privacyfriendly_service_for_storing_Documents_files_and_Photos_KEY: |
+Free_privacyfriendly_service_for_storing_Documents_files_and_Photos_70_KEY: |
   Free privacy-friendly service for storing Documents, files and Photos
 
-httpsethercalcnet_KEY: |
+httpsethercalcPnet_23_KEY: |
   https://ethercalc.net/
 
-EtherCalc_KEY: |
+EtherCalc_10_KEY: |
   EtherCalc
 
-EtherCalc_is_a_web_spreadsheet_Data_is_saved_on_the_web_and_people_can_edit_the_same_document_at_the_same_time_Changes_are_instantly_reflected_on_al_KEY: |
+EtherCalc_is_a_web_spreadsheetP_Data_is_saved_on_the_web_and_people_can_edit_the_same_document_at_the_same_timeP_Changes_are_instantly_reflected_on_al_247_KEY: |
   EtherCalc is a web spreadsheet. Data is saved on the web, and people can edit the same document at the same time. Changes are instantly reflected on all screens. Work together on inventories, survey forms, list management, brainstorming sessions.
 
-Disroot_KEY: |
+httpsdisrootPorg_21_KEY: |
+  https://disroot.org/
+
+Disroot_8_KEY: |
   Disroot
 
-Free_privacyfriendly_service_that_offers_Etherpad_EtherCalc_and_PrivateBin_KEY: |
+Free_privacyfriendly_service_that_offers_Etherpad_EtherCalc_and_PrivateBinP_78_KEY: |
   Free privacy-friendly service that offers Etherpad, EtherCalc and PrivateBin.
 
-httpsdudleinftudresdendeanonymous_KEY: |
+httpsdudlePinfPtudresdenPdeanonymous_43_KEY: |
   https://dudle.inf.tu-dresden.de/anonymous/
 
-dudle_KEY: |
+dudle_6_KEY: |
   dudle
 
-An_online_scheduling_application_free_and_opensource_Schedule_meetings_or_make_small_online_polls_No_email_collection_or_the_need_of_registration_KEY: |
+An_online_scheduling_application_free_and_opensourceP_Schedule_meetings_or_make_small_online_pollsP_No_email_collection_or_the_need_of_registrationP_151_KEY: |
   An online scheduling application, free and open-source. Schedule meetings or make small online polls. No email collection or the need of registration.
 
-httpsframadateorg_KEY: |
+httpsframadatePorg_23_KEY: |
   https://framadate.org/
 
-Framadate_KEY: |
+Framadate_10_KEY: |
   Framadate
 
-A_free_and_opensource_online_service_for_planning_an_appointment_or_making_a_decision_quickly_and_easily_No_registration_is_required_KEY: |
+A_free_and_opensource_online_service_for_planning_an_appointment_or_making_a_decision_quickly_and_easilyP_No_registration_is_requiredP_136_KEY: |
   A free and open-source online service for planning an appointment or making a decision quickly and easily. No registration is required.
 
-httpswwwlibreofficeorg_KEY: |
+httpswwwPlibreofficePorg_29_KEY: |
   https://www.libreoffice.org/
 
-LibreOffice_KEY: |
+LibreOffice_12_KEY: |
   LibreOffice
 
-Free_and_opensource_office_suite_KEY: |
+Free_and_opensource_office_suiteP_35_KEY: |
   Free and open-source office suite.
 
-httpsvscodiumcom_KEY: |
+httpsvscodiumPcom_22_KEY: |
   https://vscodium.com/
 
-VSCodium_KEY: |
+VSCodium_9_KEY: |
   VSCodium
 
-Fork_of_Microsofts_Visual_Studio_Code_editor_without_branding_or_telemetry_KEY: |
+Fork_of_Microsofts_Visual_Studio_Code_editor_without_branding_or_telemetryP_77_KEY: |
   Fork of Microsoft's Visual Studio Code editor without branding or telemetry.
 
-MAT2_KEY: |
+MAT2_4_KEY: |
   MAT2
 
-strongMAT2strong_is_free_software_which_allows_the_removal_of_metadata_of_image_audio_torrent_and_document_file_types_It_provides_both_a_comm_KEY: |
+strongMAT2strong_is_free_software_which_allows_the_removal_of_metadata_of_image_audio_torrent_and_document_file_typesP_It_provides_both_a_comm_261_KEY: |
   <strong>MAT2</strong> is free software, which allows the removal of metadata of image, audio, torrent, and document file types. It provides both a command line tool and a graphical user interface via an extension for Nautilus, the default file manager of GNOME.
 
-https0xacaborgjvoisinmat2_KEY: |
+https0xacabPorgjvoisinmat2_31_KEY: |
   https://0xacab.org/jvoisin/mat2
 
-httpspypiorgprojectmat2_KEY: |
+httpspypiPorgprojectmat2_30_KEY: |
   https://pypi.org/project/mat2/
 
-PC_Operating_Systems_KEY: |
+PC_Operating_Systems_21_KEY: |
   PC Operating Systems
 
-If_you_are_currently_using_a_operating_system_like_Windows_10_you_should_pick_an_alternative_here_KEY: |
+If_you_are_currently_using_a_operating_system_like_Windows_10_you_should_pick_an_alternative_hereP_100_KEY: |
   If you are currently using a operating system like Windows 10, you should pick an alternative here.
 
-Qubes_OS_KEY: |
+Qubes_OS_8_KEY: |
   Qubes OS
 
-Xen_KEY: |
+Xen_3_KEY: |
   Xen
 
-Qubes_is_an_opensource_operating_system_designed_to_provide_strong_security_for_desktop_computing_Qubes_is_based_on_Xen_the_X_Window_System_and_Lin_KEY: |
+Qubes_is_an_opensource_operating_system_designed_to_provide_strong_security_for_desktop_computingP_Qubes_is_based_on_Xen_the_X_Window_System_and_Lin_229_KEY: |
   Qubes is an open-source operating system designed to provide strong security for desktop computing. Qubes is based on Xen, the X Window System, and Linux, and can run most Linux applications and utilize most of the Linux drivers.
 
-This_software_may_depend_on_or_recommend_nonfree_software_KEY: |
+This_software_may_depend_on_or_recommend_nonfree_softwareP_59_KEY: |
   This software may depend on or recommend non-free software.
 
-contrib_KEY: |
+contrib_7_KEY: |
   contrib
 
-httpswwwqubesosorg_KEY: |
+httpswwwPqubesosPorg_25_KEY: |
   https://www.qubes-os.org/
 
-httpsgithubcomQubesOS_KEY: |
+httpsgithubPcomQubesOS_26_KEY: |
   https://github.com/QubesOS
 
-Fedora_Workstation_KEY: |
+Fedora_Workstation_18_KEY: |
   Fedora Workstation
 
-GNULinux_KEY: |
+GNULinux_9_KEY: |
   GNU/Linux
 
-Fedora_is_a_Linux_distribution_developed_by_the_Fedora_Project_and_sponsored_by_Red_Hat_Fedora_Workstation_is_a_secure_reliable_and_userfriendly_ed_KEY: |
+Fedora_is_a_Linux_distribution_developed_by_the_Fedora_Project_and_sponsored_by_Red_HatP_Fedora_Workstation_is_a_secure_reliable_and_userfriendly_ed_240_KEY: |
   Fedora is a Linux distribution developed by the Fedora Project and sponsored by Red Hat. Fedora Workstation is a secure, reliable, and user-friendly edition developed for desktops and laptops, using GNOME as the default desktop environment.
 
-httpsgetfedoraorg_KEY: |
+httpsgetfedoraPorg_22_KEY: |
   https://getfedora.org/
 
-httpssrcfedoraprojectorg_KEY: |
+httpssrcPfedoraprojectPorg_30_KEY: |
   https://src.fedoraproject.org/
 
-Debian_KEY: |
+Debian_6_KEY: |
   Debian
 
-Debian_is_a_Unixlike_computer_operating_system_and_a_Linux_distribution_that_is_composed_entirely_of_free_and_opensource_software_most_of_which_is_u_KEY: |
+Debian_is_a_Unixlike_computer_operating_system_and_a_Linux_distribution_that_is_composed_entirely_of_free_and_opensource_software_most_of_which_is_u_255_KEY: |
   Debian is a Unix-like computer operating system and a Linux distribution that is composed entirely of free and open-source software, most of which is under the GNU General Public License, and packaged by a group of individuals known as the Debian project.
 
-httpswwwdebianorg_KEY: |
+httpswwwPdebianPorg_23_KEY: |
   https://www.debian.org/
 
-httpssalsadebianorgqadebsources_KEY: |
+httpssalsaPdebianPorgqadebsources_38_KEY: |
   https://salsa.debian.org/qa/debsources
 
-httpswwwopenbsdorg_KEY: |
+httpswwwPopenbsdPorg_25_KEY: |
   https://www.openbsd.org/
 
-OpenBSD_KEY: |
+OpenBSD_8_KEY: |
   OpenBSD
 
-BSD_KEY: |
+BSD_4_KEY: |
   BSD
 
-A_project_that_produces_a_free_multiplatform_44BSDbased_UNIXlike_operating_system_Emphasizes_portability_standardization_correctness_proactive_KEY: |
+A_project_that_produces_a_free_multiplatform_4P4BSDbased_UNIXlike_operating_systemP_Emphasizes_portability_standardization_correctness_proactive_190_KEY: |
   A project that produces a free, multi-platform 4.4BSD-based UNIX-like operating system. Emphasizes portability, standardization, correctness, proactive security and integrated cryptography.
 
-httpswwwarchlinuxorg_KEY: |
+httpswwwParchlinuxPorg_27_KEY: |
   https://www.archlinux.org/
 
-Arch_Linux_KEY: |
+Arch_Linux_11_KEY: |
   Arch Linux
 
-A_simple_lightweight_Linux_distribution_It_is_composed_predominantly_of_free_and_opensource_software_and_supports_community_involvement_KEY: |
+GNULinux_10_KEY: |
+  GNU/Linux
+
+contrib_8_KEY: |
+  contrib
+
+A_simple_lightweight_Linux_distributionP_It_is_composed_predominantly_of_free_and_opensource_software_and_supports_community_involvementP_140_KEY: |
   A simple, lightweight Linux distribution. It is composed predominantly of free and open-source software, and supports community involvement.
 
-a_hrefhttpswwwparabolanuParabolaa_is_a____completely_open_source_version_of_Arch_Linux_KEY: |
+a_hrefhttpswwwPparabolaPnuParabolaa_is_a____completely_open_source_version_of_Arch_LinuxP_102_KEY: |
   <a href="https://www.parabola.nu/">Parabola</a> is a
     completely open source version of Arch Linux.
 
-httpstrisquelinfo_KEY: |
+httpstrisquelPinfo_23_KEY: |
   https://trisquel.info/
 
-Trisquel_KEY: |
+Trisquel_9_KEY: |
   Trisquel
 
-Derived_from_Ubuntu_this_project_aims_for_a_fully_free_software_system_without_proprietary_software_or_firmware_and_uses_Linuxlibre_a_version_of_the_KEY: |
+Derived_from_Ubuntu_this_project_aims_for_a_fully_free_software_system_without_proprietary_software_or_firmware_and_uses_Linuxlibre_a_version_of_the_212_KEY: |
   Derived from Ubuntu, this project aims for a fully free software system without proprietary software or firmware and uses Linux-libre, a version of the Linux kernel with the non-free code (binary blobs) removed.
 
-httpswwwwhonixorg_KEY: |
+httpswwwPwhonixPorg_24_KEY: |
   https://www.whonix.org/
 
-Whonix_KEY: |
+Whonix_7_KEY: |
   Whonix
 
-A_Debianbased_securityfocused_Linux_distribution_It_aims_to_provide_privacy_security_and_anonymity_on_the_internet_The_operating_system_consists_o_KEY: |
+A_Debianbased_securityfocused_Linux_distributionP_It_aims_to_provide_privacy_security_and_anonymity_on_the_internetP_The_operating_system_consists_o_285_KEY: |
   A Debian-based security-focused Linux distribution. It aims to provide privacy, security and anonymity on the internet. The operating system consists of two virtual machines, a "Workstation" and a Tor "Gateway". All communication are forced through the Tor network to accomplish this.
 
-Dont_use_Windows_10__Its_a_privacy_nightmare_KEY: |
+Dont_use_Windows_10__Its_a_privacy_nightmare_48_KEY: |
   Don't use Windows 10 - It's a privacy nightmare
 
-Remember_to_check_CPU_vulnerability_mitigations_KEY: |
+Remember_to_check_CPU_vulnerability_mitigations_48_KEY: |
   Remember to check CPU vulnerability mitigations
 
-a_href_httpssupportmicrosoftcomenushelp4073757protectwindowsdevicesfromspeculativeexecutionsidechannelattackThis_also_affects_Wi_KEY: |
+a_href_httpssupportPmicrosoftPcomenushelp4073757protectwindowsdevicesfromspeculativeexecutionsidechannelattackThis_also_affects_Wi_421_KEY: |
   <a href=" https://support.microsoft.com/en-us/help/4073757/protect-windows-devices-from-speculative-execution-side-channel-attack">This also affects Windows 10</a>, but it doesn't expose this information or mitigation instructions as easily. MacOS users check <a href="https://support.apple.com/en-us/HT210108">How to enable full mitigation for Microarchitectural Data Sampling (MDS) vulnerabilities on Apple Support</a>.
 
-When_running_a_recent_enough_Linux_kernel_you_can_check_the_CPU_vulnerabilities_it_detects_by_codetail_n_1_sysdevicessystemcpuvulnerabilities_KEY: |
+When_running_a_recent_enough_Linux_kernel_you_can_check_the_CPU_vulnerabilities_it_detects_by_codetail_n_1_sysdevicessystemcpuvulnerabilities_257_KEY: |
   When running a recent enough Linux kernel, you can check the CPU vulnerabilities it detects by <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code>. By using <code>tail -n +1</code> instead of <code>cat</code>, the file names are also visible.
 
-In_case_you_have_an_Intel_CPU_you_may_notice_SMT_vulnerable_display_after_running_the_codetailcode_command_To_mitigate_this_disable_a_href_KEY: |
+In_case_you_have_an_Intel_CPU_you_may_notice_SMT_vulnerable_display_after_running_the_codetailcode_commandP_To_mitigate_this_disable_a_href_237_KEY: |
   In case you have an Intel CPU, you may notice "SMT vulnerable" display after running the <code>tail</code> command. To mitigate this, disable <a href="https://en.wikipedia.org/wiki/Hyper-threading">hyper-threading</a> from the UEFI/BIOS.
 
-You_can_also_take_the_following_mitigation_steps_below_if_your_systemdistribution_uses_GRUB_and_supports_codeetcdefaultgrubdcode_KEY: |
+You_can_also_take_the_following_mitigation_steps_below_if_your_systemdistribution_uses_GRUB_and_supports_codeetcdefaultgrubPdcode_140_KEY: |
   You can also take the following mitigation steps below if your system/distribution uses GRUB and supports <code>/etc/default/grub.d/</code>:
 
-to_create_a_directory_for_additional_grub_configuration_KEY: |
+to_create_a_directory_for_additional_grub_configuration_56_KEY: |
   to create a directory for additional grub configuration
 
-to_create_a_new_grub_config_file_source_with_the_echoed_content_KEY: |
+to_create_a_new_grub_config_file_source_with_the_echoed_content_64_KEY: |
   to create a new grub config file source with the echoed content
 
-to_generate_a_new_grub_config_file_including_these_new_kernel_boot_flags_KEY: |
+to_generate_a_new_grub_config_file_including_these_new_kernel_boot_flags_73_KEY: |
   to generate a new grub config file including these new kernel boot flags
 
-to_reboot_KEY: |
+to_reboot_10_KEY: |
   to reboot
 
-after_the_reboot_check_codetail_n_1_sysdevicessystemcpuvulnerabilitiescode_again_to_see_that_everything_referring_to_SMT_now_says_SMT_d_KEY: |
+after_the_reboot_check_codetail_n_1_sysdevicessystemcpuvulnerabilitiescode_again_to_see_that_everything_referring_to_SMT_now_says_SMT_d_161_KEY: |
   after the reboot, check <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code> again to see that everything referring to SMT now says "SMT disabled."
 
-httpscpufail_KEY: |
+Further_reading_16_KEY: |
+  Further reading
+
+httpscpuPfail_18_KEY: |
   https://cpu.fail/
 
-CPUfail_KEY: |
+CPUPfail_9_KEY: |
   CPU.fail
 
-httpswwwkernelorgdochtmllatestadminguidehwvuln_KEY: |
+httpswwwPkernelPorgdochtmllatestadminguidehwvuln_60_KEY: |
   https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/
 
-Hardware_vulnerabilities_index_on_The_Linux_kernel_users_and_administrators_guide_KEY: |
+Hardware_vulnerabilities_index_on_The_Linux_kernel_users_and_administrators_guide_84_KEY: |
   Hardware vulnerabilities index on The Linux kernel user's and administrator's guide
 
-httpswwwcybercitibizfaqinstallupdateintelmicrocodefirmwarelinux_KEY: |
+httpswwwPcybercitiPbizfaqinstallupdateintelmicrocodefirmwarelinux_77_KEY: |
   https://www.cyberciti.biz/faq/install-update-intel-microcode-firmware-linux/
 
-How_to_installupdate_CPU_microcode_firmware_on_Linux_KEY: |
+How_to_installupdate_CPU_microcode_firmware_on_Linux_54_KEY: |
   How to install/update CPU microcode firmware on Linux
 
-Regardless_of_your_CPU_manufacturer_you_should_always_install_the_latest_microcode_packages_available_to_be_protected_from_CPU_vulnerabilities_especi_KEY: |
+Regardless_of_your_CPU_manufacturer_you_should_always_install_the_latest_microcode_packages_available_to_be_protected_from_CPU_vulnerabilities_especi_230_KEY: |
   Regardless of your CPU manufacturer, you should always install the latest microcode packages available to be protected from CPU vulnerabilities, especially if the command above reports <strong>no microcode</strong> in its output.
 
-httpswwwkernelorgdochtmllatestadminguidehwvulnmdshtml_KEY: |
+httpswwwPkernelPorgdochtmllatestadminguidehwvulnmdsPhtml_68_KEY: |
   https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html
 
-MDS__Microarchitectural_Data_Sampling_on_The_Linux_kernel_users_and_administrators_guide_KEY: |
+MDS__Microarchitectural_Data_Sampling_on_The_Linux_kernel_users_and_administrators_guide_92_KEY: |
   MDS - Microarchitectural Data Sampling on The Linux kernel user's and administrator's guide
 
-httpsmdsattackscom_KEY: |
+httpsmdsattacksPcom_24_KEY: |
   https://mdsattacks.com/
 
-RIDL_and_Fallout_MDS_attacks_on_mdsattackscom_KEY: |
+RIDL_and_Fallout_MDS_attacks_on_mdsattacksPcom_48_KEY: |
   RIDL and Fallout: MDS attacks on mdsattacks.com
 
-httpsenwikipediaorgwikiSimultaneous_multithreading_KEY: |
+httpsenPwikipediaPorgwikiSimultaneous_multithreading_58_KEY: |
   https://en.wikipedia.org/wiki/Simultaneous_multithreading
 
-Simultaneous_multithreading_on_Wikipedia_KEY: |
+Simultaneous_multithreading_on_Wikipedia_41_KEY: |
   Simultaneous multithreading on Wikipedia
 
-Live_CD_Operating_Systems_KEY: |
+Live_CD_Operating_Systems_26_KEY: |
   Live CD Operating Systems
 
-Tails_KEY: |
+Tails_5_KEY: |
   Tails
 
-Tails_is_a_live_operating_system_that_starts_on_almost_any_computer_from_a_DVD_USB_stick_or_SD_card_It_aims_at_preserving_privacy_and_anonymity_and_KEY: |
+Tails_is_a_live_operating_system_that_starts_on_almost_any_computer_from_a_DVD_USB_stick_or_SD_cardP_It_aims_at_preserving_privacy_and_anonymity_and_362_KEY: |
   Tails is a live operating system that starts on almost any computer from a DVD, USB stick, or SD card. It aims at preserving privacy and anonymity, and circumventing censorship by forcing Internet connections through the Tor network; leaving no trace on the computer; and using state-of-the-art cryptographic tools to encrypt files, emails, and instant messages.
 
-httpstailsboumorg_KEY: |
+httpstailsPboumPorg_23_KEY: |
   https://tails.boum.org/
 
-httpsgittailsimmerdachtails_KEY: |
+httpsgittailsPimmerdaPchtails_35_KEY: |
   https://git-tails.immerda.ch/tails/
 
-KNOPPIX_KEY: |
+KNOPPIX_7_KEY: |
   KNOPPIX
 
-Knoppix_is_an_operating_system_based_on_Debian_designed_to_be_run_directly_from_a_CD__DVD_Live_CD_or_a_USB_flash_drive_Live_USB_one_of_the_first__KEY: |
+Knoppix_is_an_operating_system_based_on_Debian_designed_to_be_run_directly_from_a_CD__DVD_Live_CD_or_a_USB_flash_drive_Live_USB_one_of_the_first__336_KEY: |
   Knoppix is an operating system based on Debian designed to be run directly from a CD / DVD (Live CD) or a USB flash drive (Live USB), one of the first of its kind for any operating system. When starting a program, it is loaded from the removable medium and decompressed into a RAM drive. The decompression is transparent and on-the-fly.
 
-httpswwwknoppernetknoppixindexenhtml_KEY: |
+httpswwwPknopperPnetknoppixindexenPhtml_45_KEY: |
   https://www.knopper.net/knoppix/index-en.html
 
-httpswwwknoppernetknoppixinfoindexenhtmllicense_KEY: |
+httpswwwPknopperPnetknoppixinfoindexenPhtmllicense_58_KEY: |
   https://www.knopper.net/knoppix-info/index-en.html#license
 
-Puppy_Linux_KEY: |
+Puppy_Linux_11_KEY: |
   Puppy Linux
 
-Puppy_Linux_operating_system_is_a_lightweight_Linux_distribution_that_focuses_on_ease_of_use_and_minimal_memory_footprint_The_entire_system_can_be_run_KEY: |
+Puppy_Linux_operating_system_is_a_lightweight_Linux_distribution_that_focuses_on_ease_of_use_and_minimal_memory_footprintP_The_entire_system_can_be_run_295_KEY: |
   Puppy Linux operating system is a lightweight Linux distribution that focuses on ease of use and minimal memory footprint. The entire system can be run from RAM with current versions generally taking up about 210 MB, allowing the boot medium to be removed after the operating system has started.
 
-httppuppylinuxorg_KEY: |
+httppuppylinuxPorg_22_KEY: |
   http://puppylinux.org/
 
-httpdistroibiblioorgpuppylinux_KEY: |
+httpdistroPibiblioPorgpuppylinux_37_KEY: |
   http://distro.ibiblio.org/puppylinux/
 
-httpsdistroibiblioorgtinycorelinux_KEY: |
+httpsdistroPibiblioPorgtinycorelinux_42_KEY: |
   https://distro.ibiblio.org/tinycorelinux/
 
-Tiny_Core_Linux_KEY: |
+Tiny_Core_Linux_16_KEY: |
   Tiny Core Linux
 
-A_minimal_Linux_operating_system_focusing_on_providing_a_base_system_using_BusyBox_and_FLTK_The_distribution_is_notable_for_its_size_15_MB_and_minim_KEY: |
+This_software_may_depend_on_or_recommend_nonfree_softwareP_60_KEY: |
+  This software may depend on or recommend non-free software.
+
+A_minimal_Linux_operating_system_focusing_on_providing_a_base_system_using_BusyBox_and_FLTKP_The_distribution_is_notable_for_its_size_15_MB_and_minim_211_KEY: |
   A minimal Linux operating system focusing on providing a base system using BusyBox and FLTK. The distribution is notable for its size (15 MB) and minimalism, with additional functionality provided by extensions.
 
-Mobile_Operating_Systems_KEY: |
+Mobile_Operating_Systems_25_KEY: |
   Mobile Operating Systems
 
-Even_though_the_source_code_of_the_following_OS_is_provided_installing_Google_Apps_may_compromise_your_setup_KEY: |
+Even_though_the_source_code_of_the_following_OS_is_provided_installing_Google_Apps_may_compromise_your_setupP_111_KEY: |
   Even though the source code of the following OS is provided, installing Google Apps may compromise your setup.
 
-GrapheneOS_KEY: |
+GrapheneOS_10_KEY: |
   GrapheneOS
 
-AOSP_KEY: |
+AOSP_4_KEY: |
   AOSP
 
-GrapheneOS_formerly_known_as_CopperheadOS_is_a_free_and_opensource_security_and_privacyfocused_mobile_operating_system_built_on_top_of_the_Android_KEY: |
+GrapheneOS_formerly_known_as_CopperheadOS_is_a_free_and_opensource_security_and_privacyfocused_mobile_operating_system_built_on_top_of_the_Android_249_KEY: |
   GrapheneOS (formerly known as CopperheadOS) is a free and open-source security- and privacy-focused mobile operating system built on top of the Android Open Source Project. It currently specifically targets devices offering strong hardware security.
 
-httpsgrapheneosorg_KEY: |
+httpsgrapheneosPorg_23_KEY: |
   https://grapheneos.org/
 
-httpsgithubcomGrapheneOS_KEY: |
+httpsgithubPcomGrapheneOS_30_KEY: |
   https://github.com/GrapheneOS/
 
-LineageOS_KEY: |
+LineageOS_9_KEY: |
   LineageOS
 
-LineageOS_is_a_free_and_opensource_operating_system_for_smartphones_and_tablets_based_on_the_official_releases_of_the_Android_Open_Source_Project_It_KEY: |
+LineageOS_is_a_free_and_opensource_operating_system_for_smartphones_and_tablets_based_on_the_official_releases_of_the_Android_Open_Source_ProjectP_It_199_KEY: |
   LineageOS is a free and open-source operating system for smartphones and tablets, based on the official releases of the Android Open Source Project. It is the continuation of the CyanogenMod project.
 
-httpswwwlineageosorg_KEY: |
+httpswwwPlineageosPorg_26_KEY: |
   https://www.lineageos.org/
 
-httpsgithubcomLineageOS_KEY: |
+httpsgithubPcomLineageOS_28_KEY: |
   https://github.com/LineageOS
 
-Ubuntu_Touch_KEY: |
+Ubuntu_Touch_12_KEY: |
   Ubuntu Touch
 
-Ubuntu_Touch_is_a_free_and_opensource_operating_system_for_smartphones_and_tablets_Its_an_alternative_to_the_current_popular_mobile_operating_system_KEY: |
+Ubuntu_Touch_is_a_free_and_opensource_operating_system_for_smartphones_and_tabletsP_Its_an_alternative_to_the_current_popular_mobile_operating_system_246_KEY: |
   Ubuntu Touch is a free and open-source operating system for smartphones and tablets. It's an alternative to the current popular mobile operating systems on the market. Only a few devices are <a href=https://devices.ubuntu-touch.io/>supported.</a>
 
-httpsubuntutouchio_KEY: |
+httpsubuntutouchPio_24_KEY: |
   https://ubuntu-touch.io/
 
-httpsgithubcomubports_KEY: |
+httpsgithubPcomubports_26_KEY: |
   https://github.com/ubports
 
-httpswwwreplicantus_KEY: |
+httpswwwPreplicantPus_26_KEY: |
   https://www.replicant.us/
 
-Replicant_KEY: |
+Replicant_10_KEY: |
   Replicant
 
-An_opensource_operating_system_based_on_Android_aiming_to_replace_all_proprietary_components_with_free_software_KEY: |
+AOSP_5_KEY: |
+  AOSP
+
+An_opensource_operating_system_based_on_Android_aiming_to_replace_all_proprietary_components_with_free_softwareP_115_KEY: |
   An open-source operating system based on Android, aiming to replace all proprietary components with free software.
 
-httpswwwomniromorg_KEY: |
+httpswwwPomniromPorg_25_KEY: |
   https://www.omnirom.org/
 
-OmniROM_KEY: |
+OmniROM_8_KEY: |
   OmniROM
 
-A_freesoftware_operating_system_for_smartphones_and_tablet_computers_based_on_the_Android_mobile_platform_KEY: |
+A_freesoftware_operating_system_for_smartphones_and_tablet_computers_based_on_the_Android_mobile_platformP_109_KEY: |
   A free-software operating system for smartphones and tablet computers, based on the Android mobile platform.
 
-httpsmicrogorg_KEY: |
+httpsmicrogPorg_20_KEY: |
   https://microg.org/
 
-MicroG_KEY: |
+MicroG_7_KEY: |
   MicroG
 
-Addon_Package_KEY: |
+Addon_Package_15_KEY: |
   Add-on Package
 
-A_project_that_aims_to_reimplement_the_proprietary_Google_Play_Services_in_the_Android_operating_system_with_a_FLOSS_replacement_The_microG_project_al_KEY: |
+A_project_that_aims_to_reimplement_the_proprietary_Google_Play_Services_in_the_Android_operating_system_with_a_FLOSS_replacementP_The_microG_project_al_286_KEY: |
   A project that aims to reimplement the proprietary Google Play Services in the Android operating system with a FLOSS replacement. The microG project also maintains a fork of LineageOS with microG and F-Droid preinstalled at <a href="https://lineage.microg.org/">Lineage for microG</a>.
 
-Improve_your_privacy_with_these_addons_for_Android_KEY: |
+Improve_your_privacy_with_these_addons_for_AndroidP_53_KEY: |
   Improve your privacy with these add-ons for Android.
 
-NetGuard_KEY: |
+NetGuard_9_KEY: |
   NetGuard
 
-Control_your_traffic_with_a_hrefhttpswwwnetguardmeNetGuarda_KEY: |
+Control_your_traffic_with_a_hrefhttpswwwPnetguardPmeNetGuarda_74_KEY: |
   Control your traffic with <a href="https://www.netguard.me/">NetGuard</a>
 
-strongNetGuardstrong_provides_simple_and_advanced_ways_to_block_certain_apps_access_to_the_internet_without_the_help_of_root_privileges_Applicat_KEY: |
+strongNetGuardstrong_provides_simple_and_advanced_ways_to_block_certain_apps_access_to_the_internet_without_the_help_of_root_privilegesP_Applicat_320_KEY: |
   <strong>NetGuard</strong> provides simple and advanced ways to block certain apps' access to the internet without the help of root privileges. Applications and addresses can individually be allowed or denied access to your Wi-Fi and/or mobile connection, allowing you to control which apps are able to call home or not.
 
-Orbot_KEY: |
+Orbot_6_KEY: |
   Orbot
 
-Tor_for_Android_with_a_hrefhttpsguardianprojectinfoappsorbotOrbota_KEY: |
+Tor_for_Android_with_a_hrefhttpsguardianprojectPinfoappsorbotOrbota_82_KEY: |
   Tor for Android with <a href="https://guardianproject.info/apps/orbot/">Orbot</a>
 
-strongOrbotstrong_is_a_free_proxy_app_that_empowers_other_apps_to_use_the_internet_more_securely_Orbot_uses_Tor_to_encrypt_your_Internet_traffic__KEY: |
+strongOrbotstrong_is_a_free_proxy_app_that_empowers_other_apps_to_use_the_internet_more_securelyP_Orbot_uses_Tor_to_encrypt_your_Internet_traffic__228_KEY: |
   <strong>Orbot</strong> is a free proxy app that empowers other apps to use the internet more securely. Orbot uses Tor to encrypt your Internet traffic and then hides it by bouncing through a series of computers around the world.
 
-strongRoot_Modestrong_Orbot_can_be_configured_to_transparently_proxy_all_of_your_Internet_traffic_through_Tor_You_can_also_choose_which_specific_KEY: |
+strongRoot_Modestrong_Orbot_can_be_configured_to_transparently_proxy_all_of_your_Internet_traffic_through_TorP_You_can_also_choose_which_specific_185_KEY: |
   <strong>Root Mode:</strong> Orbot can be configured to transparently proxy all of your Internet traffic through Tor. You can also choose which specific apps you want to use through Tor.
 
-See_also_KEY: |
+See_also_9_KEY: |
   See also
 
-Our_DNS_pagea_which_also_has_information_on_encrypting_DNS_on_Android_KEY: |
+Our_DNS_pagea_which_also_has_information_on_encrypting_DNS_on_AndroidP_73_KEY: |
   Our DNS page</a> which also has information on encrypting DNS on Android.
 
-Open_Source_Router_Firmware_KEY: |
+Open_Source_Router_Firmware_28_KEY: |
   Open Source Router Firmware
 
-OpenWrt_KEY: |
+OpenWrt_7_KEY: |
   OpenWrt
 
-Linux_KEY: |
+Linux_5_KEY: |
   Linux
 
-OpenWrt_is_an_operating_system_in_particular_an_embedded_operating_system_based_on_the_Linux_kernel_primarily_used_on_embedded_devices_to_route_net_KEY: |
+OpenWrt_is_an_operating_system_in_particular_an_embedded_operating_system_based_on_the_Linux_kernel_primarily_used_on_embedded_devices_to_route_net_377_KEY: |
   OpenWrt is an operating system (in particular, an embedded operating system) based on the Linux kernel, primarily used on embedded devices to route network traffic. The main components are the Linux kernel, util-linux, uClibc and BusyBox. All components have been optimized for size, to be small enough for fitting into the limited storage and memory available in home routers.
 
-httpsopenwrtorg_KEY: |
+httpsopenwrtPorg_20_KEY: |
   https://openwrt.org/
 
-httpsgitopenwrtorg_KEY: |
+httpsgitPopenwrtPorg_24_KEY: |
   https://git.openwrt.org/
 
-pfSense_KEY: |
+pfSense_7_KEY: |
   pfSense
 
-pfSense_is_an_open_source_firewallrouter_computer_software_distribution_based_on_FreeBSD_It_is_installed_on_a_computer_to_make_a_dedicated_firewallr_KEY: |
+BSD_3_KEY: |
+  BSD
+
+pfSense_is_an_open_source_firewallrouter_computer_software_distribution_based_on_FreeBSDP_It_is_installed_on_a_computer_to_make_a_dedicated_firewallr_410_KEY: |
   pfSense is an open source firewall/router computer software distribution based on FreeBSD. It is installed on a computer to make a dedicated firewall/router for a network and is noted for its reliability and offering features often only found in expensive commercial firewalls. pfSense is commonly deployed as a perimeter firewall, router, wireless access point, DHCP server, DNS server, and as a VPN endpoint.
 
-httpswwwpfsenseorg_KEY: |
+httpswwwPpfsensePorg_24_KEY: |
   https://www.pfsense.org/
 
-httpsgithubcompfsense_KEY: |
+httpsgithubPcompfsense_27_KEY: |
   https://github.com/pfsense/
 
-LibreCMC_KEY: |
+LibreCMC_8_KEY: |
   LibreCMC
 
-LibreCMC_is_a_GNULinuxlibre_distribution_for_computers_with_minimal_resources_such_as_the_Ben_Nanonote_ath9kbased_WiFi_routers_and_other_hardwar_KEY: |
+LibreCMC_is_a_GNULinuxlibre_distribution_for_computers_with_minimal_resources_such_as_the_Ben_Nanonote_ath9kbased_WiFi_routers_and_other_hardwar_410_KEY: |
   LibreCMC is a GNU/Linux-libre distribution for computers with minimal resources, such as the Ben Nanonote, ath9k-based Wi-Fi routers, and other hardware with emphasis on free software. The project's current goal is to aim for compliance with the GNU Free System Distribution Guidelines (GNU FSDG) and ensure that the project continues to meet these requirements set forth by the Free Software Foundation (FSF).
 
-httpslibrecmcorg_KEY: |
+httpslibrecmcPorg_20_KEY: |
   https://librecmc.org
 
-httpsgogslibrecmcorglibreCMClibreCMC_KEY: |
+httpsgogsPlibrecmcPorglibreCMClibreCMC_43_KEY: |
   https://gogs.librecmc.org/libreCMC/libreCMC
 
-httpsddwrtcom_KEY: |
+httpsddwrtPcom_20_KEY: |
   https://dd-wrt.com/
 
-DDWRT_KEY: |
+DDWRT_7_KEY: |
   DD-WRT
 
-A_Linuxbased_opensource_firmware_compatible_with_several_models_of_routers_and_access_points_KEY: |
+Linux_6_KEY: |
+  Linux
+
+A_Linuxbased_opensource_firmware_compatible_with_several_models_of_routers_and_access_pointsP_95_KEY: |
   A Linux-based open-source firmware compatible with several models of routers and access points.
 
-Microsoft_introduced_a_lot_of_new_features_in_Windows_10_such_as_Cortana_However_most_of_them_are_violating_your_privacy_KEY: |
+Microsoft_introduced_a_lot_of_new_features_in_Windows_10_such_as_CortanaP_However_most_of_them_are_violating_your_privacyP_124_KEY: |
   Microsoft introduced a lot of new features in Windows 10 such as Cortana. However, most of them are violating your privacy.
 
-Windows_10_Privacy_KEY: |
+Windows_10_Privacy_19_KEY: |
   Windows 10 Privacy
 
-Data_syncing_is_by_default_enabled_KEY: |
+Data_syncing_is_by_default_enabledP_36_KEY: |
   Data syncing is by default enabled.
 
-Browsing_history_and_open_websites_KEY: |
+Browsing_history_and_open_websitesP_36_KEY: |
   Browsing history and open websites.
 
-Apps_settings_KEY: |
+Apps_settingsP_15_KEY: |
   Apps settings.
 
-WiFi_hotspot_names_and_passwords_KEY: |
+WiFi_hotspot_names_and_passwordsP_34_KEY: |
   WiFi hotspot names and passwords.
 
-Your_device_is_by_default_tagged_with_a_unique_advertising_ID_KEY: |
+Your_device_is_by_default_tagged_with_a_unique_advertising_IDP_63_KEY: |
   Your device is by default tagged with a unique advertising ID.
 
-Used_to_serve_you_with_personalized_advertisements_by_thirdparty_advertisers_and_ad_networks_KEY: |
+Used_to_serve_you_with_personalized_advertisements_by_thirdparty_advertisers_and_ad_networksP_95_KEY: |
   Used to serve you with personalized advertisements by third-party advertisers and ad networks.
 
-Cortana_can_collect_any_of_your_data_KEY: |
+Cortana_can_collect_any_of_your_dataP_38_KEY: |
   Cortana can collect any of your data.
 
-Your_keystrokes_searches_and_mic_input_KEY: |
+Your_keystrokes_searches_and_mic_inputP_41_KEY: |
   Your keystrokes, searches and mic input.
 
-Calendar_data_KEY: |
+Calendar_dataP_15_KEY: |
   Calendar data.
 
-Music_you_listen_to_KEY: |
+Music_you_listen_toP_21_KEY: |
   Music you listen to.
 
-Credit_Card_information_KEY: |
+Credit_Card_informationP_25_KEY: |
   Credit Card information.
 
-Purchases_KEY: |
+PurchasesP_11_KEY: |
   Purchases.
 
-Microsoft_can_collect_any_personal_data_KEY: |
+Microsoft_can_collect_any_personal_dataP_41_KEY: |
   Microsoft can collect any personal data.
 
-Your_identity_KEY: |
+Your_identityP_15_KEY: |
   Your identity.
 
-Passwords_KEY: |
+PasswordsP_11_KEY: |
   Passwords.
 
-Demographics_KEY: |
+DemographicsP_14_KEY: |
   Demographics.
 
-Interests_and_habits_KEY: |
+Interests_and_habitsP_22_KEY: |
   Interests and habits.
 
-Usage_data_KEY: |
+Usage_dataP_12_KEY: |
   Usage data.
 
-Contacts_and_relationships_KEY: |
+Contacts_and_relationshipsP_28_KEY: |
   Contacts and relationships.
 
-Location_data_KEY: |
+Location_dataP_15_KEY: |
   Location data.
 
-Content_like_emails_instant_messages_caller_list_audio_and_video_recordings_KEY: |
+Content_like_emails_instant_messages_caller_list_audio_and_video_recordingsP_80_KEY: |
   Content like emails, instant messages, caller list, audio and video recordings.
 
-Your_data_can_be_shared_KEY: |
+Your_data_can_be_sharedP_25_KEY: |
   Your data can be shared.
 
-When_downloading_Windows_10_you_are_authorizing_Microsoft_to_share_any_of_abovementioned_data_with_any_thirdparty_with_or_without_your_consent_KEY: |
+When_downloading_Windows_10_you_are_authorizing_Microsoft_to_share_any_of_abovementioned_data_with_any_thirdparty_with_or_without_your_consentP_148_KEY: |
   When downloading Windows 10, you are authorizing Microsoft to share any of above-mentioned data with any third-party, with or without your consent.
 
-httpswwwwinprivacydeenglishhome_KEY: |
+httpswwwPwinprivacyPdeenglishhome_40_KEY: |
   https://www.winprivacy.de/english-home/
 
-Download_W10Privacy_KEY: |
+Download_W10Privacy_21_KEY: |
   Download: W10Privacy
 
-This_tool_uses_some_known_methods_that_attempt_to_disable_major_tracking_features_in_Windows_10_KEY: |
+This_tool_uses_some_known_methods_that_attempt_to_disable_major_tracking_features_in_Windows_10P_97_KEY: |
   This tool uses some known methods that attempt to disable major tracking features in Windows 10.
 
-httpsprivacymicrosoftcomenusprivacystatement_KEY: |
+httpsprivacyPmicrosoftPcomenusprivacystatement_53_KEY: |
   https://privacy.microsoft.com/en-us/privacystatement
 
-Microsoft_Privacy_Statement_KEY: |
+Microsoft_Privacy_Statement_28_KEY: |
   Microsoft Privacy Statement
 
-Microsoft_collects_uses_and_discloses_personal_information_as_described_here_This_allows_OneDrive_data_Cortana_searches_and_MS_browser_history_to_b_KEY: |
+Microsoft_collects_uses_and_discloses_personal_information_as_described_hereP_This_allows_OneDrive_data_Cortana_searches_and_MS_browser_history_to_b_176_KEY: |
   Microsoft collects, uses and discloses personal information as described here. This allows OneDrive data, Cortana searches, and MS browser history to be sold to third parties.
 
-httpssupportmicrosoftcomenushelp4468233cortanaandprivacymicrosoftprivacy_KEY: |
+httpssupportPmicrosoftPcomenushelp4468233cortanaandprivacymicrosoftprivacy_87_KEY: |
   https://support.microsoft.com/en-us/help/4468233/cortana-and-privacy-microsoft-privacy
 
-Cortana_and_privacy_KEY: |
+Cortana_and_privacy_20_KEY: |
   Cortana and privacy
 
-To_personalize_your_experience_and_provide_the_best_possible_suggestions_Cortana_accesses_your_email_and_other_communications_and_collects_data_about__KEY: |
+To_personalize_your_experience_and_provide_the_best_possible_suggestions_Cortana_accesses_your_email_and_other_communications_and_collects_data_about__398_KEY: |
   To personalize your experience and provide the best possible suggestions, Cortana accesses your email and other communications and collects data about your contacts (People), like their title, suffix, first name, last name, middle name, nicknames, and company name. If you call, email, or text someone or they call, email, or text you, Cortana collects that person’s email address or phone number.
 
-Some_good_news_KEY: |
+Some_good_news_15_KEY: |
   Some good news
 
-httpsgithubcomcrazymaxWindowsSpyBlockerreleases_KEY: |
+httpsgithubPcomcrazymaxWindowsSpyBlockerreleases_56_KEY: |
   https://github.com/crazy-max/WindowsSpyBlocker/releases
 
-WindowsSpyBlocker_KEY: |
+WindowsSpyBlocker_18_KEY: |
   WindowsSpyBlocker
 
-Opensource_tool_that_blocks_data_collection_KEY: |
+Opensource_tool_that_blocks_data_collectionP_46_KEY: |
   Open-source tool that blocks data collection.
 
-httpswwwghacksnet20150814comparisonofwindows10privacytools_KEY: |
+httpswwwPghacksPnet20150814comparisonofwindows10privacytools_74_KEY: |
   https://www.ghacks.net/2015/08/14/comparison-of-windows-10-privacy-tools/
 
-Comparison_of_Windows_10_Privacy_tools_KEY: |
+Comparison_of_Windows_10_Privacy_tools_39_KEY: |
   Comparison of Windows 10 Privacy tools
 
-More_bad_news_KEY: |
+More_bad_news_14_KEY: |
   More bad news
 
-Windows_10_Sends_Your_Data_5500_Times_Every_Day_Even_After_Tweaking_Privacy_Settings_KEY: |
+Windows_10_Sends_Your_Data_5500_Times_Every_Day_Even_After_Tweaking_Privacy_Settings_85_KEY: |
   Windows 10 Sends Your Data 5500 Times Every Day Even After Tweaking Privacy Settings
 
-The_Hacker_News_KEY: |
+The_Hacker_NewsP_17_KEY: |
   The Hacker News.
 
-httpsarstechnicacominformationtechnology201508evenwhentoldnottowindows10justcantstoptalkingtomicrosoft_KEY: |
+httpsarstechnicaPcominformationtechnology201508evenwhentoldnottowindows10justcantstoptalkingtomicrosoft_125_KEY: |
   https://arstechnica.com/information-technology/2015/08/even-when-told-not-to-windows-10-just-cant-stop-talking-to-microsoft/
 
-Even_when_told_not_to_Windows_10_just_cant_stop_talking_to_Microsoft_Its_no_wonder_that_privacy_activists_are_up_in_arms_KEY: |
+Even_when_told_not_to_Windows_10_just_cant_stop_talking_to_MicrosoftP_Its_no_wonder_that_privacy_activists_are_up_in_armsP_126_KEY: |
   Even when told not to, Windows 10 just can't stop talking to Microsoft. It's no wonder that privacy activists are up in arms.
 
-httpswwwtechdirtcomarticles2015082006171332012windows10reservesrighttoblockpiratedgamesunauthorizedhardwareshtml_KEY: |
+httpswwwPtechdirtPcomarticles2015082006171332012windows10reservesrighttoblockpiratedgamesunauthorizedhardwarePshtml_132_KEY: |
   https://www.techdirt.com/articles/20150820/06171332012/windows-10-reserves-right-to-block-pirated-games-unauthorized-hardware.shtml
 
-Windows_10_Reserves_The_Right_To_Block_Pirated_Games_And_Unauthorized_Hardware_KEY: |
+Windows_10_Reserves_The_Right_To_Block_Pirated_Games_And_Unauthorized_HardwareP_82_KEY: |
   Windows 10 Reserves The Right To Block Pirated Games And 'Unauthorized' Hardware.
 
-Click_on_whatever_service_you_need_to_view_our_recommendations_KEY: |
+Services_8_KEY: |
+  Services
+
+Click_on_whatever_service_you_need_to_view_our_recommendationsP_63_KEY: |
   Click on whatever service you need to view our recommendations.
 
-We_currently_have_the_following_freetouse_services_online_now_KEY: |
+DNS_3_KEY: |
+  DNS
+
+Email_5_KEY: |
+  Email
+
+Hosting_7_KEY: |
+  Hosting
+
+Pastebins_9_KEY: |
+  Pastebins
+
+Social_News_Aggregators_23_KEY: |
+  Social News Aggregators
+
+VPN_3_KEY: |
+  VPN
+
+We_currently_have_the_following_freetouse_services_online_nowP_65_KEY: |
   We currently have the following free-to-use services online now.
 
-Searx__Privacy_Friendly_Search_at_searchprivacytoolsio_KEY: |
+Searx__Privacy_Friendly_Search_at_searchPprivacytoolsPio_58_KEY: |
   Searx - Privacy Friendly Search at search.privacytools.io
 
-Mastodon__Tracker_Free_Social_Networking_at_socialprivacytoolsio_KEY: |
+Mastodon__Tracker_Free_Social_Networking_at_socialPprivacytoolsPio_68_KEY: |
   Mastodon - Tracker Free Social Networking at social.privacytools.io
 
-Matrix__Federated_private_chat_at_chatprivacytoolsio_KEY: |
+Matrix__Federated_private_chat_at_chatPprivacytoolsPio_56_KEY: |
   Matrix - Federated private chat at chat.privacytools.io
 
-Discourse__Forum_at_forumprivacytoolsio_KEY: |
+Discourse__Forum_at_forumPprivacytoolsPio_43_KEY: |
   Discourse - Forum at forum.privacytools.io
 
-Gitea__GitRepository_Manager_at_gitprivacytoolsio_KEY: |
+Gitea__GitRepository_Manager_at_gitPprivacytoolsPio_54_KEY: |
   Gitea - Git-Repository Manager at git.privacytools.io
 
-Write_Freely__Federated_minimalist_blog_at_writeprivacytoolsio_KEY: |
+Write_Freely__Federated_minimalist_blog_at_writePprivacytoolsPio_66_KEY: |
   Write Freely - Federated minimalist blog at write.privacytools.io
 
-PrivateBin__Encrypted_Pastebin_at_binprivacytoolsio_KEY: |
+PrivateBin__Encrypted_Pastebin_at_binPprivacytoolsPio_55_KEY: |
   PrivateBin - Encrypted Pastebin at bin.privacytools.io
 
-More_services_are_on_the_way_If_theres_something_that_would_be_super_beneficial_for_us_to_run_dont_hesitate_to_reach_out_and_ask_And_of_course_if_KEY: |
+More_services_are_on_the_wayP_If_theres_something_that_would_be_super_beneficial_for_us_to_run_dont_hesitate_to_reach_out_and_askP_And_of_course_if_305_KEY: |
   More services are on the way. If there's something that would be super beneficial for us to run, don't hesitate to reach out and ask. And of course, if you like our services, please consider <a href="{{ "/donate/" | translate_page }}">donating to support our server costs</a>, <em>any donation helps!</em>
 
-Sponsors_of__sitename__KEY: |
+Sponsors_of__sitePname__28_KEY: |
   Sponsors of {{ site.name }}
 
-The__sitename__website_and_services_are_a_community_project_There_is_no_advertising_affiliate_links_or_other_forms_of_monetizationbrstrong_KEY: |
+The__sitePname__website_and_services_are_a_community_projectP_There_is_no_advertising_affiliate_links_or_other_forms_of_monetizationPbrstrong_265_KEY: |
   The {{ site.name }} website and services are a community project. There is no advertising, affiliate links, or other forms of monetization.<br><strong>Your donations here directly support hosting this website and compensating contributors to this project.</strong>
 
-Become_a_Sponsor_KEY: |
+Become_a_Sponsor_17_KEY: |
   Become a Sponsor
 
-Donate_Directly_KEY: |
+Donate_Directly_16_KEY: |
   Donate Directly
 
-Why_sponsor__sitename__KEY: |
+Why_sponsor__sitePname_Q_29_KEY: |
   Why sponsor {{ site.name }}?
 
-This_sponsorship_program_is_designed_to_allow_companies_organizations_and_individuals_partner_with_the__sitename__team_to_support_our_vision_of__KEY: |
+This_sponsorship_program_is_designed_to_allow_companies_organizations_and_individuals_partner_with_the__sitePname__team_to_support_our_vision_of__220_KEY: |
   This sponsorship program is designed to allow companies, organizations, and individuals partner with the {{ site.name }} team to support our vision of a more privacy-respecting internet and the greater online community.
 
-With_this_exposure_and_sponsorship_your_customers_will_recognize_your_intrinsic_understanding_and_commitment_to_user_privacy_Moreover_youll_directl_KEY: |
+With_this_exposure_and_sponsorship_your_customers_will_recognize_your_intrinsic_understanding_and_commitment_to_user_privacyP_Moreover_youll_directl_242_KEY: |
   With this exposure and sponsorship, your customers will recognize your intrinsic understanding and commitment to user privacy. Moreover, you'll directly contribute to our mission of spreading privacy-respecting tools and knowledge worldwide!
 
-As_a_sponsor_of__sitename__your_company_will_be_widely_recognized_in_a_variety_of_ways_some_of_which_weve_detailed_below_KEY: |
+As_a_sponsor_of__sitePname__your_company_will_be_widely_recognized_in_a_variety_of_ways_some_of_which_weve_detailed_belowP_130_KEY: |
   As a sponsor of {{ site.name }}, your company will be widely recognized in a variety of ways, some of which we've detailed below.
 
-General_Information_KEY: |
+General_Information_20_KEY: |
   General Information
 
-This_website_receives_well_over_250000_pageviews_on_a_monthly_basis_and_is_highly_ranked_for_privacyrelated_keywords_In_addition_to_the_benefits_bel_KEY: |
+This_website_receives_well_over_250000_pageviews_on_a_monthly_basis_and_is_highly_ranked_for_privacyrelated_keywordsP_In_addition_to_the_benefits_bel_278_KEY: |
   This website receives well over 250,000 pageviews on a monthly basis and is highly ranked for privacy-related keywords. In addition to the benefits below your contribution will be featured on our OpenCollective page and we will thank you via social media for your contribution.
 
-Bronze_Sponsorship_KEY: |
+Bronze_Sponsorship_19_KEY: |
   Bronze Sponsorship
 
-Info_KEY: |
+Info_5_KEY: |
   Info
 
-Your_name_and_link_along_with_a_small_logo_or_avatar_on_the_sponsors_page_of_this_website_KEY: |
+Your_name_and_link_along_with_a_small_logo_or_avatar_on_the_sponsors_page_of_this_websiteP_91_KEY: |
   Your name and link along with a small logo or avatar on the sponsors page of this website.
 
-Silver_Sponsorship_KEY: |
+Silver_Sponsorship_19_KEY: |
   Silver Sponsorship
 
-Your_mediumsized_logo_as_a_link_at_the_top_of_our_sponsors_page_KEY: |
+Your_mediumsized_logo_as_a_link_at_the_top_of_our_sponsors_pageP_66_KEY: |
   Your medium-sized logo as a link at the top of our sponsors page.
 
-Gold_Sponsorship_KEY: |
+Gold_Sponsorship_17_KEY: |
   Gold Sponsorship
 
-Your_mediumsized_logo_as_a_link_on_the__sitename__homepage_and_at_the_very_top_of_our_sponsors_page_KEY: |
+Your_mediumsized_logo_as_a_link_on_the__sitePname__homepage_and_at_the_very_top_of_our_sponsors_pageP_107_KEY: |
   Your medium-sized logo as a link on the {{ site.name }} homepage and at the very top of our sponsors page.
 
-We_will_not_provide_KEY: |
+We_will_not_providePPP_23_KEY: |
   We will not provide...
 
-We_pride_ourselves_on_our_integrity_and_commitment_to_spreading_unbiased_and_factbased_information_regarding_privacy_and_privacyrespecting_tools_All_KEY: |
+We_pride_ourselves_on_our_integrity_and_commitment_to_spreading_unbiased_and_factbased_information_regarding_privacy_and_privacyrespecting_toolsP_All_605_KEY: |
   We pride ourselves on our integrity and commitment to spreading unbiased and fact-based information regarding privacy and privacy-respecting tools. All tools we recommend throughout our website are subject to strict criteria as judged by our team and the community across our various platforms. Your sponsorship will not grant your organization any special consideration when choosing our recommendations throughout the website, a process which we make clear via our transparent ledger on OpenCollective and our public discussions on GitHub. Your sponsorship benefits are limited to those outlined above.
 
-Tax_and_Financial_Information_KEY: |
+Tax_and_Financial_Information_30_KEY: |
   Tax and Financial Information
 
-Your_contribution_to__sitename__will_be_handled_by_the_Open_Collective_Foundation_501c3_For_US_companies_and_taxpayers_this_means_your_contr_KEY: |
+Your_contribution_to__sitePname__will_be_handled_by_the_Open_Collective_Foundation_501c3P_For_US_companies_and_taxpayers_this_means_your_contr_569_KEY: |
   Your contribution to {{ site.name }} will be handled by the Open Collective Foundation 501(c)(3). For US companies and taxpayers, this means your contribution is <strong>tax deductible</strong>. As a non-profit, your sponsorship contribution will not be used for private profit and will only be used to cover expenses incurred by the project. All of our transactions (donations and expenses) are published transparently on OpenCollective. For the benefit of our readership, anonymous contributions will not be eligible for the sponsorship opportunities outlined above.
 
-More_Information_KEY: |
+More_Information_17_KEY: |
   More Information
 
-If_you_are_interested_and_have_further_questions_you_are_welcome_to_reach_out_to_us_directly_at_a_hrefmailtosponsorsprivacytoolsiosponsorspri_KEY: |
+If_you_are_interested_and_have_further_questions_you_are_welcome_to_reach_out_to_us_directly_at_a_hrefmailtosponsorsprivacytoolsPiosponsorspri_169_KEY: |
   If you are interested and have further questions, you are welcome to reach out to us directly at <a href="mailto:sponsors@privacytools.io">sponsors@privacytools.io</a>.
 
-Using_a_VPN_will_strongnotstrong_keep_your_browsing_habits_anonymous_nor_will_it_add_additional_security_to_nonsecure_HTTP_traffic_KEY: |
+Using_a_VPN_will_strongnotstrong_keep_your_browsing_habits_anonymous_nor_will_it_add_additional_security_to_nonsecure_HTTP_trafficP_141_KEY: |
   Using a VPN will <strong>not</strong> keep your browsing habits anonymous, nor will it add additional security to non-secure (HTTP) traffic.
 
-If_you_are_looking_for_stronganonymitystrong_you_should_use_the_Tor_Browser_stronginsteadstrong_of_a_VPN_KEY: |
+If_you_are_looking_for_stronganonymitystrong_you_should_use_the_Tor_Browser_stronginsteadstrong_of_a_VPNP_117_KEY: |
   If you are looking for <strong>anonymity</strong>, you should use the Tor Browser <strong>instead</strong> of a VPN.
 
-If_youre_looking_for_added_strongsecuritystrong_you_should_always_ensure_youre_connecting_to_websites_using_a_href_providersdnsicanndn_KEY: |
+If_youre_looking_for_added_strongsecuritystrong_you_should_always_ensure_youre_connecting_to_websites_using_a_href_providersdnsicanndn_308_KEY: |
   If you're looking for added <strong>security</strong>, you should always ensure you're connecting to websites using <a href="{{ /providers/dns/#icanndns | translate_page}}">encrypted DNS</a> and <a href="https://en.wikipedia.org/wiki/HTTPS">HTTPS</a>. A VPN is not a replacement for good security practices.
 
-If_youre_looking_for_additional_strongprivacystrong_from_your_ISP_on_a_public_WiFi_network_or_while_torrenting_files_a_VPN_may_be_the_solutio_KEY: |
+If_youre_looking_for_additional_strongprivacystrong_from_your_ISP_on_a_public_WiFi_network_or_while_torrenting_files_a_VPN_may_be_the_solutio_227_KEY: |
   If you're looking for additional <strong>privacy</strong> from your ISP, on a public Wi-Fi network, or while torrenting files, a VPN may be the solution for you as long as you understand <a href="#info">the risks involved</a>.
 
-Download_Tor_KEY: |
+httpswwwPtorprojectPorg_28_KEY: |
+  https://www.torproject.org/
+
+Download_Tor_13_KEY: |
   Download Tor
 
-Tor_Myths_KEY: |
+Tor_Myths_10_KEY: |
   Tor Myths
 
-FAQ_KEY: |
+FAQ_4_KEY: |
   FAQ
 
-Our_VPN_Provider_Criteria_KEY: |
+Our_VPN_Provider_Criteria_26_KEY: |
   Our VPN Provider Criteria
 
-Please_note_we_are_not_affiliated_with_any_of_the_providers_we_recommend_This_allows_us_to_provide_completely_objective_recommendations_KEY: |
+Please_note_we_are_not_affiliated_with_any_of_the_providers_we_recommendP_This_allows_us_to_provide_completely_objective_recommendationsP_138_KEY: |
   Please note we are not affiliated with any of the providers we recommend. This allows us to provide completely objective recommendations.
 
-We_have_developed_a_clear_set_of_requirements_for_any_VPN_provider_wishing_to_be_recommended_including_strong_encryption_independent_security_audits_KEY: |
+We_have_developed_a_clear_set_of_requirements_for_any_VPN_provider_wishing_to_be_recommended_including_strong_encryption_independent_security_audits_363_KEY: |
   We have developed a clear set of requirements for any VPN provider wishing to be recommended, including strong encryption, independent security audits, modern technology, and more. We suggest you familiarize yourself with this list before choosing a VPN provider, and conduct your own research to ensure the VPN provider you choose is as trustworthy as possible.
 
-Operating_outside_the_fiveninefourteeneyes_countries_is_not_a_guarantee_of_privacy_necessarily_and_there_are_other_factors_to_consider_However_we_KEY: |
+Operating_outside_the_fiveninefourteeneyes_countries_is_not_a_guarantee_of_privacy_necessarily_and_there_are_other_factors_to_considerP_However_we_474_KEY: |
   Operating outside the five/nine/fourteen-eyes countries is not a guarantee of privacy necessarily, and there are other factors to consider. However, we believe that avoiding these countries is important if you wish to avoid mass government dragnet surveillance, especially from the United States. Read our page on <a href="{{ '/providers/#ukusa' | translate_page }}">global mass surveillance and avoiding the US and UK</a> to learn more about why we feel this is important.
 
-Minimum_to_Qualify_KEY: |
+Minimum_to_Qualify_20_KEY: |
   Minimum to Qualify:
 
-Operating_outside_the_USA_or_other_Five_Eyes_countries_KEY: |
+Operating_outside_the_USA_or_other_Five_Eyes_countriesP_56_KEY: |
   Operating outside the USA or other Five Eyes countries.
 
-Best_Case_KEY: |
+Best_Case_11_KEY: |
   Best Case:
 
-Operating_outside_the_USA_or_other_Fourteen_Eyes_countries_KEY: |
+Operating_outside_the_USA_or_other_Fourteen_Eyes_countriesP_60_KEY: |
   Operating outside the USA or other Fourteen Eyes countries.
 
-Operating_inside_a_country_with_strong_consumer_protection_laws_KEY: |
+Operating_inside_a_country_with_strong_consumer_protection_lawsP_65_KEY: |
   Operating inside a country with strong consumer protection laws.
 
-Technology_KEY: |
+Technology_11_KEY: |
   Technology
 
-We_require_all_our_recommended_VPN_providers_to_provide_OpenVPN_configuration_files_to_be_used_in_any_client_strongIfstrong_a_VPN_provides_their__KEY: |
+We_require_all_our_recommended_VPN_providers_to_provide_OpenVPN_configuration_files_to_be_used_in_any_clientP_strongIfstrong_a_VPN_provides_their__241_KEY: |
   We require all our recommended VPN providers to provide OpenVPN configuration files to be used in any client. <strong>If</strong> a VPN provides their own custom client, we require a killswitch to block network data leaks when disconnected.
 
-OpenVPN_support_KEY: |
+OpenVPN_supportP_17_KEY: |
   OpenVPN support.
 
-Killswitch_built_in_to_clients_KEY: |
+Killswitch_built_in_to_clientsP_32_KEY: |
   Killswitch built in to clients.
 
-OpenVPN_and_WireGuard_support_KEY: |
+OpenVPN_and_WireGuard_supportP_31_KEY: |
   OpenVPN and WireGuard support.
 
-Killswitch_with_highly_configurable_options_enabledisable_on_certain_networks_on_boot_etc_KEY: |
+Killswitch_with_highly_configurable_options_enabledisable_on_certain_networks_on_boot_etcP_96_KEY: |
   Killswitch with highly configurable options (enable/disable on certain networks, on boot, etc.)
 
-Easytouse_mobile_clients_especially_opensource_KEY: |
+Easytouse_mobile_clients_especially_opensourceP_52_KEY: |
   Easy-to-use mobile clients, especially open-source.
 
-Privacy_KEY: |
+Privacy_8_KEY: |
   Privacy
 
-We_prefer_our_recommended_providers_to_collect_as_little_data_as_possible_Not_collecting_personal_information_on_registration_and_accepting_anonymous_KEY: |
+We_prefer_our_recommended_providers_to_collect_as_little_data_as_possibleP_Not_collecting_personal_information_on_registration_and_accepting_anonymous_183_KEY: |
   We prefer our recommended providers to collect as little data as possible. Not collecting personal information on registration, and accepting anonymous forms of payment are required.
 
-Bitcoin_or_cash_payment_option_KEY: |
+Bitcoin_or_cash_payment_optionP_32_KEY: |
   Bitcoin or cash payment option.
 
-No_personal_information_required_to_register_Only_username_password_and_email_at_most_KEY: |
+No_personal_information_required_to_register_Only_username_password_and_email_at_mostP_90_KEY: |
   No personal information required to register: Only username, password, and email at most.
 
-Accepts_Bitcoin_cash_and_other_forms_of_cryptocurrency_andor_anonymous_payment_options_gift_cards_etc_KEY: |
+Accepts_Bitcoin_cash_and_other_forms_of_cryptocurrency_andor_anonymous_payment_options_gift_cards_etcP_109_KEY: |
   Accepts Bitcoin, cash, and other forms of cryptocurrency and/or anonymous payment options (gift cards, etc.)
 
-No_personal_information_accepted_autogenerated_username_no_email_required_etc_KEY: |
+No_personal_information_accepted_autogenerated_username_no_email_required_etcP_83_KEY: |
   No personal information accepted (autogenerated username, no email required, etc.)
 
-Security_KEY: |
+Security_9_KEY: |
   Security
 
-A_VPN_is_pointless_if_it_cant_even_provide_adequate_security_We_require_all_our_recommended_providers_to_abide_by_current_security_standards_for_thei_KEY: |
+A_VPN_is_pointless_if_it_cant_even_provide_adequate_securityP_We_require_all_our_recommended_providers_to_abide_by_current_security_standards_for_thei_397_KEY: |
   A VPN is pointless if it can't even provide adequate security. We require all our recommended providers to abide by current security standards for their OpenVPN connections. Ideally, they would use more future-proof encryption schemes by default. We also require an independent third-party to audit the provider's security, ideally in a very comprehensive manner and on a repeated (yearly) basis.
 
-Strong_Encryption_Schemes_OpenVPN_with_SHA256_authentication_RSA2048_or_better_handshake_AES256GCM_or_AES256CBC_data_encryption_KEY: |
+Strong_Encryption_Schemes_OpenVPN_with_SHA256_authentication_RSA2048_or_better_handshake_AES256GCM_or_AES256CBC_data_encryptionP_138_KEY: |
   Strong Encryption Schemes: OpenVPN with SHA-256 authentication; RSA-2048 or better handshake; AES-256-GCM or AES-256-CBC data encryption.
 
-Perfect_Forward_Secrecy_PFS_KEY: |
+Perfect_Forward_Secrecy_PFSP_31_KEY: |
   Perfect Forward Secrecy (PFS).
 
-Published_security_audits_from_a_reputable_thirdparty_firm_KEY: |
+Published_security_audits_from_a_reputable_thirdparty_firmP_61_KEY: |
   Published security audits from a reputable third-party firm.
 
-Strongest_Encryption_RSA4096_KEY: |
+Strongest_Encryption_RSA4096P_32_KEY: |
   Strongest Encryption: RSA-4096.
 
-Comprehensive_published_security_audits_from_a_reputable_thirdparty_firm_KEY: |
+Comprehensive_published_security_audits_from_a_reputable_thirdparty_firmP_75_KEY: |
   Comprehensive published security audits from a reputable third-party firm.
 
-Bugbounty_programs_andor_a_coordinated_vulnerabilitydisclosure_process_KEY: |
+Bugbounty_programs_andor_a_coordinated_vulnerabilitydisclosure_processP_75_KEY: |
   Bug-bounty programs and/or a coordinated vulnerability-disclosure process.
 
-Trust_KEY: |
+Trust_6_KEY: |
   Trust
 
-You_wouldnt_trust_your_finances_to_someone_with_a_fake_identity_so_why_trust_them_with_your_internet_data_We_require_our_recommended_providers_to_be_KEY: |
+You_wouldnt_trust_your_finances_to_someone_with_a_fake_identity_so_why_trust_them_with_your_internet_dataQ_We_require_our_recommended_providers_to_be_314_KEY: |
   You wouldn't trust your finances to someone with a fake identity, so why trust them with your internet data? We require our recommended providers to be public about their ownership or leadership. We also would like to see frequent transparency reports, especially in regard to how government requests are handled.
 
-Publicfacing_leadership_or_ownership_KEY: |
+Publicfacing_leadership_or_ownershipP_39_KEY: |
   Public-facing leadership or ownership.
 
-Publicfacing_leadership_KEY: |
+Publicfacing_leadershipP_26_KEY: |
   Public-facing leadership.
 
-Frequent_transparency_reports_KEY: |
+Frequent_transparency_reportsP_31_KEY: |
   Frequent transparency reports.
 
-Additional_Functionality_KEY: |
+Additional_Functionality_25_KEY: |
   Additional Functionality
 
-While_not_strictly_requirements_there_are_some_factors_we_looked_into_when_determining_which_providers_to_recommend_These_include_adblockingtracker_KEY: |
+While_not_strictly_requirements_there_are_some_factors_we_looked_into_when_determining_which_providers_to_recommendP_These_include_adblockingtracker_296_KEY: |
   While not strictly requirements, there are some factors we looked into when determining which providers to recommend. These include adblocking/tracker-blocking functionality, warrant canaries, multihop connections, excellent customer support, the number of allowed simultaneous connections, etc.
 
-Further_Information_and_Dangers_KEY: |
+Further_Information_and_Dangers_32_KEY: |
   Further Information and Dangers
 
-Should_I_use_a_VPN_KEY: |
+Should_I_use_a_VPNQ_20_KEY: |
   Should I use a VPN?
 
-The_answer_to_this_question_is_not_a_particularly_helpful_one_strongIt_dependsstrong_It_depends_on_what_youre_expecting_a_VPN_to_do_for_you_wh_KEY: |
+The_answer_to_this_question_is_not_a_particularly_helpful_one_strongIt_dependsPstrong_It_depends_on_what_youre_expecting_a_VPN_to_do_for_you_wh_230_KEY: |
   The answer to this question is not a particularly helpful one: <strong>It depends.</strong> It depends on what you're expecting a VPN to do for you, who you're trying to hide your traffic from, and what applications you're using.
 
-strongIn_most_cases_VPNs_do_little_to_protect_your_privacy_or_enhance_your_securitystrong_unless_paired_with_other_changes_KEY: |
+strongIn_most_cases_VPNs_do_little_to_protect_your_privacy_or_enhance_your_securitystrong_unless_paired_with_other_changesP_131_KEY: |
   <strong>In most cases, VPNs do little to protect your privacy or enhance your security</strong>, unless paired with other changes.
 
-VPNs_cannot_encrypt_data_outside_of_the_connection_between_your_device_and_the_VPN_server_VPN_providers_can_see_and_modify_your_traffic_the_same_way_y_KEY: |
+VPNs_cannot_encrypt_data_outside_of_the_connection_between_your_device_and_the_VPN_serverP_VPN_providers_can_see_and_modify_your_traffic_the_same_way_y_247_KEY: |
   VPNs cannot encrypt data outside of the connection between your device and the VPN server. VPN providers can see and modify your traffic the same way your ISP could. And there is no way to verify a VPN provider's "no logging" policies in any way.
 
-What_if_I_need_encryption_KEY: |
+What_if_I_need_encryptionQ_27_KEY: |
   What if I need encryption?
 
-In_most_cases_most_of_your_traffic_is_already_encrypted!_Over_98_of_the_top_3000_websites_offer_strongHTTPSstrong_meaning_your_nonDNS_traffic__KEY: |
+In_most_cases_most_of_your_traffic_is_already_encryptedE_Over_98_of_the_top_3000_websites_offer_strongHTTPSstrong_meaning_your_nonDNS_traffic__383_KEY: |
   In most cases, most of your traffic is already encrypted! Over 98% of the top 3000 websites offer <strong>HTTPS</strong>, meaning your non-DNS traffic is safe regardless of using a VPN. It is incredibly rare for applications that handle personal data to not support HTTPS in 2019, especially with services like Let's Encrypt offering free HTTPS certificates to any website operator.
 
-Even_if_a_site_you_visit_doesnt_support_HTTPS_a_VPN_will_not_protect_you_because_a_VPN_cannot_magically_encrypt_the_traffic_between_the_VPNs_server_KEY: |
+Even_if_a_site_you_visit_doesnt_support_HTTPS_a_VPN_will_not_protect_you_because_a_VPN_cannot_magically_encrypt_the_traffic_between_the_VPNs_server_363_KEY: |
   Even if a site you visit doesn't support HTTPS, a VPN will not protect you, because a VPN cannot magically encrypt the traffic between the VPN's servers and the website's servers. Installing an extension like <a href="https://www.eff.org/https-everywhere">HTTPS Everywhere</a> and making sure every site you visit uses HTTPS is far more helpful than using a VPN.
 
-Should_I_use_encrypted_DNS_with_a_VPN_KEY: |
+Should_I_use_encrypted_DNS_with_a_VPNQ_39_KEY: |
   Should I use encrypted DNS with a VPN?
 
-The_answer_to_this_question_is_also_not_very_helpful_strongit_dependsstrong_Your_VPN_provider_may_have_their_own_DNS_servers_but_if_they_dont_KEY: |
+The_answer_to_this_question_is_also_not_very_helpful_strongit_dependsstrongP_Your_VPN_provider_may_have_their_own_DNS_servers_but_if_they_dont_584_KEY: |
   The answer to this question is also not very helpful: <strong>it depends</strong>. Your VPN provider may have their own DNS servers, but if they don't, the traffic between your VPN provider and the DNS server isn't encrypted. You need to trust the <a href="{{ '/providers/dns/#icanndns' | translate_page }}">encrypted DNS provider</a> in addition to the VPN provider and unless your client and target server support <a href="https://www.eff.org/deeplinks/2018/09/esni-privacy-protecting-upgrade-https">encrypted SNI</a>, the VPN provider can still see which domains you are visiting.
 
-However_strongyou_shouldnt_use_encrypted_DNS_with_Torstrong_This_would_direct_all_of_your_DNS_requests_through_a_single_circuit_and_would_allow_KEY: |
+However_strongyou_shouldnt_use_encrypted_DNS_with_TorstrongP_This_would_direct_all_of_your_DNS_requests_through_a_single_circuit_and_would_allow_199_KEY: |
   However <strong>you shouldn't use encrypted DNS with Tor</strong>. This would direct all of your DNS requests through a single circuit, and would allow the encrypted DNS provider to deanonymize you.
 
-What_if_I_need_anonymity_KEY: |
+What_if_I_need_anonymityQ_26_KEY: |
   What if I need anonymity?
 
-VPNs_cannot_provide_strong_anonymity_Your_VPN_provider_will_still_see_your_real_IP_address_and_often_has_a_money_trail_that_can_be_linked_directly_ba_KEY: |
+VPNs_cannot_provide_strong_anonymityP_Your_VPN_provider_will_still_see_your_real_IP_address_and_often_has_a_money_trail_that_can_be_linked_directly_ba_225_KEY: |
   VPNs cannot provide strong anonymity. Your VPN provider will still see your real IP address, and often has a money trail that can be linked directly back to you. You cannot rely on "no logging" policies to protect your data.
 
-Shouldnt_I_hide_my_IP_address_KEY: |
+Shouldnt_I_hide_my_IP_addressQ_32_KEY: |
   Shouldn't I hide my IP address?
 
-The_idea_that_your_IP_address_is_sensitive_information_or_that_your_location_is_given_away_with_all_your_internet_traffic_is_strongfearmongeringst_KEY: |
+The_idea_that_your_IP_address_is_sensitive_information_or_that_your_location_is_given_away_with_all_your_internet_traffic_is_strongfearmongeringst_628_KEY: |
   The idea that your IP address is sensitive information, or that your location is given away with all your internet traffic is <strong>fearmongering</strong> on the part of VPN providers and their marketing. Your IP address is an insignificant amount of personal data tracking companies use to identify you, because many users' IP addresses change very frequently (Dynamic IP addresses, switching networks, switching devices, etc.). Your IP address also does not give away more than the very generalized location of your Internet Service Provider. It does not give away your home address, for example, despite common perception.
 
-Should_I_use_Tor_emandem_a_VPN_KEY: |
+Should_I_use_Tor_emandem_a_VPNQ_37_KEY: |
   Should I use Tor <em>and</em> a VPN?
 
-By_using_a_VPN_with_Tor_youre_creating_essentially_a_permanent_entry_node_often_with_a_money_trail_attached_This_provides_0_additional_benefit_to_y_KEY: |
+By_using_a_VPN_with_Tor_youre_creating_essentially_a_permanent_entry_node_often_with_a_money_trail_attachedP_This_provides_0_additional_benefit_to_y_531_KEY: |
   By using a VPN with Tor, you're creating essentially a permanent entry node, often with a money trail attached. This provides 0 additional benefit to you, while increasing the attack surface of your connection dramatically. If you wish to hide your Tor usage from your ISP or your government, Tor has a built-in solution for that: Tor bridges. <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-2-onion-recipes-vpn-not-required">Read more about Tor bridges and why using a VPN is not necessary</a>.
 
-Are_VPNs_ever_useful_KEY: |
+Are_VPNs_ever_usefulQ_22_KEY: |
   Are VPNs ever useful?
 
-A_VPN_may_still_be_useful_to_you_in_a_variety_of_scenarios_such_as_KEY: |
+A_VPN_may_still_be_useful_to_you_in_a_variety_of_scenarios_such_as_69_KEY: |
   A VPN may still be useful to you in a variety of scenarios, such as:
 
-Hiding_your_traffic_from_strongonlystrong_your_Internet_Service_Provider_KEY: |
+Hiding_your_traffic_from_strongonlystrong_your_Internet_Service_ProviderP_79_KEY: |
   Hiding your traffic from <strong>only</strong> your Internet Service Provider.
 
-Hiding_your_downloads_such_as_torrents_from_your_ISP_and_antipiracy_organizations_KEY: |
+Hiding_your_downloads_such_as_torrents_from_your_ISP_and_antipiracy_organizationsP_86_KEY: |
   Hiding your downloads (such as torrents) from your ISP and anti-piracy organizations.
 
-For_use_cases_like_these_or_if_you_have_another_compelling_reason_the_VPN_providers_we_listed_above_are_who_we_think_are_the_most_trustworthy_Howeve_KEY: |
+For_use_cases_like_these_or_if_you_have_another_compelling_reason_the_VPN_providers_we_listed_above_are_who_we_think_are_the_most_trustworthyP_Howeve_334_KEY: |
   For use cases like these, or if you have another compelling reason, the VPN providers we listed above are who we think are the most trustworthy. However, using a VPN provider still means you're <em>trusting</em> the provider. In pretty much any other scenario you should be using a secure<strong>-by-design</strong> tool such as Tor.
 
-Sources_and_Further_Reading_KEY: |
+Sources_and_Further_Reading_28_KEY: |
   Sources and Further Reading
 
-a_href_httpsschubioblog20190408veryprecariousnarrativehtml_VPN__a_Very_Precarious_Narrativea_by_Dennis_Schubert_KEY: |
+a_href_httpsschubPioblog20190408veryprecariousnarrativePhtml_VPN__a_Very_Precarious_Narrativea_by_Dennis_Schubert_133_KEY: |
   <a href=" https://schub.io/blog/2019/04/08/very-precarious-narrative.html ">VPN - a Very Precarious Narrative</a> by Dennis Schubert
 
-a_hrefhttpsgistgithubcomjoepie915a9909939e6ce7d09e29Dont_use_VPN_servicesa_by_Sven_Slootweg_KEY: |
+a_hrefhttpsgistPgithubPcomjoepie915a9909939e6ce7d09e29Dont_use_VPN_servicesa_by_Sven_Slootweg_108_KEY: |
   <a href="https://gist.github.com/joepie91/5a9909939e6ce7d09e29">Don't use VPN services</a> by Sven Slootweg
 
-a_href_softwarenetworks__translate_page_The_selfcontained_networksa_recommended_by_PrivacyTools_are_able_to_replace_a_VPN_that_allow_KEY: |
+a_href_softwarenetworks__translate_page_The_selfcontained_networksa_recommended_by_PrivacyTools_are_able_to_replace_a_VPN_that_allow_194_KEY: |
   <a href='{{ "/software/networks/" | translate_page }}'>The self-contained networks</a> recommended by PrivacyTools are able to replace a VPN that allows access to services on local area network
 
-a_hrefhttpswriteprivacytoolsiomythoughtsonsecurityslicingonionspart1mythbustingtorSlicing_Onions_Part_1__Mythbusting_Tora_by_KEY: |
+a_hrefhttpswritePprivacytoolsPiomythoughtsonsecurityslicingonionspart1mythbustingtorSlicing_Onions_Part_1__Mythbusting_Tora_by_166_KEY: |
   <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-1-myth-busting-tor">Slicing Onions: Part 1 – Myth-busting Tor</a> by blacklight447
 
-a_hrefhttpswriteprivacytoolsiomythoughtsonsecurityslicingonionspart2onionrecipesvpnnotrequiredSlicing_Onions_Part_2__Onion_rec_KEY: |
+a_hrefhttpswritePprivacytoolsPiomythoughtsonsecurityslicingonionspart2onionrecipesvpnnotrequiredSlicing_Onions_Part_2__Onion_rec_195_KEY: |
   <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-2-onion-recipes-vpn-not-required">Slicing Onions: Part 2 – Onion recipes; VPN not required</a> by blacklight447
 
-More_VPN_Providers_KEY: |
+More_VPN_Providers_19_KEY: |
   More VPN Providers
 
-httpsthatoneprivacysitenetvpncomparisonchart_KEY: |
+httpsthatoneprivacysitePnetvpncomparisonchart_53_KEY: |
   https://thatoneprivacysite.net/vpn-comparison-chart/
 
-Spreadsheet_with_unbiased_independently_verifiable_data_on_over_100_VPN_services_KEY: |
+Spreadsheet_with_unbiased_independently_verifiable_data_on_over_100_VPN_servicesP_83_KEY: |
   Spreadsheet with unbiased, independently verifiable data on over 100 VPN services.
 
-httpsthewirecuttercomreviewsbestvpnservice_KEY: |
+httpsthewirecutterPcomreviewsbestvpnservice_52_KEY: |
   https://thewirecutter.com/reviews/best-vpn-service/
 
-Indepth_research_on_53_popular_VPN_providers_KEY: |
+Indepth_research_on_53_popular_VPN_providersP_47_KEY: |
   In-depth research on 53 popular VPN providers.
 
-Related_VPN_information_KEY: |
+Related_VPN_information_24_KEY: |
   Related VPN information
 
-httpsvikingvpncomblogsofftopicbewareofvpnmarketingandaffiliateprograms_KEY: |
+httpsvikingvpnPcomblogsofftopicbewareofvpnmarketingandaffiliateprograms_85_KEY: |
   https://vikingvpn.com/blogs/off-topic/beware-of-vpn-marketing-and-affiliate-programs
 
-Beware_of_False_Reviews__VPN_Marketing_and_Affiliate_Programs_KEY: |
+Beware_of_False_Reviews__VPN_Marketing_and_Affiliate_Programs_63_KEY: |
   Beware of False Reviews - VPN Marketing and Affiliate Programs
 
-httpswwwgoldenfrogcomtakebackyourinternetarticles7mythsaboutvpnloggingandanonymity_KEY: |
+httpswwwPgoldenfrogPcomtakebackyourinternetarticles7mythsaboutvpnloggingandanonymity_100_KEY: |
   https://www.goldenfrog.com/take-back-your-internet/articles/7-myths-about-vpn-logging-and-anonymity
 
-I_am_Anonymous_When_I_Use_a_VPN__7_Myths_Debunked_KEY: |
+I_am_Anonymous_When_I_Use_a_VPN__7_Myths_Debunked_51_KEY: |
   I am Anonymous When I Use a VPN - 7 Myths Debunked
 
-Note_KEY: |
+Note_6_KEY: |
   Note:
 
-While_this_is_a_good_read_they_also_use_the_article_for_selfpromotion_KEY: |
+While_this_is_a_good_read_they_also_use_the_article_for_selfpromotion_72_KEY: |
   While this is a good read, they also use the article for self-promotion
 
-httpstorrentfreakcomproxyshvpnprovidermonitoredtraffictocatchhacker130930_KEY: |
+httpstorrentfreakPcomproxyshvpnprovidermonitoredtraffictocatchhacker130930_89_KEY: |
   https://torrentfreak.com/proxy-sh-vpn-provider-monitored-traffic-to-catch-hacker-130930/
 
-Proxysh_VPN_Provider_Sniffed_Server_Traffic_to_Catch_Hacker_KEY: |
+ProxyPsh_VPN_Provider_Sniffed_Server_Traffic_to_Catch_Hacker_61_KEY: |
   Proxy.sh VPN Provider Sniffed Server Traffic to Catch Hacker
 
-httpsproxyshpanelknowledgebasephpactiondisplayarticleid5_KEY: |
+httpsproxyPshpanelknowledgebasePphpQactiondisplayarticleid5_68_KEY: |
   https://proxy.sh/panel/knowledgebase.php?action=displayarticle&id=5
 
-Ethical_policy__All_of_the_reasons_why_Proxysh_might_enable_logging_KEY: |
+Ethical_policy__All_of_the_reasons_why_ProxyPsh_might_enable_logging_70_KEY: |
   Ethical policy - All of the reasons why Proxy.sh might enable logging
 
-httpswwwivpnnetprivacy_KEY: |
+httpswwwPivpnPnetprivacy_29_KEY: |
   https://www.ivpn.net/privacy
 
-IVPNnet_will_collect_your_email_and_IP_address_after_sign_up_KEY: |
+IVPNPnet_will_collect_your_email_and_IP_address_after_sign_up_62_KEY: |
   IVPN.net will collect your email and IP address after sign up
 
-Read_the_a_datatoggletooltip_dataplacementtop_dataoriginaltitleThe_IP_collected_at_signup_is_only_used_for_a_few_seconds_by_our_fraud_modu_KEY: |
+Read_the_a_datatoggletooltip_dataplacementtop_dataoriginaltitleThe_IP_collected_at_signup_is_only_used_for_a_few_seconds_by_our_fraud_modu_383_KEY: |
   Read the <a data-toggle="tooltip" data-placement="top" data-original-title="The IP collected at signup is only used for a few seconds by our fraud module and then discarded, it is not stored. Storing them would significantly increase our own liability and certainly would not be in our interest. You're absolutely welcome to signup using Tor or a VPN.">Email statement</a> from IVPN.
 
-httpsmediumcomblackVPNnologs6d65d95a3016_KEY: |
+httpsmediumPcomblackVPNnologs6d65d95a3016_50_KEY: |
   https://medium.com/@blackVPN/no-logs-6d65d95a3016
 
-blackVPN_announced_to_delete_connection_logs_after_disconnection_KEY: |
+blackVPN_announced_to_delete_connection_logs_after_disconnection_65_KEY: |
   blackVPN announced to delete connection logs after disconnection
 
-httpsgistgithubcomkennwhite1f3bc4d889b02b35d8aa_KEY: |
+httpsgistPgithubPcomkennwhite1f3bc4d889b02b35d8aa_55_KEY: |
   https://gist.github.com/kennwhite/1f3bc4d889b02b35d8aa
 
-Dont_use_LT2P_IPSec_use_other_protocols_KEY: |
+Dont_use_LT2P_IPSec_use_other_protocolsP_43_KEY: |
   Don't use LT2P IPSec, use other protocols.
 


### PR DESCRIPTION
This is to make  don't end up using the same string for two
strings using the same words but different length and punctuation.

For example, there are two strings of different length on the site that started with this exact substring:

> You are being watched. Private and state-sponsored organizations are monitoring and recording your online activities.

As a result, the shorter string on the site ended up being superseded by the longer string. I had to bump the max base key length up from 100 to 150. Encoding the length in the key makes sure we don't run into this issue in the future for even longer strings.