### PR TITLE
Use e.g., instead of eg for instant messengers

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -80,14 +80,14 @@
         <li>Allows you to choose who to trust your data with by choosing between multiple "public" servers.</li>
         <li>Often allows for third party clients which can provide a more native, customized, or accessible experience.</li>
         <li>Generally a less juicy target for governments wanting <a href="#exploiting-centralized-networks">backdoor access to everything</a> as the trust is decentralized. The server may be hosted independently from the organization developing the software.</li>
-        <li>Server software can be verified that it matches public source code, assuming you have access to the server or you trust the person who does (eg family member)</li>
+        <li>Server software can be verified that it matches public source code, assuming you have access to the server or you trust the person who does (e.g., a family member)</li>
         <li>Third-party developers can contribute code and add new features, instead of waiting for a private development team to do so.</li>
     </ul>
 
     <h3>Disadvantages</h3>
     <ul>
         <li>Adding new features is more complex, because these features need to be standardized and tested to ensure they work with all servers on the network.</li>
-        <li>Some metadata may be available. Information like "who is talking to whom," but not actual message content if E2EE is used.</li>
+        <li>Some metadata may be available (e.g., information like "who is talking to whom," but not actual message content if E2EE is used).</li>
         <li>Federated servers generally require trusting your server's administrator. They may be a hobbyist or otherwise not a "security professional," and may not serve standard documents like a privacy policy or terms of service detailing how your data is utilized.</li>
         <li>Server administrators sometimes choose to block other servers, which are a source of unmoderated abuse or break general rules of accepted behavior. This will hinder your ability to communicate with users on those servers.</li>
     </ul>


### PR DESCRIPTION
The sentence about metadata flows better if the second fragment is used as an example of metadata