### PR TITLE
i18n: strip all newlines for Weblate

### DIFF
--- a/_plugins/weblate-source-file.rb
+++ b/_plugins/weblate-source-file.rb
@@ -34,7 +34,7 @@ module Weblate
       def add_entry(weblate_id, source_text)
         unless id_already_exists?(weblate_id) or source_text.nil? or source_text.empty?
           new_entry = <<-YAML
-#{weblate_id}: |
+#{weblate_id}: |-
   #{source_text}
 
           YAML
@@ -44,7 +44,7 @@ module Weblate
       end
 
       def id_already_exists?(weblate_id)
-        File.readlines(weblate_source_location).grep(/^#{weblate_id}: \|$/).any?
+        File.readlines(weblate_source_location).grep(/^#{weblate_id}: \|-$/).any?
       end
 
       def refresh


### PR DESCRIPTION
See https://github.com/privacytoolsIO/privacytools.io/pull/1509#issuecomment-558552605. This PR should get rid of `\n` in the parsed YAML (https://yaml.org/YAML_for_ruby.html#three_trailing_newlines_in_literals)

Not including a source file change in this one as I think it's better to let you handle source file refreshes (also, I have other PRs that add new keys anyway)
