### PR TITLE
i18n: Encode string lengths after strip

### DIFF
--- a/_plugins/weblate-source-file.rb
+++ b/_plugins/weblate-source-file.rb
@@ -19,13 +19,16 @@ module Weblate
 
   class ID
     def self.get(source_text)
-      source_text.nil? or source_text.empty? ? source_text
-                                             : source_text.strip[0..150]
-                                                          .gsub(/([^\w\d\s\.\?\!]|\n)/, '')
-                                                          .tr(' ', '_') 
-                                                          .tr('.', 'P')
-                                                          .tr('?', 'Q')
-                                                          .tr('!', 'E') << "_" << source_text.length.to_s << "_KEY"
+      if source_text.nil? or source_text.empty?
+        source_text
+      else
+        len_encoding = source_text.strip.length.to_s
+        source_text.strip[0..150].gsub(/([^\w\d\s\.\?\!]|\n)/, '')
+                                 .tr(' ', '_') 
+                                 .tr('.', 'P')
+                                 .tr('?', 'Q')
+                                 .tr('!', 'E') << "_" << len_encoding << "_KEY"
+      end
     end
   end
 

--- a/weblate-source-file.yml
+++ b/weblate-source-file.yml
@@ -29,17 +29,17 @@ Encrypted_DNS_Resolvers_23_KEY: |-
 Dont_let_Google_see_all_your_DNS_trafficP_Discover_privacycentric_alternatives_to_the_traditional_DNS_providersP_114_KEY: |-
   Don't let Google see all your DNS traffic. Discover privacy-centric alternatives to the traditional DNS providers.
 
-Best_Secure_Email_Providers_for_Privacy_39_KEY: |-
-  Best Secure Email Providers for Privacy
-
-Find_a_secure_email_provider_that_will_keep_your_privacy_in_mindP_Dont_settle_for_adsupported_platformsP_Never_trust_any_company_with_your_privacy_a_165_KEY: |-
-  Find a secure email provider that will keep your privacy in mind. Don't settle for ad-supported platforms. Never trust any company with your privacy, always encrypt.
-
 Email_Clients_13_KEY: |-
   Email Clients
 
 Discover_free_opensource_and_secure_email_clients_along_with_some_email_alternatives_you_may_not_have_consideredP_117_KEY: |-
   Discover free, open-source, and secure email clients, along with some email alternatives you may not have considered.
+
+Best_Secure_Email_Providers_for_Privacy_39_KEY: |-
+  Best Secure Email Providers for Privacy
+
+Find_a_secure_email_provider_that_will_keep_your_privacy_in_mindP_Dont_settle_for_adsupported_platformsP_Never_trust_any_company_with_your_privacy_a_165_KEY: |-
+  Find a secure email provider that will keep your privacy in mind. Don't settle for ad-supported platforms. Never trust any company with your privacy, always encrypt.
 
 Encryption_Tools_16_KEY: |-
   Encryption Tools
@@ -155,151 +155,124 @@ VPN_Services_12_KEY: |-
 Find_a_nologging_VPN_operator_who_isnt_out_to_sell_or_read_your_web_trafficP_78_KEY: |-
   Find a no-logging VPN operator who isn't out to sell or read your web traffic.
 
-Provider_9_KEY: |-
+Provider_8_KEY: |-
   Provider
 
-Avoid_US__UK_services_23_KEY: |-
+Avoid_US__UK_services_22_KEY: |-
   Avoid US & UK services
 
-Cloud_Storage_14_KEY: |-
-  Cloud Storage
-
-DNS_4_KEY: |-
+DNS_3_KEY: |-
   DNS
 
-Email_6_KEY: |-
+Email_5_KEY: |-
   Email
 
-Hosting_8_KEY: |-
+Hosting_7_KEY: |-
   Hosting
 
-Pastebins_10_KEY: |-
+Pastebins_9_KEY: |-
   Pastebins
 
-Search_Engines_15_KEY: |-
-  Search Engines
-
-Social_Networks_16_KEY: |-
-  Social Networks
-
-Social_News_Aggregators_24_KEY: |-
+Social_News_Aggregators_23_KEY: |-
   Social News Aggregators
 
-VPN_4_KEY: |-
+VPN_3_KEY: |-
   VPN
 
-Browser_8_KEY: |-
+Browser_7_KEY: |-
   Browser
 
-Recommendation_15_KEY: |-
+Recommendation_14_KEY: |-
   Recommendation
 
-Fingerprinting_Info_20_KEY: |-
+Fingerprinting_Info_19_KEY: |-
   Fingerprinting Info
 
-WebRTC_IP_Leak_15_KEY: |-
+WebRTC_IP_Leak_14_KEY: |-
   WebRTC IP Leak
 
-Browser_Addons_16_KEY: |-
+Browser_Addons_15_KEY: |-
   Browser Add-ons
 
-Firefox_Tweaks_15_KEY: |-
+Firefox_Tweaks_14_KEY: |-
   Firefox Tweaks
 
-Software_9_KEY: |-
+Software_8_KEY: |-
   Software
 
-CalendarContacts_Sync_Tools_29_KEY: |-
-  Calendar/Contacts Sync Tools
-
-Digital_Notebook_17_KEY: |-
+Digital_Notebook_16_KEY: |-
   Digital Notebook
 
-Email_Alternatives_19_KEY: |-
+Email_Alternatives_18_KEY: |-
   Email Alternatives
 
-Email_Clients_14_KEY: |-
-  Email Clients
-
-File_Encryption_16_KEY: |-
+File_Encryption_15_KEY: |-
   File Encryption
 
-File_Sharing_13_KEY: |-
-  File Sharing
-
-File_Sync_10_KEY: |-
-  File Sync
-
-Metadata_Removal_Tools_23_KEY: |-
+Metadata_Removal_Tools_22_KEY: |-
   Metadata Removal Tools
 
-Password_Manager_17_KEY: |-
+Password_Manager_16_KEY: |-
   Password Manager
 
-Productivity_Tools_19_KEY: |-
-  Productivity Tools
-
-RealTime_Communication_24_KEY: |-
-  Real-Time Communication
-
-Selfcontained_Networks_24_KEY: |-
+Selfcontained_Networks_23_KEY: |-
   Self-contained Networks
 
-SelfHosted_Cloud_Server_25_KEY: |-
+SelfHosted_Cloud_Server_24_KEY: |-
   Self-Hosted Cloud Server
 
-OS_3_KEY: |-
+OS_2_KEY: |-
   OS
 
-PC_OS_6_KEY: |-
+PC_OS_5_KEY: |-
   PC OS
 
-Live_CD_OS_11_KEY: |-
+Live_CD_OS_10_KEY: |-
   Live CD OS
 
-Mobile_OS_10_KEY: |-
+Mobile_OS_9_KEY: |-
   Mobile OS
 
-Android_Privacy_Addons_24_KEY: |-
+Android_Privacy_Addons_23_KEY: |-
   Android Privacy Add-ons
 
-Router_Firmware_16_KEY: |-
+Router_Firmware_15_KEY: |-
   Router Firmware
 
-Dont_use_Windows_10_21_KEY: |-
+Dont_use_Windows_10_20_KEY: |-
   Don't use Windows 10
 
-Participate_12_KEY: |-
+Participate_11_KEY: |-
   Participate
 
-Services_9_KEY: |-
+Services_8_KEY: |-
   Services
 
-Blog_5_KEY: |-
+Blog_4_KEY: |-
   Blog
 
-Sponsors_9_KEY: |-
+Sponsors_8_KEY: |-
   Sponsors
 
-About_Us_9_KEY: |-
+About_Us_8_KEY: |-
   About Us
 
-Theme_6_KEY: |-
+Theme_5_KEY: |-
   Theme
 
-Toggle_Theme_13_KEY: |-
+Toggle_Theme_12_KEY: |-
   Toggle Theme
 
-Language_9_KEY: |-
+Language_8_KEY: |-
   Language
 
-Language_Selection_19_KEY: |-
+Language_Selection_18_KEY: |-
   Language Selection
 
-You_are_being_watchedP_Private_and_statesponsored_organizations_are_monitoring_and_recording_your_online_activitiesP_118_KEY: |-
+You_are_being_watchedP_Private_and_statesponsored_organizations_are_monitoring_and_recording_your_online_activitiesP_117_KEY: |-
   You are being watched. Private and state-sponsored organizations are monitoring and recording your online activities.
 
-At_strongPrivacyToolsstrong_we_provide_services_tools_and_knowledge_to_protect_your_privacy_against_global_mass_surveillance_and_moderate_a_th_422_KEY: |-
+At_strongPrivacyToolsstrong_we_provide_services_tools_and_knowledge_to_protect_your_privacy_against_global_mass_surveillance_and_moderate_a_th_421_KEY: |-
   At <strong>PrivacyTools</strong>, we provide services, tools, and knowledge to protect your privacy against global mass surveillance, and moderate a thriving community of privacy-minded individuals like yourself to discuss and learn about new advances in protecting your online data. This website serves as the centerpiece of our organization, where we research and recommend various software solutions for our community.
 
 strongTransparencystrong_is_our_strongest_value_and_its_what_sets_us_apart_from_the_rest_of_the_privacy_recommendations_communityP_Editorial_c_1014_KEY: |-
@@ -311,7 +284,7 @@ Additionally_we_are_a_notforprofit_organizationP_We_do_not_utilize_paid_recommen
 We_take_the_operation_of_our_various_a_href_services__translate_page_servicesa_very_seriously_and_require_all_participants_to_adhere__440_KEY: |-
   We take the operation of our various <a href='{{ "/services/" | translate_page }}'>services</a> very seriously, and require all participants to adhere to our <a href="https://github.com/privacytoolsIO/.github/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a>. For any questions or to report abuse, please see our CoC’s <a href="https://github.com/privacytoolsIO/.github/blob/master/CODE_OF_CONDUCT.md#enforcement">Enforcement section</a>.
 
-Core_Contributors_18_KEY: |-
+Core_Contributors_17_KEY: |-
   Core Contributors
 
 Founder_7_KEY: |-
@@ -365,112 +338,112 @@ Im_the_moderator_at_rPrivacy_and_rprivacytoolsIOP_Day_to_day_I_am_also__iirony_a
 Of_course_we_couldnt_do_any_of_this_without_our_very_generous_a_hrefhttpsopencollectivePcomprivacytoolsiofinancial_contributorsa_a_hre_333_KEY: |-
   Of course, we couldn't do any of this without our very generous <a href="https://opencollective.com/privacytoolsio/">financial contributors</a>, <a href="https://github.com/privacytoolsIO/privacytools.io/graphs/contributors">website contributors</a>, and the countless community members that help share new ideas and spread the word!
 
-Thank_youP_11_KEY: |-
+Thank_youP_10_KEY: |-
   Thank you.
 
-Get_involvedE_14_KEY: |-
+Get_involvedE_13_KEY: |-
   Get involved!
 
-Donate_7_KEY: |-
+Donate_6_KEY: |-
   Donate
 
-Contact_Us_11_KEY: |-
+Contact_Us_10_KEY: |-
   Contact Us
 
-Its_very_important_to_us_to_stay_uptodate_on_the_latest_changes_in_the_privacy_spaceP_If_you_have_a_software_recommendation_for_us_or_want_to_reque_245_KEY: |-
+Its_very_important_to_us_to_stay_uptodate_on_the_latest_changes_in_the_privacy_spaceP_If_you_have_a_software_recommendation_for_us_or_want_to_reque_244_KEY: |-
   It's very important to us to stay up-to-date on the latest changes in the privacy space. If you have a software recommendation for us, or want to request a change on this website, please don't hesitate to reach out in one of the following ways.
 
-Start_a_discussion_in_our_Discourse_forum_42_KEY: |-
+Start_a_discussion_in_our_Discourse_forum_41_KEY: |-
   Start a discussion in our Discourse forum
 
-Open_an_issue_on_GitHub_24_KEY: |-
+Open_an_issue_on_GitHub_23_KEY: |-
   Open an issue on GitHub
 
-Suggest_something_new_on_our_subreddit_39_KEY: |-
+Suggest_something_new_on_our_subreddit_38_KEY: |-
   Suggest something new on our subreddit
 
-For_complete_transparency_software_and_providers_will_only_be_considered_for_this_website_after_discussions_take_place_on_our_GitHub_issue_trackerP_We_196_KEY: |-
+For_complete_transparency_software_and_providers_will_only_be_considered_for_this_website_after_discussions_take_place_on_our_GitHub_issue_trackerP_We_195_KEY: |-
   For complete transparency, software and providers will only be considered for this website after discussions take place on our GitHub issue tracker. We of course don't make any changes in secret.
 
-Join_our_Matrix_room_at_codegeneralprivacytoolsPiocode_or_join_the_a_hrefhttpskeybasePioteamprivacytools_ioprivacytools_io_Keybase_tea_400_KEY: |-
+Join_our_Matrix_room_at_codegeneralprivacytoolsPiocode_or_join_the_a_hrefhttpskeybasePioteamprivacytools_ioprivacytools_io_Keybase_tea_399_KEY: |-
   Join our Matrix room at <code>#general:privacytools.io</code> or join the <a href="https://keybase.io/team/privacytools_io">privacytools_io Keybase team</a> to chat with us and other members about this site and privacy in general! If you need a Matrix account, you can sign up with our own homeserver (<code>https://chat.privacytools.io</code>) using <a href="https://riot.privacytools.io">Riot</a>.
 
-Spread_the_word_and_help_your_friends_38_KEY: |-
+Spread_the_word_and_help_your_friends_37_KEY: |-
   Spread the word and help your friends
 
 privacytoolsPio__encryption_against_global_mass_surveillance_61_KEY: |-
   privacytools.io - encryption against global mass surveillance
 
-Facebook_9_KEY: |-
+Facebook_8_KEY: |-
   Facebook
 
 Knowledge_and_tools_to_protect_your_privacy_against_global_mass_surveillance_76_KEY: |-
   Knowledge and tools to protect your privacy against global mass surveillance
 
-Twitter_8_KEY: |-
+Twitter_7_KEY: |-
   Twitter
 
-Mastodon_9_KEY: |-
+Mastodon_8_KEY: |-
   Mastodon
 
-reddit_7_KEY: |-
+reddit_6_KEY: |-
   reddit
 
-LinkedIn_9_KEY: |-
+LinkedIn_8_KEY: |-
   LinkedIn
 
-Mix_4_KEY: |-
+Mix_3_KEY: |-
   Mix
 
-Diaspora_10_KEY: |-
+Diaspora_9_KEY: |-
   Diaspora*
 
-Copy_URL_and_Description_25_KEY: |-
+Copy_URL_and_Description_24_KEY: |-
   Copy URL and Description
 
-_sitePname___Encryption_and_tools_to_protect_against_global_mass_surveillance___sitePproduction_url__append_lang__uri_escape__138_KEY: |-
+_sitePname___Encryption_and_tools_to_protect_against_global_mass_surveillance___sitePproduction_url__append_lang__uri_escape__137_KEY: |-
   {{ site.name }} - Encryption and tools to protect against global mass surveillance - {{ site.production_url | append_lang | uri_escape }}
 
-For_easy_copy_and_pasteP_Share_this_text_snippetP_50_KEY: |-
+For_easy_copy_and_pasteP_Share_this_text_snippetP_49_KEY: |-
   For easy copy and paste. Share this text snippet.
 
 This_work_is_freeP_You_can_redistribute_it_andor_modify_it_under_the_terms_of_the_quotCreative_Commons_CC0_1P0_Universal_Public_Domain_Dedicationqu_155_KEY: |-
   This work is free. You can redistribute it and/or modify it under the terms of the &quot;Creative Commons CC0 1.0 Universal Public Domain Dedication&quot;.
 
-Contact_8_KEY: |-
+Contact_7_KEY: |-
   Contact
 
-Please_support_this_project_by_donatingP_We_are_adfree_and_not_affiliated_with_any_providersP_Your_donation_will_cover_our_costs_for_servers_and_domai_155_KEY: |-
+Please_support_this_project_by_donatingP_We_are_adfree_and_not_affiliated_with_any_providersP_Your_donation_will_cover_our_costs_for_servers_and_domai_154_KEY: |-
   Please support this project by donating. We are ad-free and not affiliated with any providers. Your donation will cover our costs for servers and domains.
 
-Support_UsE_12_KEY: |-
+Support_UsE_11_KEY: |-
   Support Us!
 
-JavaScript_Licenses_20_KEY: |-
+JavaScript_Licenses_19_KEY: |-
   JavaScript Licenses
 
-Translation_status_19_KEY: |-
+Translation_status_18_KEY: |-
   Translation status
 
 Help_translate_PrivacyTools_on_WeblateE_39_KEY: |-
   Help translate PrivacyTools on Weblate!
 
-NonEnglish_translated_versions_of_PrivacyTools_are_crowdsourced_and_provided_on_an_asis_basis_and_we_make_no_guarantees_towards_the_accuracy_of_ea_171_KEY: |-
+NonEnglish_translated_versions_of_PrivacyTools_are_crowdsourced_and_provided_on_an_asis_basis_and_we_make_no_guarantees_towards_the_accuracy_of_ea_170_KEY: |-
   Non-English (translated) versions of PrivacyTools are crowdsourced and provided on an as-is basis, and we make no guarantees towards the accuracy of each translated site.
 
 No_Ads_No_Google_Analytics_No_Affiliates_No_CrossSite_RequestsP_67_KEY: |-
   No Ads, No Google Analytics, No Affiliates, No Cross-Site Requests.
 
-_sitePname__is_a_socially_motivated_website_that_provides_information_for_protecting_your_data_security_and_privacyP_Never_trust_any_company_with_y_180_KEY: |-
+_sitePname__is_a_socially_motivated_website_that_provides_information_for_protecting_your_data_security_and_privacyP_Never_trust_any_company_with_y_179_KEY: |-
   {{ site.name }} is a socially motivated website that provides information for protecting your data security and privacy. Never trust any company with your privacy, always encrypt.
 
-View_our_privacy_statement_27_KEY: |-
+View_our_privacy_statement_26_KEY: |-
   View our privacy statement
 
-Learn_More_11_KEY: |-
+Learn_More_10_KEY: |-
   Learn More
 
-Browser_Recommendations_For_Desktop_36_KEY: |-
+Browser_Recommendations_For_Desktop_35_KEY: |-
   Browser Recommendations For Desktop
 
 Firefox_7_KEY: |-
@@ -482,10 +455,10 @@ Firefox_is_fast_reliable_opensource_and_respects_your_privacyP_Dont_forget_to_ad
 httpsfirefoxPcom_19_KEY: |-
   https://firefox.com
 
-Website_8_KEY: |-
+Website_7_KEY: |-
   Website
 
-Forum_6_KEY: |-
+Forum_5_KEY: |-
   Forum
 
 httpswwwPmozillaPorgfirefoxwindows_40_KEY: |-
@@ -518,7 +491,7 @@ Tor_Browser_is_your_choice_if_you_need_an_extra_layer_of_anonymityP_Its_a_modifi
 httpswwwPtorprojectPorg_27_KEY: |-
   https://www.torproject.org/
 
-Requires_specific_software_to_access_torprojectPorg_53_KEY: |-
+Requires_specific_software_to_access_torprojectPorg_52_KEY: |-
   Requires specific software to access: torproject.org
 
 httpswwwPtorprojectPorgdownload_36_KEY: |-
@@ -527,7 +500,7 @@ httpswwwPtorprojectPorgdownload_36_KEY: |-
 httpstracPtorprojectPorgprojectstor_40_KEY: |-
   https://trac.torproject.org/projects/tor
 
-Browser_Recommendations_For_Android_36_KEY: |-
+Browser_Recommendations_For_Android_35_KEY: |-
   Browser Recommendations For Android
 
 httpswwwPmozillaPorgenUSfirefoxmobile_45_KEY: |-
@@ -578,28 +551,28 @@ httpswwwPbromitePorgdownloadbromite_41_KEY: |-
 httpsgithubPcombromitebromite_34_KEY: |-
   https://github.com/bromite/bromite
 
-Worth_Mentioning_for_Android_29_KEY: |-
+Worth_Mentioning_for_Android_28_KEY: |-
   Worth Mentioning for Android
 
-httpswwwPstoutnerPcomprivacybrowser_42_KEY: |-
+httpswwwPstoutnerPcomprivacybrowser_41_KEY: |-
   https://www.stoutner.com/privacy-browser/
 
-Privacy_Browser_16_KEY: |-
+Privacy_Browser_15_KEY: |-
   Privacy Browser
 
-An_opensource_web_browser_focused_on_user_privacyP_Features_include_integrated_ad_blocking_with_a_hrefhttpseasylistPtoEasyLista_a_href_307_KEY: |-
+An_opensource_web_browser_focused_on_user_privacyP_Features_include_integrated_ad_blocking_with_a_hrefhttpseasylistPtoEasyLista_a_href_306_KEY: |-
   An open-source web browser focused on user privacy. Features include integrated ad blocking with <a href="https://easylist.to/">EasyList</a>, <a href="https://www.stoutner.com/privacy-browser-2-5/">SSL certificate pinning</a>, and <a href='https://guardianproject.info/apps/orbot/'>Tor Orbot proxy support.
 
-httpsplayPgooglePcomstoreappsdetailsQidcomPgooglePandroidPwebviewhlen_US_82_KEY: |-
+httpsplayPgooglePcomstoreappsdetailsQidcomPgooglePandroidPwebviewhlen_US_81_KEY: |-
   https://play.google.com/store/apps/details?id=com.google.android.webview&hl=en_US
 
-Privacy_Browser_relies_on_the_Android_System_WebView_which_needs_to_be_kept_up_to_date_to_fix_security_issuesP_One_can_update_WebView_by_either_install_223_KEY: |-
+Privacy_Browser_relies_on_the_Android_System_WebView_which_needs_to_be_kept_up_to_date_to_fix_security_issuesP_One_can_update_WebView_by_either_install_222_KEY: |-
   Privacy Browser relies on the Android System WebView which needs to be kept up to date to fix security issues. One can update WebView by either installing it from Google Play or Aurora Store which you can get from F-Droid.
 
-Keep_Android_WebView_uptodate_32_KEY: |-
+Keep_Android_WebView_uptodate_31_KEY: |-
   Keep Android WebView up-to-date
 
-Browser_Recommendations_For_iOS_32_KEY: |-
+Browser_Recommendations_For_iOS_31_KEY: |-
   Browser Recommendations For iOS
 
 Firefox_is_fast_reliable_opensource_and_respects_your_privacyP_Note_Because_of_limitations_set_by_Apple_in_iOS_our_recommended_tweaks_cannot_be_a_515_KEY: |-
@@ -641,133 +614,133 @@ httpsappsPapplePcomusappduckduckgoprivacybrowserid663592361_68_KEY: |-
 httpsgithubPcomduckduckgoiOS_33_KEY: |-
   https://github.com/duckduckgo/iOS
 
-Worth_Mentioning_for_iOS_25_KEY: |-
+Worth_Mentioning_for_iOS_24_KEY: |-
   Worth Mentioning for iOS
 
-httpssnowhazePcomenindexPhtml_35_KEY: |-
+httpssnowhazePcomenindexPhtml_34_KEY: |-
   https://snowhaze.com/en/index.html
 
-SnowHaze_9_KEY: |-
+SnowHaze_8_KEY: |-
   SnowHaze
 
-An_opensource_web_browser_with_builtin_ad_tracker_cookie_and_fingerprint_blocking_all_customizable_on_a_persite_basisP_126_KEY: |-
+An_opensource_web_browser_with_builtin_ad_tracker_cookie_and_fingerprint_blocking_all_customizable_on_a_persite_basisP_125_KEY: |-
   An open-source web browser with built-in ad, tracker, cookie, and fingerprint blocking, all customizable on a per-site basis.
 
-Browser_Fingerprint__Is_your_browser_configuration_uniqueQ_60_KEY: |-
+Browser_Fingerprint__Is_your_browser_configuration_uniqueQ_59_KEY: |-
   Browser Fingerprint - Is your browser configuration unique?
 
-Your_Browser_sends_information_that_makes_you_unique_amongst_millions_of_users_and_therefore_easy_to_identifyP_111_KEY: |-
+Your_Browser_sends_information_that_makes_you_unique_amongst_millions_of_users_and_therefore_easy_to_identifyP_110_KEY: |-
   Your Browser sends information that makes you unique amongst millions of users and therefore easy to identify.
 
-When_you_visit_a_web_page_your_browser_voluntarily_sends_information_about_its_configuration_such_as_available_fonts_browser_type_and_addonsP_If_t_390_KEY: |-
+When_you_visit_a_web_page_your_browser_voluntarily_sends_information_about_its_configuration_such_as_available_fonts_browser_type_and_addonsP_If_t_389_KEY: |-
   When you visit a web page, your browser voluntarily sends information about its configuration, such as available fonts, browser type, and add-ons. If this combination of information is unique, it may be possible to identify and track you without using cookies. EFF created a Tool called <a href="https://panopticlick.eff.org/">Panopticlick</a> to test your browser to see how unique it is.
 
-httpspanopticlickPeffPorg_30_KEY: |-
+httpspanopticlickPeffPorg_29_KEY: |-
   https://panopticlick.eff.org/
 
-Test_your_Browser_now_22_KEY: |-
+Test_your_Browser_now_21_KEY: |-
   Test your Browser now
 
-You_need_to_find_what_strongmost_browsersstrong_are_reporting_and_then_use_those_variables_to_bring_your_browser_in_the_same_populationP_This_mea_650_KEY: |-
+You_need_to_find_what_strongmost_browsersstrong_are_reporting_and_then_use_those_variables_to_bring_your_browser_in_the_same_populationP_This_mea_649_KEY: |-
   You need to find what <strong>most browsers</strong> are reporting, and then use those variables to bring your browser in the same population. This means having the same fonts, plugins, and extensions installed as the large installed base. You should have a <a href="https://addons.mozilla.org/firefox/addon/uaswitcher/">spoofed user-agent string</a> to match what the large userbase has. You need to have the same settings enabled and disabled, such as DNT and WebGL. You need your browser to look as common as everyone else. Disabling JavaScript, using Linux, or even using the Tor Browser Bundle, will make your browser stick out from the masses.
 
-Modern_web_browsers_have_not_been_architected_to_assure_personal_web_privacyP_Rather_than_worrying_about_being_fingerprinted_it_seems_more_practical_t_417_KEY: |-
+Modern_web_browsers_have_not_been_architected_to_assure_personal_web_privacyP_Rather_than_worrying_about_being_fingerprinted_it_seems_more_practical_t_416_KEY: |-
   Modern web browsers have not been architected to assure personal web privacy. Rather than worrying about being fingerprinted, it seems more practical to use <a href="#addons"><i class="fas fa-link"></i> free software plugins</a> like Privacy Badger and uBlock Origin. They not only respect your freedom, but your privacy also. You can get much further with these than trying to manipulate your browser's fingerprint.
 
-Firefox_Addon_CanvasBlocker_29_KEY: |-
+Firefox_Addon_CanvasBlocker_28_KEY: |-
   Firefox Addon: CanvasBlocker
 
-httpsaddonsPmozillaPorgfirefoxaddoncanvasblocker_56_KEY: |-
+httpsaddonsPmozillaPorgfirefoxaddoncanvasblocker_55_KEY: |-
   https://addons.mozilla.org/firefox/addon/canvasblocker/
 
-addonsPmozillaPorg_19_KEY: |-
+addonsPmozillaPorg_18_KEY: |-
   addons.mozilla.org
 
-strongCanvasBlockerstrong_allows_users_to_prevent_websites_from_using_some_Javascript_APIs_to_fingerprint_themP_Users_can_choose_to_block_the_APIs_280_KEY: |-
+strongCanvasBlockerstrong_allows_users_to_prevent_websites_from_using_some_Javascript_APIs_to_fingerprint_themP_Users_can_choose_to_block_the_APIs_279_KEY: |-
   <strong>CanvasBlocker</strong> allows users to prevent websites from using some Javascript APIs to fingerprint them. Users can choose to block the APIs entirely on some or all websites (which may break some websites) or just block or fake its fingerprinting-friendly readout API.
 
-Related_Information_20_KEY: |-
+Related_Information_19_KEY: |-
   Related Information
 
-httpspanopticlickPeffPorgstaticbrowseruniquenessPpdf_59_KEY: |-
+httpspanopticlickPeffPorgstaticbrowseruniquenessPpdf_58_KEY: |-
   https://panopticlick.eff.org/static/browser-uniqueness.pdf
 
-How_Unique_Is_Your_Web_BrowserQ_Peter_Eckersley_EFFP_54_KEY: |-
+How_Unique_Is_Your_Web_BrowserQ_Peter_Eckersley_EFFP_53_KEY: |-
   How Unique Is Your Web Browser? Peter Eckersley, EFF.
 
-Our_Firefox_privacy_addons_sectionP_37_KEY: |-
+Our_Firefox_privacy_addons_sectionP_36_KEY: |-
   Our Firefox privacy add-ons section.
 
-httpswwwPbrowserleaksPcom_30_KEY: |-
+httpswwwPbrowserleaksPcom_29_KEY: |-
   https://www.browserleaks.com/
 
 Web_browser_security_testing_tools_that_tell_you_what_exactly_personal_identity_data_may_be_leaked_without_any_permissions_when_you_surf_the_InternetP_150_KEY: |-
   Web browser security testing tools that tell you what exactly personal identity data may be leaked without any permissions when you surf the Internet.
 
-WebRTC_IP_Leak_Test__Is_your_IP_address_leakingQ_50_KEY: |-
+WebRTC_IP_Leak_Test__Is_your_IP_address_leakingQ_49_KEY: |-
   WebRTC IP Leak Test - Is your IP address leaking?
 
-WebRTC_is_a_new_communication_protocol_that_relies_on_JavaScript_that_can_leak_your_actual_IP_address_from_behind_your_VPNP_124_KEY: |-
+WebRTC_is_a_new_communication_protocol_that_relies_on_JavaScript_that_can_leak_your_actual_IP_address_from_behind_your_VPNP_123_KEY: |-
   WebRTC is a new communication protocol that relies on JavaScript that can leak your actual IP address from behind your VPN.
 
-While_software_like_NoScript_prevents_this_its_probably_a_good_idea_to_block_this_protocol_directly_as_well_just_to_be_safeP_128_KEY: |-
+While_software_like_NoScript_prevents_this_its_probably_a_good_idea_to_block_this_protocol_directly_as_well_just_to_be_safeP_127_KEY: |-
   While software like NoScript prevents this, it's probably a good idea to block this protocol directly as well, just to be safe.
 
-httpsipleakPnet_19_KEY: |-
+httpsipleakPnet_18_KEY: |-
   https://ipleak.net
 
-How_to_disable_WebRTC_in_FirefoxQ_34_KEY: |-
+How_to_disable_WebRTC_in_FirefoxQ_33_KEY: |-
   How to disable WebRTC in Firefox?
 
 In_short_Set_mediaPpeerconnectionPenabled_to_false_in_aboutconfigP_74_KEY: |-
   In short: Set "media.peerconnection.enabled" to "false" in "about:config".
 
-Explained_11_KEY: |-
+Explained_10_KEY: |-
   Explained:
 
-Enter_aboutconfig_in_the_firefox_address_bar_and_press_enterP_65_KEY: |-
+Enter_aboutconfig_in_the_firefox_address_bar_and_press_enterP_64_KEY: |-
   Enter "about:config" in the firefox address bar and press enter.
 
-Press_the_button_Ill_be_careful_I_promiseE_47_KEY: |-
+Press_the_button_Ill_be_careful_I_promiseE_46_KEY: |-
   Press the button "I'll be careful, I promise!"
 
-Search_for_mediaPpeerconnectionPenabled_42_KEY: |-
+Search_for_mediaPpeerconnectionPenabled_41_KEY: |-
   Search for "media.peerconnection.enabled"
 
-Double_click_the_entry_the_column_Value_should_now_be_false_65_KEY: |-
+Double_click_the_entry_the_column_Value_should_now_be_false_64_KEY: |-
   Double click the entry, the column "Value" should now be "false"
 
-DoneP_Do_the_WebRTC_leak_test_againP_37_KEY: |-
+DoneP_Do_the_WebRTC_leak_test_againP_36_KEY: |-
   Done. Do the WebRTC leak test again.
 
-If_you_want_to_make_sure_every_single_WebRTCrelated_setting_is_really_disabled_change_these_settings_104_KEY: |-
+If_you_want_to_make_sure_every_single_WebRTCrelated_setting_is_really_disabled_change_these_settings_103_KEY: |-
   If you want to make sure every single WebRTC-related setting is really disabled, change these settings:
 
-Now_you_can_be_100_sure_WebRTC_is_disabledP_45_KEY: |-
+Now_you_can_be_100_sure_WebRTC_is_disabledP_44_KEY: |-
   Now you can be 100% sure WebRTC is disabled.
 
-Test_your_Browser_again_24_KEY: |-
+Test_your_Browser_again_23_KEY: |-
   Test your Browser again
 
-How_to_fix_the_WebRTC_Leak_in_Google_ChromeQ_45_KEY: |-
+How_to_fix_the_WebRTC_Leak_in_Google_ChromeQ_44_KEY: |-
   How to fix the WebRTC Leak in Google Chrome?
 
 WebRTC_cannot_be_fully_disabled_in_Chrome_however_it_is_possible_to_change_its_routing_settings_and_prevent_leaks_using_an_extensionP_Two_opensour_552_KEY: |-
   WebRTC cannot be fully disabled in Chrome; however, it is possible to change its routing settings (and prevent leaks) using an extension. Two open-source solutions include <a href="https://chrome.google.com/webstore/detail/webrtc-leak-prevent/eiadekoaikejlgdbkbdfeijglgfdalml">WebRTC Leak Prevent</a> (options may need to be changed depending on the scenario), and <a href="https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm">uBlock Origin</a> (select "Prevent WebRTC from leaking local IP addresses" in Settings).
 
-What_about_other_browsersQ_27_KEY: |-
+What_about_other_browsersQ_26_KEY: |-
   What about other browsers?
 
 Chrome_on_iOS_Internet_Explorer_and_Safari_does_not_implement_WebRTC_yetP_74_KEY: |-
   Chrome on iOS, Internet Explorer and Safari does not implement WebRTC yet.
 
-But_we_recommend_using_Firefox_on_all_devicesP_47_KEY: |-
+But_we_recommend_using_Firefox_on_all_devicesP_46_KEY: |-
   But we recommend using Firefox on all devices.
 
-Recommended_Browser_Addons_28_KEY: |-
+Recommended_Browser_Addons_27_KEY: |-
   Recommended Browser Add-ons
 
-Improve_your_privacy_with_these_browser_addonsP_49_KEY: |-
+Improve_your_privacy_with_these_browser_addonsP_48_KEY: |-
   Improve your privacy with these browser add-ons.
 
 uBlock_Origin_Block_Ads_and_Trackers_37_KEY: |-
@@ -914,10 +887,10 @@ httpsaddonsPoperaPcomenextensionsdetailsprivacybadger_62_KEY: |-
 httpsgithubPcomEFForgprivacybadger_39_KEY: |-
   https://github.com/EFForg/privacybadger
 
-For_Power_Users_Only_21_KEY: |-
+For_Power_Users_Only_20_KEY: |-
   For Power Users Only
 
-These_addons_require_quite_a_lot_of_interaction_from_the_userP_Some_sites_will_not_work_properly_until_you_have_configured_the_addonsP_136_KEY: |-
+These_addons_require_quite_a_lot_of_interaction_from_the_userP_Some_sites_will_not_work_properly_until_you_have_configured_the_addonsP_135_KEY: |-
   These addons require quite a lot of interaction from the user. Some sites will not work properly until you have configured the add-ons.
 
 uMatrix_Stop_CrossSite_Requests_33_KEY: |-
@@ -959,40 +932,40 @@ httpschromePgooglePcomwebstoredetailnoscriptdoojmbjmlfjjnbmnoijecmcbfeoakpjm_83_
 httpsgithubPcomhackademixnoscript_38_KEY: |-
   https://github.com/hackademix/noscript
 
-Firefox_Privacy_Related_aboutconfig_Tweaks_47_KEY: |-
+Firefox_Privacy_Related_aboutconfig_Tweaks_46_KEY: |-
   Firefox: Privacy Related "about:config" Tweaks
 
-This_is_a_collection_of_privacyrelated_strongaboutconfigstrong_tweaksP_Well_show_you_how_to_enhance_the_privacy_of_your_Firefox_browserP_145_KEY: |-
+This_is_a_collection_of_privacyrelated_strongaboutconfigstrong_tweaksP_Well_show_you_how_to_enhance_the_privacy_of_your_Firefox_browserP_144_KEY: |-
   This is a collection of privacy-related <strong>about:config</strong> tweaks. We'll show you how to enhance the privacy of your Firefox browser.
 
-Preparation_13_KEY: |-
+Preparation_12_KEY: |-
   Preparation:
 
-Follow_the_instructions_belowPPP_33_KEY: |-
+Follow_the_instructions_belowPPP_32_KEY: |-
   Follow the instructions below...
 
-Getting_started_17_KEY: |-
+Getting_started_16_KEY: |-
   Getting started:
 
-A_result_of_the_a_hrefhttpswikiPmozillaPorgSecurityTor_UpliftTor_Uplifta_effort_this_preference_isolates_all_browser_identifier_sources__353_KEY: |-
+A_result_of_the_a_hrefhttpswikiPmozillaPorgSecurityTor_UpliftTor_Uplifta_effort_this_preference_isolates_all_browser_identifier_sources__352_KEY: |-
   A result of the <a href="https://wiki.mozilla.org/Security/Tor_Uplift">Tor Uplift</a> effort, this preference isolates all browser identifier sources (e.g. cookies) to the first party domain, with the goal of preventing tracking across different domains. (Don't do this if you are using the Firefox Addon "Cookie AutoDelete" with Firefox v58 or below.)
 
-A_result_of_the_a_hrefhttpswikiPmozillaPorgSecurityTor_UpliftTor_Uplifta_effort_this_preference_makes_Firefox_more_resistant_to_browser_f_166_KEY: |-
+A_result_of_the_a_hrefhttpswikiPmozillaPorgSecurityTor_UpliftTor_Uplifta_effort_this_preference_makes_Firefox_more_resistant_to_browser_f_165_KEY: |-
   A result of the <a href="https://wiki.mozilla.org/Security/Tor_Uplift">Tor Uplift</a> effort, this preference makes Firefox more resistant to browser fingerprinting.
 
-FF67_Blocks_Fingerprinting_30_KEY: |-
+FF67_Blocks_Fingerprinting_29_KEY: |-
   [FF67+] Blocks Fingerprinting
 
-FF67_Blocks_CryptoMining_28_KEY: |-
+FF67_Blocks_CryptoMining_27_KEY: |-
   [FF67+] Blocks CryptoMining
 
-This_is_Mozillas_new_builtin_tracking_protectionP_It_uses_DisconnectPme_filter_list_which_is_redundant_if_you_are_already_using_uBlock_Origin_3rd_pa_246_KEY: |-
+This_is_Mozillas_new_builtin_tracking_protectionP_It_uses_DisconnectPme_filter_list_which_is_redundant_if_you_are_already_using_uBlock_Origin_3rd_pa_245_KEY: |-
   This is Mozilla's new built-in tracking protection. It uses Disconnect.me filter list, which is redundant if you are already using uBlock Origin 3rd party filters, therefore you should set it to false if you are using the add-on functionalities.
 
-The_attribute_would_be_useful_for_letting_websites_track_visitors_clicksP_75_KEY: |-
+The_attribute_would_be_useful_for_letting_websites_track_visitors_clicksP_74_KEY: |-
   The attribute would be useful for letting websites track visitors' clicks.
 
-Even_with_Firefox_set_to_not_remember_history_your_closed_tabs_are_stored_temporarily_at_Menu_gt_History_gt_Recently_Closed_TabsP_137_KEY: |-
+Even_with_Firefox_set_to_not_remember_history_your_closed_tabs_are_stored_temporarily_at_Menu_gt_History_gt_Recently_Closed_TabsP_136_KEY: |-
   Even with Firefox set to not remember history, your closed tabs are stored temporarily at Menu -&gt; History -&gt; Recently Closed Tabs.
 
 Disable_preloading_of_autocomplete_URLsP_Firefox_preloads_URLs_that_autocomplete_when_a_user_types_into_the_address_bar_which_is_a_concern_if_URLs_are_204_KEY: |-
@@ -1001,166 +974,166 @@ Disable_preloading_of_autocomplete_URLsP_Firefox_preloads_URLs_that_autocomplete
 httpswwwPghacksPnet20170724disablepreloadingfirefoxautocompleteurls_79_KEY: |-
   https://www.ghacks.net/2017/07/24/disable-preloading-firefox-autocomplete-urls/
 
-Source_7_KEY: |-
+Source_6_KEY: |-
   Source
 
-Disable_that_websites_can_get_notifications_if_you_copy_paste_or_cut_something_from_a_web_page_and_it_lets_them_know_which_part_of_the_page_had_been_162_KEY: |-
+Disable_that_websites_can_get_notifications_if_you_copy_paste_or_cut_something_from_a_web_page_and_it_lets_them_know_which_part_of_the_page_had_been_161_KEY: |-
   Disable that websites can get notifications if you copy, paste, or cut something from a web page, and it lets them know which part of the page had been selected.
 
 Disables_playback_of_DRMcontrolled_HTML5_content_which_if_enabled_automatically_downloads_the_Widevine_Content_Decryption_Module_provided_by_Google_156_KEY: |-
   Disables playback of DRM-controlled HTML5 content, which, if enabled, automatically downloads the Widevine Content Decryption Module provided by Google Inc.
 
-httpssupportPmozillaPorgkbenabledrmw_optoutofcdmplaybackuninstallcdmsandstopallcdmdownloads_110_KEY: |-
+httpssupportPmozillaPorgkbenabledrmw_optoutofcdmplaybackuninstallcdmsandstopallcdmdownloads_109_KEY: |-
   https://support.mozilla.org/kb/enable-drm#w_opt-out-of-cdm-playback-uninstall-cdms-and-stop-all-cdm-downloads
 
-Details_8_KEY: |-
+Details_7_KEY: |-
   Details
 
-DRMcontrolled_content_that_requires_the_Adobe_Flash_or_Microsoft_Silverlight_NPAPI_plugins_will_still_play_if_installed_and_enabled_in_FirefoxP_146_KEY: |-
+DRMcontrolled_content_that_requires_the_Adobe_Flash_or_Microsoft_Silverlight_NPAPI_plugins_will_still_play_if_installed_and_enabled_in_FirefoxP_145_KEY: |-
   DRM-controlled content that requires the Adobe Flash or Microsoft Silverlight NPAPI plugins will still play, if installed and enabled in Firefox.
 
 Disables_the_Widevine_Content_Decryption_Module_provided_by_Google_IncP_used_for_the_playback_of_DRMcontrolled_HTML5_contentP_127_KEY: |-
   Disables the Widevine Content Decryption Module provided by Google Inc., used for the playback of DRM-controlled HTML5 content.
 
-httpssupportPmozillaPorgkbenabledrmw_disablethegooglewidevinecdmwithoutuninstalling_97_KEY: |-
+httpssupportPmozillaPorgkbenabledrmw_disablethegooglewidevinecdmwithoutuninstalling_96_KEY: |-
   https://support.mozilla.org/kb/enable-drm#w_disable-the-google-widevine-cdm-without-uninstalling
 
-Websites_can_track_the_microphone_and_camera_status_of_your_deviceP_68_KEY: |-
+Websites_can_track_the_microphone_and_camera_status_of_your_deviceP_67_KEY: |-
   Websites can track the microphone and camera status of your device.
 
-Disable_cookies_16_KEY: |-
+Disable_cookies_15_KEY: |-
   Disable cookies
 
-Accept_all_cookies_by_default_30_KEY: |-
+Accept_all_cookies_by_default_29_KEY: |-
   Accept all cookies by default
 
-Only_accept_from_the_originating_site_block_thirdparty_cookies_66_KEY: |-
+Only_accept_from_the_originating_site_block_thirdparty_cookies_65_KEY: |-
   Only accept from the originating site (block third-party cookies)
 
-Block_all_cookies_by_default_29_KEY: |-
+Block_all_cookies_by_default_28_KEY: |-
   Block all cookies by default
 
 Only_send_codeReferercode_header_when_the_full_hostnames_matchP_Note_if_you_notice_significant_breakage_you_might_try_code1code_combined_w_206_KEY: |-
   Only send <code>Referer</code> header when the full hostnames match. (Note: if you notice significant breakage, you might try <code>1</code> combined with an <code>XOriginTrimmingPolicy</code> tweak below.)
 
-httpsfeedingPcloudPgeekPnzpoststweakingreferrerforprivacyinfirefox_78_KEY: |-
+httpsfeedingPcloudPgeekPnzpoststweakingreferrerforprivacyinfirefox_77_KEY: |-
   https://feeding.cloud.geek.nz/posts/tweaking-referrer-for-privacy-in-firefox/
 
-Send_codeReferercode_in_all_cases_39_KEY: |-
+Send_codeReferercode_in_all_cases_38_KEY: |-
   Send <code>Referer</code> in all cases
 
-Send_codeReferercode_to_same_eTLD_sites_45_KEY: |-
+Send_codeReferercode_to_same_eTLD_sites_44_KEY: |-
   Send <code>Referer</code> to same eTLD sites
 
-Send_codeReferercode_only_when_the_full_hostnames_match_61_KEY: |-
+Send_codeReferercode_only_when_the_full_hostnames_match_60_KEY: |-
   Send <code>Referer</code> only when the full hostnames match
 
 When_sending_codeReferercode_across_origins_only_send_scheme_host_and_port_in_the_codeReferercode_header_of_crossorigin_requestsP_143_KEY: |-
   When sending <code>Referer</code> across origins, only send scheme, host, and port in the <code>Referer</code> header of cross-origin requests.
 
-Send_full_url_in_codeReferercode_38_KEY: |-
+Send_full_url_in_codeReferercode_37_KEY: |-
   Send full url in <code>Referer</code>
 
-Send_url_without_query_string_in_codeReferercode_54_KEY: |-
+Send_url_without_query_string_in_codeReferercode_53_KEY: |-
   Send url without query string in <code>Referer</code>
 
-Only_send_scheme_host_and_port_in_codeReferercode_57_KEY: |-
+Only_send_scheme_host_and_port_in_codeReferercode_56_KEY: |-
   Only send scheme, host, and port in <code>Referer</code>
 
-Looking_for_TRR_DoH_or_ESNIQ_30_KEY: |-
+Looking_for_TRR_DoH_or_ESNIQ_29_KEY: |-
   Looking for TRR, DoH or ESNI?
 
-They_have_moved_to_a_href_providersdnsicanndns__translate_page_our_DNS_pageaP_97_KEY: |-
+They_have_moved_to_a_href_providersdnsicanndns__translate_page_our_DNS_pageaP_96_KEY: |-
   They have moved to <a href="{{ '/providers/dns/#icanndns' | translate_page }}">our DNS page</a>.
 
 WebGL_is_a_potential_security_riskP_35_KEY: |-
   WebGL is a potential security risk.
 
-httpssecurityPstackexchangePcomquestions13799iswebglasecurityconcern_79_KEY: |-
+httpssecurityPstackexchangePcomquestions13799iswebglasecurityconcern_78_KEY: |-
   https://security.stackexchange.com/questions/13799/is-webgl-a-security-concern
 
 This_preference_controls_when_to_store_extra_information_about_a_session_contents_of_forms_scrollbar_positions_cookies_and_POST_dataP_137_KEY: |-
   This preference controls when to store extra information about a session: contents of forms, scrollbar positions, cookies, and POST data.
 
-httpkbPmozillazinePorgBrowserPsessionstorePprivacy_level_61_KEY: |-
+httpkbPmozillazinePorgBrowserPsessionstorePprivacy_level_60_KEY: |-
   http://kb.mozillazine.org/Browser.sessionstore.privacy_level
 
-Store_extra_session_data_for_any_siteP_Default_starting_with_Firefox_4P_74_KEY: |-
+Store_extra_session_data_for_any_siteP_Default_starting_with_Firefox_4P_73_KEY: |-
   Store extra session data for any site. (Default starting with Firefox 4.)
 
-Store_extra_session_data_for_unencrypted_nonHTTPS_sites_onlyP_Default_before_Firefox_4P_93_KEY: |-
+Store_extra_session_data_for_unencrypted_nonHTTPS_sites_onlyP_Default_before_Firefox_4P_92_KEY: |-
   Store extra session data for unencrypted (non-HTTPS) sites only. (Default before Firefox 4.)
 
-Never_store_extra_session_dataP_32_KEY: |-
+Never_store_extra_session_dataP_31_KEY: |-
   Never store extra session data.
 
 Not_rendering_IDNs_as_their_Punycode_equivalent_leaves_you_open_to_phishing_attacks_that_can_be_very_difficult_to_noticeP_121_KEY: |-
   Not rendering IDNs as their Punycode equivalent leaves you open to phishing attacks that can be very difficult to notice.
 
-httpskrebsonsecurityPcom201803lookalikedomainsandvisualconfusionmore42636_88_KEY: |-
+httpskrebsonsecurityPcom201803lookalikedomainsandvisualconfusionmore42636_87_KEY: |-
   https://krebsonsecurity.com/2018/03/look-alike-domains-and-visual-confusion/#more-42636
 
-Firefox_userPjs_Templates_26_KEY: |-
+Firefox_userPjs_Templates_25_KEY: |-
   Firefox user.js Templates
 
-httpsgithubPcomghacksuserjsghacksuserPjs_47_KEY: |-
+httpsgithubPcomghacksuserjsghacksuserPjs_46_KEY: |-
   https://github.com/ghacksuserjs/ghacks-user.js
 
-ghacksuserPjs_15_KEY: |-
+ghacksuserPjs_14_KEY: |-
   ghacks-user.js
 
-An_ongoing_comprehensive_userPjs_template_for_configuring_and_hardening_Firefox_privacy_security_and_antifingerprintingP_123_KEY: |-
+An_ongoing_comprehensive_userPjs_template_for_configuring_and_hardening_Firefox_privacy_security_and_antifingerprintingP_122_KEY: |-
   An ongoing comprehensive user.js template for configuring and hardening Firefox privacy, security and anti-fingerprinting.
 
-httpsblogPprivacytoolsPiofirefoxprivacyanintroductiontosafe_70_KEY: |-
+httpsblogPprivacytoolsPiofirefoxprivacyanintroductiontosafe_69_KEY: |-
   https://blog.privacytools.io/firefox-privacy-an-introduction-to-safe/
 
-Firefox_Privacy_Tips_and_Tricks_for_Better_Browsing_53_KEY: |-
+Firefox_Privacy_Tips_and_Tricks_for_Better_Browsing_52_KEY: |-
   Firefox Privacy: Tips and Tricks for Better Browsing
 
-A_good_starting_guide_for_users_looking_to_keep_their_data_private_and_secureP_79_KEY: |-
+A_good_starting_guide_for_users_looking_to_keep_their_data_private_and_secureP_78_KEY: |-
   A good starting guide for users looking to keep their data private and secure.
 
-httpsffprofilePcom_23_KEY: |-
+httpsffprofilePcom_22_KEY: |-
   https://ffprofile.com/
 
-ffprofilePcom_14_KEY: |-
+ffprofilePcom_13_KEY: |-
   ffprofile.com
 
-Helps_you_to_create_a_Firefox_profile_with_the_defaults_you_likeP_66_KEY: |-
+Helps_you_to_create_a_Firefox_profile_with_the_defaults_you_likeP_65_KEY: |-
   Helps you to create a Firefox profile with the defaults you like.
 
-httpkbPmozillazinePorgCategorySecurity_and_privacyrelated_preferences_76_KEY: |-
+httpkbPmozillazinePorgCategorySecurity_and_privacyrelated_preferences_75_KEY: |-
   http://kb.mozillazine.org/Category:Security_and_privacy-related_preferences
 
-mozillazinePorg_16_KEY: |-
+mozillazinePorg_15_KEY: |-
   mozillazine.org
 
-Security_and_privacyrelated_preferencesP_43_KEY: |-
+Security_and_privacyrelated_preferencesP_41_KEY: |-
   Security and privacy-related preferences.
 
-httpsaddonsPmozillaPorgfirefoxaddonprivacysettings_59_KEY: |-
+httpsaddonsPmozillaPorgfirefoxaddonprivacysettings_58_KEY: |-
   https://addons.mozilla.org/firefox/addon/privacy-settings/
 
-Privacy_Settings_17_KEY: |-
+Privacy_Settings_16_KEY: |-
   Privacy Settings
 
-A_Firefox_addon_to_alter_builtin_privacy_settings_easily_with_a_toolbar_panelP_81_KEY: |-
+A_Firefox_addon_to_alter_builtin_privacy_settings_easily_with_a_toolbar_panelP_80_KEY: |-
   A Firefox add-on to alter built-in privacy settings easily with a toolbar panel.
 
-https12bytesPorgarticlestechfirefoxthefirefoxprivacyguidefordummies_81_KEY: |-
+https12bytesPorgarticlestechfirefoxthefirefoxprivacyguidefordummies_80_KEY: |-
   https://12bytes.org/articles/tech/firefox/the-firefox-privacy-guide-for-dummies/
 
-Firefox_Privacy_Guide_For_Dummies_34_KEY: |-
+Firefox_Privacy_Guide_For_Dummies_33_KEY: |-
   Firefox Privacy Guide For Dummies
 
-Guide_on_ways_already_discussed_and_others_to_improve_your_privacy_and_safety_on_FirefoxP_92_KEY: |-
+Guide_on_ways_already_discussed_and_others_to_improve_your_privacy_and_safety_on_FirefoxP_91_KEY: |-
   Guide on ways (already discussed and others) to improve your privacy and safety on Firefox.
 
-Calendar_and_Contacts_Sync_27_KEY: |-
+Calendar_and_Contacts_Sync_26_KEY: |-
   Calendar and Contacts Sync
 
-If_you_are_currently_using_a_calendar_and_or_contacts_synchronization_service_like_Google_Sync_or_iCloud_you_should_pick_an_alternative_hereP_143_KEY: |-
+If_you_are_currently_using_a_calendar_and_or_contacts_synchronization_service_like_Google_Sync_or_iCloud_you_should_pick_an_alternative_hereP_142_KEY: |-
   If you are currently using a calendar and or contacts synchronization service like Google Sync or iCloud, you should pick an alternative here.
 
 Nextcloud_9_KEY: |-
@@ -1223,28 +1196,28 @@ httpsclientPetesyncPcom_27_KEY: |-
 httpsgithubPcometesync_26_KEY: |-
   https://github.com/etesync
 
-Worth_Mentioning_17_KEY: |-
+Worth_Mentioning_16_KEY: |-
   Worth Mentioning
 
-httpsfruuxPcom_19_KEY: |-
+httpsfruuxPcom_18_KEY: |-
   https://fruux.com/
 
-fruux_6_KEY: |-
+fruux_5_KEY: |-
   fruux
 
-A_unified_contactscalendaring_system_that_works_across_platforms_and_devicesP_79_KEY: |-
+A_unified_contactscalendaring_system_that_works_across_platforms_and_devicesP_78_KEY: |-
   A unified contacts/calendaring system that works across platforms and devices.
 
-cloud_backups_14_KEY: |-
+cloud_backups_13_KEY: |-
   cloud backups
 
 Consider_regularly_exporting_your_calendar_and_or_contacts_and_backing_them_up_on_a_separate_storage_drive_or_uploading_them_to_cloud_storage_ideally__209_KEY: |-
   Consider regularly exporting your calendar and or contacts and backing them up on a separate storage drive or uploading them to cloud storage (ideally after <a href="../encryption-tools/">encrypting</a> them).
 
-SelfHosted_Cloud_Server_Software_34_KEY: |-
+SelfHosted_Cloud_Server_Software_33_KEY: |-
   Self-Hosted Cloud Server Software
 
-If_you_are_currently_using_a_Cloud_Storage_Services_like_Dropbox_Google_Drive_Microsoft_OneDrive_or_Apple_iCloud_you_should_think_about_hosting_it_o_163_KEY: |-
+If_you_are_currently_using_a_Cloud_Storage_Services_like_Dropbox_Google_Drive_Microsoft_OneDrive_or_Apple_iCloud_you_should_think_about_hosting_it_o_162_KEY: |-
   If you are currently using a Cloud Storage Services like Dropbox, Google Drive, Microsoft OneDrive or Apple iCloud, you should think about hosting it on your own.
 
 Nextcloud_is_similar_in_functionality_to_the_widely_used_Dropbox_with_the_difference_being_that_Nextcloud_is_free_and_opensource_thereby_allowing_an_284_KEY: |-
@@ -1286,169 +1259,169 @@ httppkgsrcPsefilesystemstahoelafs_39_KEY: |-
 httpswwwPtahoelafsPorgtractahoelafsbrowser_50_KEY: |-
   https://www.tahoe-lafs.org/trac/tahoe-lafs/browser
 
-httpsgithubPcomxwikilabscryptpad_40_KEY: |-
+httpsgithubPcomxwikilabscryptpad_39_KEY: |-
   https://github.com/xwiki-labs/cryptpad/
 
-CryptPad_9_KEY: |-
+CryptPad_8_KEY: |-
   CryptPad
 
-An_opensource_and_endtoend_encrypted_realtime_collaborative_editor_that_lets_you_share_folders_media_and_documentsP_122_KEY: |-
+An_opensource_and_endtoend_encrypted_realtime_collaborative_editor_that_lets_you_share_folders_media_and_documentsP_121_KEY: |-
   An open-source and end-to-end encrypted real-time collaborative editor that lets you share folders, media, and documents.
 
-Encrypted_Domain_Name_System_DNS_Resolvers_45_KEY: |-
+Encrypted_Domain_Name_System_DNS_Resolvers_44_KEY: |-
   Encrypted Domain Name System (DNS) Resolvers
 
-Note_Using_an_encrypted_DNS_resolver_will_not_make_you_anonymous_nor_hide_your_internet_traffic_from_your_Internet_Service_ProviderP_But_it_will_prev_342_KEY: |-
+Note_Using_an_encrypted_DNS_resolver_will_not_make_you_anonymous_nor_hide_your_internet_traffic_from_your_Internet_Service_ProviderP_But_it_will_prev_341_KEY: |-
   Note: Using an encrypted DNS resolver will not make you anonymous, nor hide your internet traffic from your Internet Service Provider. But it will prevent DNS hijacking, and make your DNS requests harder for third parties to eavesdrop on and tamper with. If you are currently using Google's DNS resolver, you should pick an alternative here.
 
-DNS_Provider_13_KEY: |-
+DNS_Provider_12_KEY: |-
   DNS Provider
 
-Server_Locations_17_KEY: |-
+Server_Locations_16_KEY: |-
   Server Locations
 
-Privacy_Policy_15_KEY: |-
+Privacy_Policy_14_KEY: |-
   Privacy Policy
 
-Type_5_KEY: |-
+Type_4_KEY: |-
   Type
 
-Logging_8_KEY: |-
+Logging_7_KEY: |-
   Logging
 
-Protocols_10_KEY: |-
+Protocols_9_KEY: |-
   Protocols
 
-DNSSEC_7_KEY: |-
+DNSSEC_6_KEY: |-
   DNSSEC
 
-QNAME_Minimization_19_KEY: |-
+QNAME_Minimization_18_KEY: |-
   QNAME Minimization
 
-Filtering_10_KEY: |-
+Filtering_9_KEY: |-
   Filtering
 
-Source_Code_12_KEY: |-
+Source_Code_11_KEY: |-
   Source Code
 
-Hosting_Provider_17_KEY: |-
+Hosting_Provider_16_KEY: |-
   Hosting Provider
 
-AdGuard_8_KEY: |-
+AdGuard_7_KEY: |-
   AdGuard
 
-httpsadguardPcomenadguarddnsoverviewPhtml_49_KEY: |-
+httpsadguardPcomenadguarddnsoverviewPhtml_48_KEY: |-
   https://adguard.com/en/adguard-dns/overview.html
 
 Anycast_based_in_span_classnotextwrapspan_classflagicon_flagiconcyspan_Cyprusspan_104_KEY: |-
   Anycast (based in <span class="no-text-wrap"><span class="flag-icon flag-icon-cy"></span> Cyprus)</span>
 
-httpsadguardPcomenprivacydnsPhtml_40_KEY: |-
+httpsadguardPcomenprivacydnsPhtml_39_KEY: |-
   https://adguard.com/en/privacy/dns.html
 
-Commercial_11_KEY: |-
+Commercial_10_KEY: |-
   Commercial
 
-No_3_KEY: |-
+No_2_KEY: |-
   No
 
-DoH_DoT_DNSCrypt_19_KEY: |-
+DoH_DoT_DNSCrypt_18_KEY: |-
   DoH, DoT, DNSCrypt
 
-Yes_4_KEY: |-
+Yes_3_KEY: |-
   Yes
 
-Ads_trackers_15_KEY: |-
+Ads_trackers_14_KEY: |-
   Ads, trackers,
 
-malicious_domains_18_KEY: |-
+malicious_domains_17_KEY: |-
   malicious domains
 
-httpsgithubPcomAdguardTeamAdGuardDNS_43_KEY: |-
+httpsgithubPcomAdguardTeamAdGuardDNS_42_KEY: |-
   https://github.com/AdguardTeam/AdGuardDNS/
 
-httpsflopsPruenaboutPhtml_31_KEY: |-
+httpsflopsPruenaboutPhtml_30_KEY: |-
   https://flops.ru/en/about.html
 
-Serveroid_LLC_15_KEY: |-
+Serveroid_LLC_14_KEY: |-
   Serveroid, LLC
 
-BlahDNS_8_KEY: |-
+BlahDNS_7_KEY: |-
   BlahDNS
 
-httpsblahdnsPcom_21_KEY: |-
+httpsblahdnsPcom_20_KEY: |-
   https://blahdns.com/
 
-Finland_8_KEY: |-
+Finland_7_KEY: |-
   Finland
 
-Germany_8_KEY: |-
+Germany_7_KEY: |-
   Germany
 
-Japan_6_KEY: |-
+Japan_5_KEY: |-
   Japan
 
-No_logsP_11_KEY: |-
+No_logsP_10_KEY: |-
   "No logs."
 
-Hobby_Project_14_KEY: |-
+Hobby_Project_13_KEY: |-
   Hobby Project
 
-DoH_4_KEY: |-
+DoH_3_KEY: |-
   DoH
 
-Supports_port_443_in_addition_to_853_37_KEY: |-
+Supports_port_443_in_addition_to_853_36_KEY: |-
   Supports port 443 in addition to 853
 
-DoT_4_KEY: |-
+DoT_3_KEY: |-
   DoT
 
-DNSCrypt_9_KEY: |-
+DNSCrypt_8_KEY: |-
   DNSCrypt
 
-And_some_wildcard_and_IDN_domainsP_35_KEY: |-
+And_some_wildcard_and_IDN_domainsP_34_KEY: |-
   And some wildcard and IDN domains.
 
-httpsgithubPcomookangzhengblahdnsdefaultblockedwildcarddomain_71_KEY: |-
+httpsgithubPcomookangzhengblahdnsdefaultblockedwildcarddomain_70_KEY: |-
   https://github.com/ookangzheng/blahdns#default-blocked-wildcard-domain
 
-httpsgithubPcomookangzhengblahdns_40_KEY: |-
+httpsgithubPcomookangzhengblahdns_39_KEY: |-
   https://github.com/ookangzheng/blahdns/
 
-httpswwwPchoopaPcom_24_KEY: |-
+httpswwwPchoopaPcom_23_KEY: |-
   https://www.choopa.com/
 
-Choopa_LLC_12_KEY: |-
+Choopa_LLC_11_KEY: |-
   Choopa, LLC
 
-httpswwwPdatacenterlightPch_32_KEY: |-
+httpswwwPdatacenterlightPch_31_KEY: |-
   https://www.datacenterlight.ch/
 
-Data_Center_Light_18_KEY: |-
+Data_Center_Light_17_KEY: |-
   Data Center Light
 
-httpswwwPhetznerPcom_25_KEY: |-
+httpswwwPhetznerPcom_24_KEY: |-
   https://www.hetzner.com/
 
-Hetzner_Online_GmbH_20_KEY: |-
+Hetzner_Online_GmbH_19_KEY: |-
   Hetzner Online GmbH
 
-Cloudflare_11_KEY: |-
+Cloudflare_10_KEY: |-
   Cloudflare
 
-httpsdevelopersPcloudflarePcom1P1P1P1settingup1P1P1P1_62_KEY: |-
+httpsdevelopersPcloudflarePcom1P1P1P1settingup1P1P1P1_61_KEY: |-
   https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/
 
-Cloudflare_is_one_of_the_worlds_largest_networks_and_a_problem_considering_anonymity_and_decentralizationP_109_KEY: |-
+Cloudflare_is_one_of_the_worlds_largest_networks_and_a_problem_considering_anonymity_and_decentralizationP_108_KEY: |-
   Cloudflare is one of the world's largest networks, and a problem considering anonymity and decentralization.
 
-httpscodebergPorgcrimeflarecloudflaretor_48_KEY: |-
+httpscodebergPorgcrimeflarecloudflaretor_47_KEY: |-
   https://codeberg.org/crimeflare/cloudflare-tor/
 
 Anycast_based_in_span_classnotextwrap_span_classflagicon_flagiconusspan_USspan_101_KEY: |-
   Anycast (based in <span class="no-text-wrap"> <span class="flag-icon flag-icon-us"></span> US)</span>
 
-httpswwwPcloudflarePcomprivacypolicy_42_KEY: |-
+httpswwwPcloudflarePcomprivacypolicy_41_KEY: |-
   https://www.cloudflare.com/privacypolicy/
 
 We_will_collect_limited_DNS_query_data_that_is_sent_to_the_resolversP_This_data_does_not_contain_user_IP_addresses_or_any_other_personally_identifiabl_220_KEY: |-
@@ -1457,22 +1430,22 @@ We_will_collect_limited_DNS_query_data_that_is_sent_to_the_resolversP_This_data_
 httpsdevelopersPcloudflarePcom1P1P1P1commitmenttoprivacyprivacypolicyprivacypolicy_94_KEY: |-
   https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/privacy-policy/
 
-Some_5_KEY: |-
+Some_4_KEY: |-
   Some
 
-Self_5_KEY: |-
+Self_4_KEY: |-
   Self
 
-CZPNIC_7_KEY: |-
+CZPNIC_6_KEY: |-
   CZ.NIC
 
-httpswwwPnicPczodvr_25_KEY: |-
+httpswwwPnicPczodvr_24_KEY: |-
   https://www.nic.cz/odvr/
 
-Czech_Republic_15_KEY: |-
+Czech_Republic_14_KEY: |-
   Czech Republic
 
-CZPNIC_resolvers_neither_collect_any_personal_data_nor_gather_information_on_pages_where_your_computer_sends_personal_dataP_126_KEY: |-
+CZPNIC_resolvers_neither_collect_any_personal_data_nor_gather_information_on_pages_where_your_computer_sends_personal_dataP_125_KEY: |-
   "CZ.NIC resolvers neither collect any personal data nor gather information on pages where your computer sends personal data."
 
 CZPNIC_is_an_interest_association_of_legal_entities_founded_in_1998_by_leading_providers_of_Internet_servicesP_113_KEY: |-
@@ -1481,172 +1454,175 @@ CZPNIC_is_an_interest_association_of_legal_entities_founded_in_1998_by_leading_p
 httpswwwPnicPczpage351aboutassociation_46_KEY: |-
   https://www.nic.cz/page/351/about-association/
 
-Association_12_KEY: |-
+Association_11_KEY: |-
   Association
 
-DoH_DoT_9_KEY: |-
+DoH_DoT_8_KEY: |-
   DoH, DoT
 
-dnswarden_10_KEY: |-
+dnswarden_9_KEY: |-
   dnswarden
 
-httpsgithubPcombhanupratapysdnswardenblobmasterREADMEPmd_65_KEY: |-
+httpsgithubPcombhanupratapysdnswardenblobmasterREADMEPmd_64_KEY: |-
   https://github.com/bhanupratapys/dnswarden/blob/master/README.md
 
-httpsgithubPcombhanupratapysdnswardenblobmasterREADMEPmdprivacypolicyandtc_87_KEY: |-
+httpsgithubPcombhanupratapysdnswardenblobmasterREADMEPmdprivacypolicyandtc_86_KEY: |-
   https://github.com/bhanupratapys/dnswarden/blob/master/README.md#privacy-policy-and-tc
 
-Based_on_server_choice_23_KEY: |-
+Based_on_server_choice_22_KEY: |-
   Based on server choice
 
-Foundation_for_Applied_Privacy_31_KEY: |-
+Foundation_for_Applied_Privacy_30_KEY: |-
   Foundation for Applied Privacy
 
-httpsappliedprivacyPnetservicesdns_41_KEY: |-
+httpsappliedprivacyPnetservicesdns_40_KEY: |-
   https://appliedprivacy.net/services/dns/
 
-Austria_8_KEY: |-
+Austria_7_KEY: |-
   Austria
 
-httpsappliedprivacyPnetprivacypolicy_42_KEY: |-
+httpsappliedprivacyPnetprivacypolicy_41_KEY: |-
   https://appliedprivacy.net/privacy-policy
 
-NonProfit_11_KEY: |-
+NonProfit_10_KEY: |-
   Non-Profit
 
 We_do_NOT_log_your_IP_address_or_DNS_queries_during_normal_operationsP_We_do_NOT_share_query_data_with_third_parties_that_are_not_directly_involved_wi_242_KEY: |-
   "We do NOT log your IP address or DNS queries during normal operations. We do NOT share query data with third parties that are not directly involved with resolving the query (i.e. sending queries to authoritative nameservers for resolution)."
 
-httpswwwPipaxPat_21_KEY: |-
+httpsappliedprivacyPnetprivacypolicy_42_KEY: |-
+  https://appliedprivacy.net/privacy-policy/
+
+httpswwwPipaxPat_20_KEY: |-
   https://www.ipax.at/
 
-IPAX_OG_8_KEY: |-
+IPAX_OG_7_KEY: |-
   IPAX OG
 
 httpswwwPnextdnsPio_23_KEY: |-
   https://www.nextdns.io/
 
-NextDNS_8_KEY: |-
+NextDNS_7_KEY: |-
   NextDNS
 
 Anycast_based_in_span_classnotextwrapspan_classflagicon_flagiconusspan_USspan_100_KEY: |-
   Anycast (based in <span class="no-text-wrap"><span class="flag-icon flag-icon-us"></span> US)</span>
 
-httpswwwPnextdnsPioprivacy_31_KEY: |-
+httpswwwPnextdnsPioprivacy_30_KEY: |-
   https://www.nextdns.io/privacy
 
-Some_of_the_features_require_some_sort_of_data_retentionP_In_that_case_we_give_our_users_the_choice_to_granularly_or_completely_disable_those_feature_232_KEY: |-
+Some_of_the_features_require_some_sort_of_data_retentionP_In_that_case_we_give_our_users_the_choice_to_granularly_or_completely_disable_those_feature_231_KEY: |-
   "Some of the features require some sort of data retention. In that case, we give our users the choice to granularly or completely disable those features (and associated data retention), and we follow up immediately on that promise"
 
-Based_on_user_choice_21_KEY: |-
+Based_on_user_choice_20_KEY: |-
   Based on user choice
 
-NixNet_7_KEY: |-
+NixNet_6_KEY: |-
   NixNet
 
-httpsnixnetPxyzdns_24_KEY: |-
+httpsnixnetPxyzdns_23_KEY: |-
   https://nixnet.xyz/dns/
 
 Anycast_based_in_span_classflagicon_flagiconusspan_USspan_74_KEY: |-
   Anycast (based in <span class="flag-icon flag-icon-us"></span> US),</span>
 
-US_3_KEY: |-
+US_2_KEY: |-
   US
 
-Luxembourg_11_KEY: |-
+Luxembourg_10_KEY: |-
   Luxembourg
 
-httpsnixnetPxyzprivacy_28_KEY: |-
+httpsnixnetPxyzprivacy_27_KEY: |-
   https://nixnet.xyz/privacy/
 
 Part_of_LibreHosters_a_network_of_cooperation_and_solidarity_that_uses_free_software_to_encourage_decentralisation_through_federation_and_distributed_163_KEY: |-
   Part of LibreHosters, "a network of cooperation and solidarity that uses free software to encourage decentralisation through federation and distributed platforms."
 
-httpslibrehoPst_20_KEY: |-
+httpslibrehoPst_19_KEY: |-
   https://libreho.st/
 
-Informal_collective_20_KEY: |-
+Informal_collective_19_KEY: |-
   Informal collective
 
-httpsgitPnixnetPxyzNixNetdns_34_KEY: |-
+httpsgitPnixnetPxyzNixNetdns_33_KEY: |-
   https://git.nixnet.xyz/NixNet/dns
 
-httpsfrantechPca_21_KEY: |-
+httpsfrantechPca_20_KEY: |-
   https://frantech.ca/
 
-FranTech_Solutions_19_KEY: |-
+FranTech_Solutions_18_KEY: |-
   FranTech Solutions
 
-PowerDNS_9_KEY: |-
+PowerDNS_8_KEY: |-
   PowerDNS
 
-httpspowerdnsPorg_22_KEY: |-
+httpspowerdnsPorg_21_KEY: |-
   https://powerdns.org/
 
-The_Netherlands_16_KEY: |-
+The_Netherlands_15_KEY: |-
   The Netherlands
 
-httpspowerdnsPorgdohprivacyPhtml_38_KEY: |-
+httpspowerdnsPorgdohprivacyPhtml_37_KEY: |-
   https://powerdns.org/doh/privacy.html
 
-httpsgithubPcomPowerDNSpdns_33_KEY: |-
+httpsgithubPcomPowerDNSpdns_32_KEY: |-
   https://github.com/PowerDNS/pdns
 
-httpswwwPtransipPnl_24_KEY: |-
+httpswwwPtransipPnl_23_KEY: |-
   https://www.transip.nl/
 
-TransIP_BPVP_Admin_19_KEY: |-
+TransIP_BPVP_Admin_18_KEY: |-
   TransIP B.V. Admin
 
-Quad9_6_KEY: |-
+Quad9_5_KEY: |-
   Quad9
 
-httpsquad9Pnet_19_KEY: |-
+httpsquad9Pnet_18_KEY: |-
   https://quad9.net/
 
-Founders_include_the_Global_Cyber_Alliance_composed_of_the_City_of_London_Police_and_Manhattan_District_Attorneys_Office_123_KEY: |-
+Founders_include_the_Global_Cyber_Alliance_composed_of_the_City_of_London_Police_and_Manhattan_District_Attorneys_Office_122_KEY: |-
   Founders include the Global Cyber Alliance, composed of the City of London Police and Manhattan District Attorney's Office
 
-httpsquad9Pnetpolicy_26_KEY: |-
+httpsquad9Pnetpolicy_25_KEY: |-
   https://quad9.net/policy/
 
 Our_normal_course_of_data_management_does_not_have_any_IP_address_information_or_other_PII_logged_to_disk_or_transmitted_out_of_the_location_in_which__175_KEY: |-
   "Our normal course of data management does not have any IP address information or other PII logged to disk or transmitted out of the location in which the query was received."
 
-Malicious_domains_18_KEY: |-
+Malicious_domains_17_KEY: |-
   Malicious domains
 
-httpswwwPpchPnet_21_KEY: |-
+httpswwwPpchPnet_20_KEY: |-
   https://www.pch.net/
 
-Packet_Clearing_House_22_KEY: |-
+Packet_Clearing_House_21_KEY: |-
   Packet Clearing House
 
-SecureDNS_10_KEY: |-
+SecureDNS_9_KEY: |-
   SecureDNS
 
-httpssecurednsPeu_22_KEY: |-
+httpssecurednsPeu_21_KEY: |-
   https://securedns.eu/
 
-httpssecurednsPeuprivacy_30_KEY: |-
+httpssecurednsPeuprivacy_29_KEY: |-
   https://securedns.eu/#privacy
 
-httpswwwPdigitaloceanPcom_30_KEY: |-
+httpswwwPdigitaloceanPcom_29_KEY: |-
   https://www.digitalocean.com/
 
-DigitalOcean_IncP_19_KEY: |-
+DigitalOcean_IncP_18_KEY: |-
   DigitalOcean, Inc.
 
-httpssnopytaPorgservicednsindexPhtml_43_KEY: |-
+httpssnopytaPorgservicednsindexPhtml_42_KEY: |-
   https://snopyta.org/service/dns/index.html
 
-Snopyta_8_KEY: |-
+Snopyta_7_KEY: |-
   Snopyta
 
-httpssnopytaPorgprivacy_policy_36_KEY: |-
+httpssnopytaPorgprivacy_policy_35_KEY: |-
   https://snopyta.org/privacy_policy/
 
-UncensoredDNS_14_KEY: |-
+UncensoredDNS_13_KEY: |-
   UncensoredDNS
 
 httpsblogPuncensoreddnsPorg_31_KEY: |-
@@ -1655,49 +1631,49 @@ httpsblogPuncensoreddnsPorg_31_KEY: |-
 Anycast_based_in_span_classnotextwrapspan_classflagicon_flagicondkspan_Denmark_98_KEY: |-
   Anycast (based in <span class="no-text-wrap"><span class="flag-icon flag-icon-dk"></span> Denmark)
 
-Denmark_8_KEY: |-
+Denmark_7_KEY: |-
   Denmark
 
-Absolutely_nothing_is_being_logged_neither_about_the_users_nor_the_usage_of_this_serviceP_I_do_keep_graphs_of_the_total_number_of_queries_but_no_per_299_KEY: |-
+Absolutely_nothing_is_being_logged_neither_about_the_users_nor_the_usage_of_this_serviceP_I_do_keep_graphs_of_the_total_number_of_queries_but_no_per_298_KEY: |-
   "Absolutely nothing is being logged, neither about the users nor the usage of this service. I do keep graphs of the total number of queries, but no personally identifiable information is saved. The data that is saved will never be sold or used for anything except capacity planning of the service."
 
-httpswwwPteliacompanyPcom_29_KEY: |-
+httpswwwPteliacompanyPcom_28_KEY: |-
   https://www.teliacompany.com
 
-Telia_Company_AB_17_KEY: |-
+Telia_Company_AB_16_KEY: |-
   Telia Company AB
 
-Terms_6_KEY: |-
+Terms_5_KEY: |-
   Terms
 
-DNSoverTLS_DoT__A_security_protocol_for_encrypted_DNS_on_a_dedicated_port_853P_Some_providers_support_port_443_which_generally_works_everywhere_wh_226_KEY: |-
+DNSoverTLS_DoT__A_security_protocol_for_encrypted_DNS_on_a_dedicated_port_853P_Some_providers_support_port_443_which_generally_works_everywhere_wh_225_KEY: |-
   DNS-over-TLS (DoT) - A security protocol for encrypted DNS on a dedicated port 853. Some providers support port 443 which generally works everywhere while port 853 is often blocked by restrictive firewalls. DoT has two modes:
 
 Oppurtunistic_mode_the_client_attempts_to_form_a_DNSoverTLS_connection_to_the_server_on_port_853_without_performing_certificate_validationP_If_it_fa_184_KEY: |-
   Oppurtunistic mode: the client attempts to form a DNS-over-TLS connection to the server on port 853 without performing certificate validation. If it fails, it will use unencrypted DNS.
 
-In_other_words_automatic_mode_leaves_your_DNS_traffic_vulnerable_to_SSL_strip_and_MITM_attacks_95_KEY: |-
+In_other_words_automatic_mode_leaves_your_DNS_traffic_vulnerable_to_SSL_strip_and_MITM_attacks_94_KEY: |-
   In other words automatic mode leaves your DNS traffic vulnerable to SSL strip and MITM attacks
 
-Strict_mode_the_client_connects_to_a_specific_hostname_and_performs_certificate_validation_for_itP_If_it_fails_no_DNS_queries_are_made_until_it_succe_156_KEY: |-
+Strict_mode_the_client_connects_to_a_specific_hostname_and_performs_certificate_validation_for_itP_If_it_fails_no_DNS_queries_are_made_until_it_succe_155_KEY: |-
   Strict mode: the client connects to a specific hostname and performs certificate validation for it. If it fails, no DNS queries are made until it succeeds.
 
 DNSoverHTTPS_DoH__Similar_to_DoT_but_uses_HTTPS_instead_being_indistinguishable_from_normal_HTTPS_traffic_on_port_443P_127_KEY: |-
   DNS-over-HTTPS (DoH) - Similar to DoT, but uses HTTPS instead, being indistinguishable from "normal" HTTPS traffic on port 443.
 
-DoH_contains_metadata_such_as_useragent_which_may_include_system_information_that_is_sent_to_the_DNS_serverP_112_KEY: |-
+DoH_contains_metadata_such_as_useragent_which_may_include_system_information_that_is_sent_to_the_DNS_serverP_111_KEY: |-
   DoH contains metadata such as user-agent (which may include system information) that is sent to the DNS server.
 
-httpstoolsPietfPorghtmlrfc8484section8P2_48_KEY: |-
+httpstoolsPietfPorghtmlrfc8484section8P2_47_KEY: |-
   https://tools.ietf.org/html/rfc8484#section-8.2
 
-DNSCrypt__An_older_yet_robust_method_of_encrypting_DNSP_57_KEY: |-
+DNSCrypt__An_older_yet_robust_method_of_encrypting_DNSP_56_KEY: |-
   DNSCrypt - An older yet robust method of encrypting DNS.
 
-How_to_verify_DNS_is_encrypted_31_KEY: |-
+How_to_verify_DNS_is_encrypted_30_KEY: |-
   How to verify DNS is encrypted
 
-DoH__DoT_10_KEY: |-
+DoH__DoT_9_KEY: |-
   DoH / DoT
 
 Check_a_hrefhttpswwwPdnsleaktestPcomDNSLeakTestPcomaP_65_KEY: |-
@@ -1712,10 +1688,10 @@ Check_the_website_of_your_DNS_providerP_They_may_have_a_page_for_telling_you_are
 If_using_Firefoxs_trusted_recursive_resolver_TRR_navigate_to_codeaboutnetworkingdnscodeP_If_the_TRR_column_says_true_for_some_fields_you__165_KEY: |-
   If using Firefox's trusted recursive resolver (TRR), navigate to <code>about:networking#dns</code>. If the TRR column says "true" for some fields, you are using DoH.
 
-Some_fields_will_say_false_depending_on_the_the_value_of_networkPtrrPmode_in_aboutconfig_92_KEY: |-
+Some_fields_will_say_false_depending_on_the_the_value_of_networkPtrrPmode_in_aboutconfig_91_KEY: |-
   Some fields will say "false" depending on the the value of network.trr.mode in about:config
 
-httpswikiPmozillaPorgTrusted_Recursive_Resolver_52_KEY: |-
+httpswikiPmozillaPorgTrusted_Recursive_Resolver_51_KEY: |-
   https://wiki.mozilla.org/Trusted_Recursive_Resolver
 
 dnscryptproxy__Check_a_hrefhttpsgithubPcomjedisct1dnscryptproxywikiCheckingdnscryptproxys_wiki_on_how_to_verify_that_your_DNS_is_encry_160_KEY: |-
@@ -1724,13 +1700,13 @@ dnscryptproxy__Check_a_hrefhttpsgithubPcomjedisct1dnscryptproxywikiCheckingdnscr
 DNSSEC__Check_a_hrefhttpsdnssecPvsPuniduePdeDNSSEC_Resolver_Test_by_Matthus_WanderaP_99_KEY: |-
   DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">DNSSEC Resolver Test by Matthäus Wander</a>.
 
-QNAME_Minimization__Run_codedig_short_txt_qnamemintestPinternetPnlcode_from_the_commandline_taken_from_a_hrefhttpsnlnetlabsPnldownloads_455_KEY: |-
+QNAME_Minimization__Run_codedig_short_txt_qnamemintestPinternetPnlcode_from_the_commandline_taken_from_a_hrefhttpsnlnetlabsPnldownloads_454_KEY: |-
   QNAME Minimization - Run <code>dig +short txt qnamemintest.internet.nl</code> from the command-line (taken from <a href="https://nlnetlabs.nl/downloads/presentations/unbound_qnamemin_oarc24.pdf">this NLnet Labs presentation</a>). If you are on Windows 10, run <code>Resolve-DnsName -Type TXT -Name qnamemintest.internet.nl</code> from the PowerShell. You should see this display: <code>"HOORAY - QNAME minimisation is enabled on your resolver :)!"</code>
 
-Software_Suggestions_and_Additional_Information_48_KEY: |-
+Software_Suggestions_and_Additional_Information_47_KEY: |-
   Software Suggestions and Additional Information
 
-Encrypted_DNS_clients_for_desktop_35_KEY: |-
+Encrypted_DNS_clients_for_desktop_34_KEY: |-
   Encrypted DNS clients for desktop:
 
 emFirefoxem_comes_with_builtin_DoH_support_with_Cloudflare_set_as_the_default_resolver_but_can_be_configured_to_use_any_DoH_resolverP_140_KEY: |-
@@ -1742,22 +1718,22 @@ Cloudflare_has_agreed_to_collect_only_a_limited_amount_of_data_about_the_DNS_req
 httpsdevelopersPcloudflarePcom1P1P1P1commitmenttoprivacyprivacypolicyfirefox_87_KEY: |-
   https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/firefox/
 
-Currently_Mozilla_is_a_hrefhttpsblogPmozillaPorgfuturereleases20190731dnsoverhttpsdohupdatedetectingmanagednetworksanduserchoice_238_KEY: |-
+Currently_Mozilla_is_a_hrefhttpsblogPmozillaPorgfuturereleases20190731dnsoverhttpsdohupdatedetectingmanagednetworksanduserchoice_237_KEY: |-
   Currently Mozilla is <a href="https://blog.mozilla.org/futurereleases/2019/07/31/dns-over-https-doh-update-detecting-managed-networks-and-user-choice/">conducting studies</a> before enabling DoH by default for all US-based Firefox users.
 
-DNS_over_HTTPS_can_be_enabled_in_Menu__Preferences_codeaboutpreferencescode__Network_Settings__Enable_DNS_over_HTTPSP_Set_Use_Provider__203_KEY: |-
+DNS_over_HTTPS_can_be_enabled_in_Menu__Preferences_codeaboutpreferencescode__Network_Settings__Enable_DNS_over_HTTPSP_Set_Use_Provider__202_KEY: |-
   DNS over HTTPS can be enabled in Menu -> Preferences (<code>about:preferences</code>) -> Network Settings -> Enable DNS over HTTPS. Set "Use Provider" to "Custom", and enter your DoH provider's address.
 
-Advanced_users_may_enable_it_in_codeaboutconfigcode_by_setting_codenetworkPtrrPcustom_uricode_and_codenetworkPtrrPuricode_as_the_addres_450_KEY: |-
+Advanced_users_may_enable_it_in_codeaboutconfigcode_by_setting_codenetworkPtrrPcustom_uricode_and_codenetworkPtrrPuricode_as_the_addres_449_KEY: |-
   Advanced users may enable it in <code>about:config</code> by setting <code>network.trr.custom_uri</code> and <code>network.trr.uri</code> as the address you find from the documentation of your DoH provider and <code>network.trr.mode</code> as <code>2</code>. It may also be desirable to set <code>network.security.esni.enabled</code> to <code>True</code> in order to enable encrypted SNI and make sites supporting ESNI a bit more difficult to track.
 
-Encrypted_DNS_clients_for_mobile_34_KEY: |-
+Encrypted_DNS_clients_for_mobile_33_KEY: |-
   Encrypted DNS clients for mobile:
 
 emAndroid_9em_comes_with_a_DoT_client_by_a_hrefhttpssupportPgooglePcomandroidanswer9089903defaultaP_118_KEY: |-
   <em>Android 9</em> comes with a DoT client by <a href="https://support.google.com/android/answer/9089903">default</a>.
 
-PPPbut_with_some_caveats_25_KEY: |-
+PPPbut_with_some_caveats_24_KEY: |-
   ...but with some caveats
 
 httpswwwPquad9Pnetprivatednsquad9android9_49_KEY: |-
@@ -1766,34 +1742,34 @@ httpswwwPquad9Pnetprivatednsquad9android9_49_KEY: |-
 We_recommend_selecting_emPrivate_DNS_provider_hostnameem_and_entering_the_DoT_address_from_documentation_of_your_DoT_provider_to_enable_strict_mod_171_KEY: |-
   We recommend selecting <em>Private DNS provider hostname</em> and entering the DoT address from documentation of your DoT provider to enable strict mode (see Terms above).
 
-If_you_are_on_a_network_blocking_access_to_port_853_Android_will_error_about_the_network_not_having_internet_connectivityP_124_KEY: |-
+If_you_are_on_a_network_blocking_access_to_port_853_Android_will_error_about_the_network_not_having_internet_connectivityP_123_KEY: |-
   If you are on a network blocking access to port 853, Android will error about the network not having internet connectivity.
 
-httpsappsPapplePcomappid1452162351_40_KEY: |-
+httpsappsPapplePcomappid1452162351_39_KEY: |-
   https://apps.apple.com/app/id1452162351
 
-DNSCloak_9_KEY: |-
+DNSCloak_8_KEY: |-
   DNSCloak
 
 An_a_hrefhttpsgithubPcomssdnscloakopensourcea_DNSCrypt_and_DoH_client_for_iOS_by_tda_datatoggletooltip_dataplacementbottom_da_362_KEY: |-
   An <a href="https://github.com/s-s/dnscloak">open-source</a> DNSCrypt and DoH client for iOS by <td><a data-toggle="tooltip" data-placement="bottom" data-original-title='"A charitable non-profit host organization for international Free Software projects."' href="https://techcultivation.org/">the Center for the Cultivation of Technology gemeinnuetzige GmbH</a>.
 
-httpsgitPfrostnerdPcomPublicAndroidAppssmokescreenblobmasterREADMEPmd_78_KEY: |-
+httpsgitPfrostnerdPcomPublicAndroidAppssmokescreenblobmasterREADMEPmd_77_KEY: |-
   https://git.frostnerd.com/PublicAndroidApps/smokescreen/blob/master/README.md
 
-Nebulo_7_KEY: |-
+Nebulo_6_KEY: |-
   Nebulo
 
 An_opensource_application_for_Android_supporting_DoH_and_DoTP_It_also_supports_caching_DNS_responses_and_locally_logging_DNS_queriesP_134_KEY: |-
   An open-source application for Android supporting DoH and DoT. It also supports caching DNS responses and locally logging DNS queries.
 
-Local_DNS_servers_19_KEY: |-
+Local_DNS_servers_18_KEY: |-
   Local DNS servers:
 
 httpsdnsprivacyPorgwikidisplayDPDNSPrivacyDaemonStubby_66_KEY: |-
   https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby
 
-Stubby_7_KEY: |-
+Stubby_6_KEY: |-
   Stubby
 
 An_opensource_application_for_Linux_macOS_and_Windows_that_acts_as_a_local_DNS_Privacy_stub_resolver_using_DoTP_114_KEY: |-
@@ -1802,7 +1778,7 @@ An_opensource_application_for_Linux_macOS_and_Windows_that_acts_as_a_local_DNS_P
 httpsnlnetlabsPnlprojectsunboundabout_44_KEY: |-
   https://nlnetlabs.nl/projects/unbound/about/
 
-Unbound_8_KEY: |-
+Unbound_7_KEY: |-
   Unbound
 
 a_validating_recursive_caching_DNS_resolverP_It_can_also_be_ran_networkwide_and_has_supported_DNSoverTLS_since_version_1P7P3P_130_KEY: |-
@@ -1817,245 +1793,104 @@ Networkwide_DNS_servers_25_KEY: |-
 httpspiholePnet_20_KEY: |-
   https://pi-hole.net/
 
-Pihole_8_KEY: |-
+Pihole_7_KEY: |-
   Pi-hole
 
-A_networkwide_DNS_server_mainly_for_the_Raspberry_PiP_Blocks_ads_tracking_and_malicious_domains_for_all_devices_on_your_networkP_132_KEY: |-
+A_networkwide_DNS_server_mainly_for_the_Raspberry_PiP_Blocks_ads_tracking_and_malicious_domains_for_all_devices_on_your_networkP_131_KEY: |-
   A network-wide DNS server mainly for the Raspberry Pi. Blocks ads, tracking, and malicious domains for all devices on your network.
 
-httpsgitlabPcomquidsupnotrack_35_KEY: |-
+httpsgitlabPcomquidsupnotrack_34_KEY: |-
   https://gitlab.com/quidsup/notrack
 
-NoTrack_8_KEY: |-
+NoTrack_7_KEY: |-
   NoTrack
 
-A_networkwide_DNS_server_like_Pihole_for_blocking_ads_tracking_and_malicious_domainsP_90_KEY: |-
+A_networkwide_DNS_server_like_Pihole_for_blocking_ads_tracking_and_malicious_domainsP_89_KEY: |-
   A network-wide DNS server like Pi-hole for blocking ads, tracking, and malicious domains.
 
-Further_reading_17_KEY: |-
+Further_reading_16_KEY: |-
   Further reading:
 
-On_Firefox_DoH_and_ESNI_25_KEY: |-
+On_Firefox_DoH_and_ESNI_24_KEY: |-
   On Firefox, DoH and ESNI
 
-Trusted_Recursive_Resolver_DoH_on_MozillaWiki_48_KEY: |-
+Trusted_Recursive_Resolver_DoH_on_MozillaWiki_47_KEY: |-
   Trusted Recursive Resolver (DoH) on MozillaWiki
 
-httpsbugzillaPmozillaPorgshow_bugPcgiQid1500289_53_KEY: |-
+httpsbugzillaPmozillaPorgshow_bugPcgiQid1500289_52_KEY: |-
   https://bugzilla.mozilla.org/show_bug.cgi?id=1500289
 
-Firefox_bug_report_requesting_the_ability_to_use_ESNI_without_DoH_66_KEY: |-
+Firefox_bug_report_requesting_the_ability_to_use_ESNI_without_DoH_65_KEY: |-
   Firefox bug report requesting the ability to use ESNI without DoH
 
-httpsbugzillaPmozillaPorgshow_bugPcgiQid1542754_53_KEY: |-
+httpsbugzillaPmozillaPorgshow_bugPcgiQid1542754_52_KEY: |-
   https://bugzilla.mozilla.org/show_bug.cgi?id=1542754
 
-Firefox_bug_report_requesting_the_ability_to_use_Android_9s_Private_DNS_DoT_and_benefit_from_encrypted_SNI_without_having_to_enable_DoH_140_KEY: |-
+Firefox_bug_report_requesting_the_ability_to_use_Android_9s_Private_DNS_DoT_and_benefit_from_encrypted_SNI_without_having_to_enable_DoH_139_KEY: |-
   Firefox bug report requesting the ability to use Android 9+'s Private DNS (DoT) and benefit from encrypted SNI without having to enable DoH
 
-httpsblogPcloudflarePcomencryptedsni_43_KEY: |-
+httpsblogPcloudflarePcomencryptedsni_42_KEY: |-
   https://blog.cloudflare.com/encrypted-sni/
 
-Encrypt_it_or_lose_it_how_encrypted_SNI_works_on_Cloudflare_blog_66_KEY: |-
+Encrypt_it_or_lose_it_how_encrypted_SNI_works_on_Cloudflare_blog_65_KEY: |-
   Encrypt it or lose it: how encrypted SNI works on Cloudflare blog
 
-httpswwwPiscPorgblogsqnameminimizationandprivacy_58_KEY: |-
+httpswwwPiscPorgblogsqnameminimizationandprivacy_57_KEY: |-
   https://www.isc.org/blogs/qname-minimization-and-privacy/
 
-QNAME_Minimization_and_Your_Privacya_by_the_Internet_Systems_Consortium_ISC_81_KEY: |-
+QNAME_Minimization_and_Your_Privacya_by_the_Internet_Systems_Consortium_ISC_80_KEY: |-
   QNAME Minimization and Your Privacy</a> by the Internet Systems Consortium (ISC)
 
-httpswwwPiscPorgdnssec_28_KEY: |-
+httpswwwPiscPorgdnssec_27_KEY: |-
   https://www.isc.org/dnssec/
 
-DNSSEC_and_BIND_9a_by_the_ISC_33_KEY: |-
+DNSSEC_and_BIND_9a_by_the_ISC_32_KEY: |-
   DNSSEC and BIND 9</a> by the ISC
 
-Donate_via_OpenCollective_26_KEY: |-
+Donate_via_OpenCollective_25_KEY: |-
   Donate via OpenCollective
 
 If_you_are_able_please_consider_contributing_to_our_development_and_outreach_programsP_87_KEY: |-
   If you are able, please consider contributing to our development and outreach programs.
 
-Contributions_via_OpenCollective_to__sitePname__are_tax_deductible_for_US_taxpayersP_89_KEY: |-
+Contributions_via_OpenCollective_to__sitePname__are_tax_deductible_for_US_taxpayersP_88_KEY: |-
   Contributions via OpenCollective to {{ site.name }} are tax deductible for US taxpayers.
 
-These_funds_are_transparently_and_primarily_used_to_cover_server_costsP_72_KEY: |-
+These_funds_are_transparently_and_primarily_used_to_cover_server_costsP_71_KEY: |-
   These funds are transparently and primarily used to cover server costs.
 
-Contribute_11_KEY: |-
+Contribute_10_KEY: |-
   Contribute
 
-More_Info_10_KEY: |-
+More_Info_9_KEY: |-
   More Info
 
-Please_Donate_14_KEY: |-
+Please_Donate_13_KEY: |-
   Please Donate
 
-Our_website_is_free_of_advertisements_and_not_affiliated_with_any_listed_providersP_84_KEY: |-
+Our_website_is_free_of_advertisements_and_not_affiliated_with_any_listed_providersP_83_KEY: |-
   Our website is free of advertisements and not affiliated with any listed providers.
 
-Your_donation_will_cover_our_costs_for_servers_domains_coffee_beer_and_pizzaP_82_KEY: |-
+Your_donation_will_cover_our_costs_for_servers_domains_coffee_beer_and_pizzaP_81_KEY: |-
   Your donation will cover our costs for servers, domains, coffee, beer, and pizza.
 
-You_may_also_contribute_via_the_cryptocurrencies_below_however_we_will_not_be_able_to_provide_a_receipt_for_your_contributionP_129_KEY: |-
+You_may_also_contribute_via_the_cryptocurrencies_below_however_we_will_not_be_able_to_provide_a_receipt_for_your_contributionP_128_KEY: |-
   You may also contribute via the cryptocurrencies below; however, we will not be able to provide a receipt for your contribution.
 
-Your_contribution_will_be_considered_an_anonymous_unrestricted_contribution_and_paid_to_our_Fiscal_Host_at_OpenCollective_when_we_convert_to_currencyP_152_KEY: |-
+Your_contribution_will_be_considered_an_anonymous_unrestricted_contribution_and_paid_to_our_Fiscal_Host_at_OpenCollective_when_we_convert_to_currencyP_151_KEY: |-
   Your contribution will be considered an anonymous, unrestricted contribution and paid to our Fiscal Host at OpenCollective when we convert to currency.
 
-We_prefer_Bitcoin_donations_to_be_above_5_due_to_the_state_of_the_networks_transaction_feesP_You_are_welcome_to_donate_any_smaller_or_larger_amount_o_223_KEY: |-
+We_prefer_Bitcoin_donations_to_be_above_5_due_to_the_state_of_the_networks_transaction_feesP_You_are_welcome_to_donate_any_smaller_or_larger_amount_o_222_KEY: |-
   We prefer Bitcoin donations to be above $5 due to the state of the network's transaction fees. You are welcome to donate any smaller or larger amount on any other cryptocurrency, such as Bitcoin Cash, Ethereum, or Stellar.
 
-More_Cryptocurrencies_22_KEY: |-
+More_Cryptocurrencies_21_KEY: |-
   More Cryptocurrencies
 
-The_a_href_contact__translate_page__sitePname__teama_does_not_necessarily_endorse_all_of_the_cryptocurrencies_listed_on_this_pageP_225_KEY: |-
+The_a_href_contact__translate_page__sitePname__teama_does_not_necessarily_endorse_all_of_the_cryptocurrencies_listed_on_this_pageP_224_KEY: |-
   The <a href="{{ '/contact/' | translate_page }}">{{ site.name }} team</a> does not necessarily endorse all of the cryptocurrencies listed on this page. Please conduct your own research before purchasing any cryptocurrencies.
 
-Thanks_for_your_supportP_You_are_awesomeE_42_KEY: |-
+Thanks_for_your_supportP_You_are_awesomeE_41_KEY: |-
   Thanks for your support. You are awesome!
-
-PrivacyConscious_Email_Providers__No_Affiliates_50_KEY: |-
-  Privacy-Conscious Email Providers - No Affiliates
-
-All_providers_listed_here_are_operating_outside_the_US_and_support_a_datatoggletooltip_dataplacementbottom_dataoriginaltitleWhen_sending_o_339_KEY: |-
-  All providers listed here are operating outside the US and support <a data-toggle="tooltip" data-placement="bottom" data-original-title="When sending or receiving emails, if both the sending and receiving servers support TLS encryption, the email is sent between servers using an encrypted connection.">SMTP TLS.</a> The table is sortable.
-
-Email_Provider_15_KEY: |-
-  Email Provider
-
-Since_6_KEY: |-
-  Since
-
-Jurisdiction_13_KEY: |-
-  Jurisdiction
-
-Storage_8_KEY: |-
-  Storage
-
-Yearly_Price_13_KEY: |-
-  Yearly Price
-
-Bitcoin_8_KEY: |-
-  Bitcoin
-
-Encryption_11_KEY: |-
-  Encryption
-
-Own_Domain_11_KEY: |-
-  Own Domain
-
-httpsdisrootPorg_20_KEY: |-
-  https://disroot.org
-
-Netherlands_12_KEY: |-
-  Netherlands
-
-_Free__tl_note_free_as_in_no_money_cost__49_KEY: |-
-  {{ "Free" | tl_note: free as in no money cost }}
-
-Accepted_9_KEY: |-
-  Accepted
-
-Builtin_9_KEY: |-
-  Built-in
-
-httpskolabnowPcom_21_KEY: |-
-  https://kolabnow.com
-
-Switzerland_12_KEY: |-
-  Switzerland
-
-httpsmailboxPorg_20_KEY: |-
-  https://mailbox.org
-
-httpsmailfencePcom_22_KEY: |-
-  https://mailfence.com
-
-Belgium_8_KEY: |-
-  Belgium
-
-httpswwwPneomailboxPcom_27_KEY: |-
-  https://www.neomailbox.com
-
-httpsposteoPde_18_KEY: |-
-  https://posteo.de
-
-httpsprotonmailPcom_23_KEY: |-
-  https://protonmail.com
-
-Tor_4_KEY: |-
-  Tor
-
-httpsrunboxPcom_19_KEY: |-
-  https://runbox.com
-
-Norway_7_KEY: |-
-  Norway
-
-httpssoverinPnet_21_KEY: |-
-  https://soverin.net/
-
-httpswwwPstartmailPcom_26_KEY: |-
-  https://www.startmail.com
-
-httpswwwPtutanotaPcom_25_KEY: |-
-  https://www.tutanota.com
-
-Interesting_Email_Providers_Under_Development_46_KEY: |-
-  Interesting Email Providers Under Development
-
-httpswwwPconfidantmailPorg_31_KEY: |-
-  https://www.confidantmail.org/
-
-Confidant_Mail_15_KEY: |-
-  Confidant Mail
-
-An_opensource_nonSMTP_cryptographic_email_system_optimized_for_large_file_attachmentsP_It_is_a_secure_and_spamresistant_alternative_to_regular_email_377_KEY: |-
-  An open-source non-SMTP cryptographic email system optimized for large file attachments. It is a secure and spam-resistant alternative to regular email and online file drop services. It uses <a href="https://theprivacyguide.org/tutorials/gpg.html">GNU Privacy Guard (GPG)</a> for content encryption and authentication, and TLS 1.2 with ephemeral keys for transport encryption.
-
-Become_Your_Own_Email_Provider_with_MailinaBox_50_KEY: |-
-  Become Your Own Email Provider with Mail-in-a-Box
-
-httpsmailinaboxPemail_26_KEY: |-
-  https://mailinabox.email/
-
-MailinaBox_14_KEY: |-
-  Mail-in-a-Box
-
-Take_it_a_step_further_and_get_control_of_your_email_with_this_easytodeploy_mail_server_in_a_boxP_MailinaBox_lets_you_become_your_own_mail_service_405_KEY: |-
-  Take it a step further and get control of your email with this easy-to-deploy mail server in a box. Mail-in-a-Box lets you become your own mail service provider in a few easy steps. It's sort of like making your own Gmail, but one you control from top to bottom. Technically, Mail-in-a-Box turns a fresh cloud computer into a working mail server. But you don't need to be a technology expert to set it up.
-
-More_6_KEY: |-
-  More:
-
-httpsmailinaboxPemail_25_KEY: |-
-  https://mailinabox.email/
-
-httpswwwPwiredPcom201110ecpaturnstwentyfive_54_KEY: |-
-  https://www.wired.com/2011/10/ecpa-turns-twenty-five/
-
-Aging_Privacy_Law_Leaves_Cloud_EMail_Open_to_Cops_53_KEY: |-
-  Aging 'Privacy' Law Leaves Cloud E-Mail Open to Cops
-
-Data_stored_in_the_cloud_for_longer_than_6_months_is_considered_abandoned_and_may_be_accessed_by_intelligence_agencies_without_a_warrantP_Learning_Use_284_KEY: |-
-  Data stored in the cloud for longer than 6 months is considered abandoned and may be accessed by intelligence agencies without a warrant. Learning: Use an external email client like Thunderbird or Enigmail, download your emails and store them locally. Never leave them on the server.
-
-httpswwwPeffPorgdeeplinks201204mayfirstriseupserverseizurefbioverreachesyetagain_95_KEY: |-
-  https://www.eff.org/deeplinks/2012/04/may-firstriseup-server-seizure-fbi-overreaches-yet-again
-
-With_May_FirstRiseup_Server_Seizure_FBI_Overreaches_Yet_Again_64_KEY: |-
-  With May First/Riseup Server Seizure, FBI Overreaches Yet Again
-
-httpswwwPautisticiPorgaicrackdown_40_KEY: |-
-  https://www.autistici.org/ai/crackdown/
-
-AutisticiInventati_server_compromised_39_KEY: |-
-  Autistici/Inventati server compromised
-
-The_cryptographic_services_offered_by_the_AutisticiInventati_server_have_been_compromised_on_15th_June_2004P_It_was_discovered_on_21st_June_2005P_One__342_KEY: |-
-  The cryptographic services offered by the Autistici/Inventati server have been compromised on 15th June 2004. It was discovered on 21st June 2005. One year later. During an enquiry on a single mailbox, the Postal Police may have tapped for a whole year every user's private communication going through the server autistici.org/inventati.org.
 
 Thunderbird_11_KEY: |-
   Thunderbird
@@ -2111,79 +1946,79 @@ httppkgsrcPsemailclawsmail_32_KEY: |-
 httpsgitPclawsmailPorg_27_KEY: |-
   https://git.claws-mail.org/
 
-Privacy_Email_Tools_20_KEY: |-
+Privacy_Email_Tools_19_KEY: |-
   Privacy Email Tools
 
-httpswwwPgpg4usbPorg_25_KEY: |-
+httpswwwPgpg4usbPorg_24_KEY: |-
   https://www.gpg4usb.org/
 
-gpg4usb_8_KEY: |-
+gpg4usb_7_KEY: |-
   gpg4usb
 
-A_very_easy_to_use_and_small_portable_editor_to_encrypt_and_decrypt_any_textmessage_or_fileP_For_Windows_and_LinuxP_a_hrefhttpstheprivacyguideP_193_KEY: |-
+A_very_easy_to_use_and_small_portable_editor_to_encrypt_and_decrypt_any_textmessage_or_fileP_For_Windows_and_LinuxP_a_hrefhttpstheprivacyguideP_192_KEY: |-
   A very easy to use and small portable editor to encrypt and decrypt any text-message or -file. For Windows and Linux. <a href="https://theprivacyguide.org/tutorials/gpg.html">GPG tutorial</a>.
 
-httpswwwPmailvelopePcom_28_KEY: |-
+httpswwwPmailvelopePcom_27_KEY: |-
   https://www.mailvelope.com/
 
-Mailvelope_11_KEY: |-
+Mailvelope_10_KEY: |-
   Mailvelope
 
-A_browser_extension_that_enables_the_exchange_of_encrypted_emails_following_the_a_hrefhttpstheprivacyguidePorgtutorialspgpPhtmlOpenPGP_encryp_170_KEY: |-
+A_browser_extension_that_enables_the_exchange_of_encrypted_emails_following_the_a_hrefhttpstheprivacyguidePorgtutorialspgpPhtmlOpenPGP_encryp_169_KEY: |-
   A browser extension that enables the exchange of encrypted emails following the <a href="https://theprivacyguide.org/tutorials/pgp.html">OpenPGP encryption standard</a>.
 
-httpswwwPenigmailPnet_26_KEY: |-
+httpswwwPenigmailPnet_25_KEY: |-
   https://www.enigmail.net/
 
-Enigmail_9_KEY: |-
+Enigmail_8_KEY: |-
   Enigmail
 
-A_security_extension_to_Thunderbird_and_SeamonkeyP_It_enables_you_to_write_and_receive_email_messages_signed_andor_encrypted_with_the_a_hrefhttps_214_KEY: |-
+A_security_extension_to_Thunderbird_and_SeamonkeyP_It_enables_you_to_write_and_receive_email_messages_signed_andor_encrypted_with_the_a_hrefhttps_213_KEY: |-
   A security extension to Thunderbird and Seamonkey. It enables you to write and receive email messages signed and/or encrypted with the <a href="https://theprivacyguide.org/tutorials/pgp.html">OpenPGP standard</a>.
 
-httpsaddonsPthunderbirdPnetthunderbirdaddontorbirdy_59_KEY: |-
+httpsaddonsPthunderbirdPnetthunderbirdaddontorbirdy_58_KEY: |-
   https://addons.thunderbird.net/thunderbird/addon/torbirdy/
 
-TorBirdy_9_KEY: |-
+TorBirdy_8_KEY: |-
   TorBirdy
 
-TorBirdy_configures_Thunderbird_to_make_connections_over_the_Tor_anonymity_networkP_This_extension_is_in_beta_and_should_be_considered_experimentalP_149_KEY: |-
+TorBirdy_configures_Thunderbird_to_make_connections_over_the_Tor_anonymity_networkP_This_extension_is_in_beta_and_should_be_considered_experimentalP_148_KEY: |-
   TorBirdy configures Thunderbird to make connections over the Tor anonymity network. This extension is in beta and should be considered experimental.
 
-httpswwwPemailprivacytesterPcom_36_KEY: |-
+httpswwwPemailprivacytesterPcom_35_KEY: |-
   https://www.emailprivacytester.com/
 
-Email_Privacy_Tester_21_KEY: |-
+Email_Privacy_Tester_20_KEY: |-
   Email Privacy Tester
 
-This_tool_will_send_an_Email_to_your_address_and_perform_privacyrelated_testsP_80_KEY: |-
+This_tool_will_send_an_Email_to_your_address_and_perform_privacyrelated_testsP_79_KEY: |-
   This tool will send an Email to your address and perform privacy-related tests.
 
-httpsgithubPcomk9mailk9releases_39_KEY: |-
+httpsgithubPcomk9mailk9releases_38_KEY: |-
   https://github.com/k9mail/k-9/releases
 
-K9_Mail_9_KEY: |-
+K9_Mail_8_KEY: |-
   K-9 Mail
 
-An_independent_mail_application_for_AndroidP_It_supports_both_POP3_and_IMAP_mailboxes_but_only_supports_push_mail_for_IMAPP_125_KEY: |-
+An_independent_mail_application_for_AndroidP_It_supports_both_POP3_and_IMAP_mailboxes_but_only_supports_push_mail_for_IMAPP_124_KEY: |-
   An independent mail application for Android. It supports both POP3 and IMAP mailboxes, but only supports push mail for IMAP.
 
-httpswwwPgnupgPorg_23_KEY: |-
+httpswwwPgnupgPorg_22_KEY: |-
   https://www.gnupg.org/
 
-GNU_Privacy_Guard_18_KEY: |-
+GNU_Privacy_Guard_17_KEY: |-
   GNU Privacy Guard
 
-Email_EncryptionP_GnuPG_is_a_GPL_Licensed_alternative_to_the_PGP_suite_of_cryptographic_softwareP_a_hrefhttpstheprivacyguidePorgtutorialsgpgPht_229_KEY: |-
+Email_EncryptionP_GnuPG_is_a_GPL_Licensed_alternative_to_the_PGP_suite_of_cryptographic_softwareP_a_hrefhttpstheprivacyguidePorgtutorialsgpgPht_228_KEY: |-
   Email Encryption. GnuPG is a GPL Licensed alternative to the PGP suite of cryptographic software. <a href="https://theprivacyguide.org/tutorials/gpg.html">Tutorial.</a> Use <a href="https://gpgtools.org/">GPGTools for macOS.</a>
 
-httpswwwPmailpilePis_25_KEY: |-
+httpswwwPmailpilePis_24_KEY: |-
   https://www.mailpile.is/
 
-Mailpile_Beta_16_KEY: |-
+Mailpile_Beta_15_KEY: |-
   Mailpile (Beta)
 
-A_modern_fast_webmail_client_with_userfriendly_encryption_and_privacy_featuresP_83_KEY: |-
+A_modern_fast_webmail_client_with_userfriendly_encryption_and_privacy_featuresP_82_KEY: |-
   A modern, fast web-mail client with user-friendly encryption and privacy features.
 
 Bitmessage_10_KEY: |-
@@ -2228,19 +2063,157 @@ httpsretrosharePccdownloadsPhtmlfreebsd_44_KEY: |-
 httpsgithubPcomRetroShareRetroShare_40_KEY: |-
   https://github.com/RetroShare/RetroShare
 
-httpsi2pbotePxyz_21_KEY: |-
+httpsi2pbotePxyz_20_KEY: |-
   https://i2pbote.xyz/
 
-I2PBote_9_KEY: |-
+I2PBote_8_KEY: |-
   I2P-Bote
 
-Endtoend_encrypted_decentralized_mail_system_within_the_I2P_networkP_71_KEY: |-
+Endtoend_encrypted_decentralized_mail_system_within_the_I2P_networkP_70_KEY: |-
   End-to-end encrypted decentralized mail system within the I2P network.
 
-File_Encryption_Software_25_KEY: |-
+PrivacyConscious_Email_Providers__No_Affiliates_49_KEY: |-
+  Privacy-Conscious Email Providers - No Affiliates
+
+All_providers_listed_here_are_operating_outside_the_US_and_support_a_datatoggletooltip_dataplacementbottom_dataoriginaltitleWhen_sending_o_339_KEY: |-
+  All providers listed here are operating outside the US and support <a data-toggle="tooltip" data-placement="bottom" data-original-title="When sending or receiving emails, if both the sending and receiving servers support TLS encryption, the email is sent between servers using an encrypted connection.">SMTP TLS.</a> The table is sortable.
+
+Email_Provider_14_KEY: |-
+  Email Provider
+
+Since_5_KEY: |-
+  Since
+
+Jurisdiction_12_KEY: |-
+  Jurisdiction
+
+Storage_7_KEY: |-
+  Storage
+
+Yearly_Price_12_KEY: |-
+  Yearly Price
+
+Bitcoin_7_KEY: |-
+  Bitcoin
+
+Encryption_10_KEY: |-
+  Encryption
+
+Own_Domain_10_KEY: |-
+  Own Domain
+
+httpsdisrootPorg_19_KEY: |-
+  https://disroot.org
+
+Netherlands_11_KEY: |-
+  Netherlands
+
+_Free__tl_note_free_as_in_no_money_cost__48_KEY: |-
+  {{ "Free" | tl_note: free as in no money cost }}
+
+Accepted_8_KEY: |-
+  Accepted
+
+Builtin_8_KEY: |-
+  Built-in
+
+httpskolabnowPcom_20_KEY: |-
+  https://kolabnow.com
+
+Switzerland_11_KEY: |-
+  Switzerland
+
+httpsmailboxPorg_19_KEY: |-
+  https://mailbox.org
+
+httpsmailfencePcom_21_KEY: |-
+  https://mailfence.com
+
+Belgium_7_KEY: |-
+  Belgium
+
+httpswwwPneomailboxPcom_26_KEY: |-
+  https://www.neomailbox.com
+
+httpsposteoPde_17_KEY: |-
+  https://posteo.de
+
+httpsprotonmailPcom_22_KEY: |-
+  https://protonmail.com
+
+Tor_3_KEY: |-
+  Tor
+
+httpsrunboxPcom_18_KEY: |-
+  https://runbox.com
+
+Norway_6_KEY: |-
+  Norway
+
+httpssoverinPnet_20_KEY: |-
+  https://soverin.net/
+
+httpswwwPstartmailPcom_25_KEY: |-
+  https://www.startmail.com
+
+httpswwwPtutanotaPcom_24_KEY: |-
+  https://www.tutanota.com
+
+Interesting_Email_Providers_Under_Development_45_KEY: |-
+  Interesting Email Providers Under Development
+
+httpswwwPconfidantmailPorg_30_KEY: |-
+  https://www.confidantmail.org/
+
+Confidant_Mail_14_KEY: |-
+  Confidant Mail
+
+An_opensource_nonSMTP_cryptographic_email_system_optimized_for_large_file_attachmentsP_It_is_a_secure_and_spamresistant_alternative_to_regular_email_376_KEY: |-
+  An open-source non-SMTP cryptographic email system optimized for large file attachments. It is a secure and spam-resistant alternative to regular email and online file drop services. It uses <a href="https://theprivacyguide.org/tutorials/gpg.html">GNU Privacy Guard (GPG)</a> for content encryption and authentication, and TLS 1.2 with ephemeral keys for transport encryption.
+
+Become_Your_Own_Email_Provider_with_MailinaBox_49_KEY: |-
+  Become Your Own Email Provider with Mail-in-a-Box
+
+httpsmailinaboxPemail_25_KEY: |-
+  https://mailinabox.email/
+
+MailinaBox_13_KEY: |-
+  Mail-in-a-Box
+
+Take_it_a_step_further_and_get_control_of_your_email_with_this_easytodeploy_mail_server_in_a_boxP_MailinaBox_lets_you_become_your_own_mail_service_405_KEY: |-
+  Take it a step further and get control of your email with this easy-to-deploy mail server in a box. Mail-in-a-Box lets you become your own mail service provider in a few easy steps. It's sort of like making your own Gmail, but one you control from top to bottom. Technically, Mail-in-a-Box turns a fresh cloud computer into a working mail server. But you don't need to be a technology expert to set it up.
+
+More_5_KEY: |-
+  More:
+
+httpswwwPwiredPcom201110ecpaturnstwentyfive_53_KEY: |-
+  https://www.wired.com/2011/10/ecpa-turns-twenty-five/
+
+Aging_Privacy_Law_Leaves_Cloud_EMail_Open_to_Cops_52_KEY: |-
+  Aging 'Privacy' Law Leaves Cloud E-Mail Open to Cops
+
+Data_stored_in_the_cloud_for_longer_than_6_months_is_considered_abandoned_and_may_be_accessed_by_intelligence_agencies_without_a_warrantP_Learning_Use_283_KEY: |-
+  Data stored in the cloud for longer than 6 months is considered abandoned and may be accessed by intelligence agencies without a warrant. Learning: Use an external email client like Thunderbird or Enigmail, download your emails and store them locally. Never leave them on the server.
+
+httpswwwPeffPorgdeeplinks201204mayfirstriseupserverseizurefbioverreachesyetagain_94_KEY: |-
+  https://www.eff.org/deeplinks/2012/04/may-firstriseup-server-seizure-fbi-overreaches-yet-again
+
+With_May_FirstRiseup_Server_Seizure_FBI_Overreaches_Yet_Again_63_KEY: |-
+  With May First/Riseup Server Seizure, FBI Overreaches Yet Again
+
+httpswwwPautisticiPorgaicrackdown_39_KEY: |-
+  https://www.autistici.org/ai/crackdown/
+
+AutisticiInventati_server_compromised_38_KEY: |-
+  Autistici/Inventati server compromised
+
+The_cryptographic_services_offered_by_the_AutisticiInventati_server_have_been_compromised_on_15th_June_2004P_It_was_discovered_on_21st_June_2005P_One__341_KEY: |-
+  The cryptographic services offered by the Autistici/Inventati server have been compromised on 15th June 2004. It was discovered on 21st June 2005. One year later. During an enquiry on a single mailbox, the Postal Police may have tapped for a whole year every user's private communication going through the server autistici.org/inventati.org.
+
+File_Encryption_Software_24_KEY: |-
   File Encryption Software
 
-If_you_are_currently_not_using_encryption_software_for_your_hard_disk_emails_or_file_archives_you_should_pick_one_hereP_123_KEY: |-
+If_you_are_currently_not_using_encryption_software_for_your_hard_disk_emails_or_file_archives_you_should_pick_one_hereP_122_KEY: |-
   If you are currently not using encryption software for your hard disk, emails, or file archives, you should pick one here.
 
 VeraCrypt__Disk_Encryption_27_KEY: |-
@@ -2318,43 +2291,43 @@ httpswwwPpeazipPorgpeazipbsdPhtml_38_KEY: |-
 httpsosdnPnetprojectspeazip_32_KEY: |-
   https://osdn.net/projects/peazip
 
-httpscryptomatorPorg_25_KEY: |-
+httpscryptomatorPorg_24_KEY: |-
   https://cryptomator.org/
 
-Cryptomator_12_KEY: |-
+Cryptomator_11_KEY: |-
   Cryptomator
 
 Free_clientside_AES_encryption_for_your_cloud_filesP_Open_source_software_No_backdoors_no_registrationP_106_KEY: |-
   Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.
 
-Cryptomators_mobile_apps_are_not_opensourceP_47_KEY: |-
+Cryptomators_mobile_apps_are_not_opensourceP_46_KEY: |-
   Cryptomator's mobile apps are not open-source.
 
-httpsgitlabPcomcryptsetupcryptsetup_42_KEY: |-
+httpsgitlabPcomcryptsetupcryptsetup_41_KEY: |-
   https://gitlab.com/cryptsetup/cryptsetup/
 
-Linux_Unified_Key_Setup_LUKS_31_KEY: |-
+Linux_Unified_Key_Setup_LUKS_30_KEY: |-
   Linux Unified Key Setup (LUKS)
 
-A_full_disk_encryption_system_for_Linux_using_dmcrypt_as_the_disk_encryption_backendP_Included_by_default_in_UbuntuP_Available_for_Windows_and_LinuxP_151_KEY: |-
+A_full_disk_encryption_system_for_Linux_using_dmcrypt_as_the_disk_encryption_backendP_Included_by_default_in_UbuntuP_Available_for_Windows_and_LinuxP_150_KEY: |-
   A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.
 
-httpshatPsh_16_KEY: |-
+httpshatPsh_15_KEY: |-
   https://hat.sh/
 
-HatPsh_7_KEY: |-
+HatPsh_6_KEY: |-
   Hat.sh
 
-A_crossplatform_serverless_JavaScript_web_application_that_provides_secure_file_encryption_using_the_AES256GCM_algorithm_in_your_browserP_It_can_al_189_KEY: |-
+A_crossplatform_serverless_JavaScript_web_application_that_provides_secure_file_encryption_using_the_AES256GCM_algorithm_in_your_browserP_It_can_al_188_KEY: |-
   A cross-platform, serverless JavaScript web application that provides secure file encryption using the AES-256-GCM algorithm in your browser. It can also be downloaded and run offline.</a>
 
-httpswwwPkekaPio_21_KEY: |-
+httpswwwPkekaPio_20_KEY: |-
   https://www.keka.io/
 
-Keka_5_KEY: |-
+Keka_4_KEY: |-
   Keka
 
-A_macOSonly_opensource_file_archiver_with_the_ability_to_encrypt_filesP_75_KEY: |-
+A_macOSonly_opensource_file_archiver_with_the_ability_to_encrypt_filesP_74_KEY: |-
   A macOS-only, open-source file archiver with the ability to encrypt files.
 
 Firefox_Send_12_KEY: |-
@@ -2414,22 +2387,22 @@ httpspypiPorgprojectmagicwormhole_40_KEY: |-
 httpsgithubPcomwarnermagicwormhole_40_KEY: |-
   https://github.com/warner/magic-wormhole
 
-httpsgithubPcomschollzcroc_32_KEY: |-
+httpsgithubPcomschollzcroc_31_KEY: |-
   https://github.com/schollz/croc
 
-croc_5_KEY: |-
+croc_4_KEY: |-
   croc
 
-Easily_and_securely_send_things_from_one_computer_to_anotherP_62_KEY: |-
+Easily_and_securely_send_things_from_one_computer_to_anotherP_61_KEY: |-
   Easily and securely send things from one computer to another.
 
-httpsfreedomboxPorg_24_KEY: |-
+httpsfreedomboxPorg_23_KEY: |-
   https://freedombox.org/
 
-FreedomBox_11_KEY: |-
+FreedomBox_10_KEY: |-
   FreedomBox
 
-Designed_to_be_your_own_inexpensive_server_at_homeP_It_runs_free_software_and_offers_an_increasing_number_of_services_ranging_from_a_calendar_or_Jabber_179_KEY: |-
+Designed_to_be_your_own_inexpensive_server_at_homeP_It_runs_free_software_and_offers_an_increasing_number_of_services_ranging_from_a_calendar_or_Jabber_178_KEY: |-
   Designed to be your own inexpensive server at home. It runs free software and offers an increasing number of services ranging from a calendar or Jabber server, to a wiki, or VPN.
 
 Syncthing_9_KEY: |-
@@ -2474,16 +2447,16 @@ httpswwwPsparklesharePorg_29_KEY: |-
 httpsgithubPcomhbonsSparkleShare_37_KEY: |-
   https://github.com/hbons/SparkleShare
 
-httpsgitannexPbranchablePcom_34_KEY: |-
+httpsgitannexPbranchablePcom_33_KEY: |-
   https://git-annex.branchable.com/
 
-gitannex_10_KEY: |-
+gitannex_9_KEY: |-
   git-annex
 
-Allows_managing_files_with_git_without_checking_the_file_contents_into_gitP_While_that_may_seem_paradoxical_it_is_useful_when_dealing_with_files_larg_251_KEY: |-
+Allows_managing_files_with_git_without_checking_the_file_contents_into_gitP_While_that_may_seem_paradoxical_it_is_useful_when_dealing_with_files_larg_250_KEY: |-
   Allows managing files with git, without checking the file contents into git. While that may seem paradoxical, it is useful when dealing with files larger than git can currently easily handle, whether due to limitations in memory, time, or disk space.
 
-Secure_Hosting_Provider_24_KEY: |-
+Secure_Hosting_Provider_23_KEY: |-
   Secure Hosting Provider
 
 Data_Center_Bahnhof_20_KEY: |-
@@ -2522,28 +2495,28 @@ Orange_Website_is_an_Icelandic_web_hosting_provider_that_prides_themselves_in_pr
 httpswwwPorangewebsitePcom_30_KEY: |-
   https://www.orangewebsite.com/
 
-NewE_5_KEY: |-
+NewE_4_KEY: |-
   New!
 
 Financial_a_hrefhttpsopencollectivePcomprivacytoolsio_classalertlinkcontributionsa_to__sitePname__are_now_tax_deductible_in_the_USE_151_KEY: |-
   Financial <a href="https://opencollective.com/privacytoolsio" class="alert-link">contributions</a> to {{ site.name }} are now tax deductible in the US!
 
-Learn_morePPP_14_KEY: |-
+Learn_morePPP_13_KEY: |-
   Learn more...
 
-You_are_being_watchedP_Private_and_statesponsored_organizations_are_monitoring_and_recording_your_online_activitiesP__sitePname__provides_services_231_KEY: |-
+You_are_being_watchedP_Private_and_statesponsored_organizations_are_monitoring_and_recording_your_online_activitiesP__sitePname__provides_services_230_KEY: |-
   You are being watched. Private and state-sponsored organizations are monitoring and recording your online activities. {{ site.name }} provides services, tools and knowledge to protect your privacy against global mass surveillance.
 
-Try__sitePname__Search_a_PrivacyRespecting_Search_Engine_63_KEY: |-
+Try__sitePname__Search_a_PrivacyRespecting_Search_Engine_62_KEY: |-
   Try {{ site.name }} Search, a Privacy-Respecting Search Engine
 
-start_search_13_KEY: |-
+start_search_12_KEY: |-
   start search
 
-Privacy_Tools_14_KEY: |-
+Privacy_Tools_13_KEY: |-
   Privacy Tools
 
-Prefer_the_classic_siteQ_View_a_singlepage_layoutP_52_KEY: |-
+Prefer_the_classic_siteQ_View_a_singlepage_layoutP_51_KEY: |-
   Prefer the classic site? View a single-page layout.
 
 Discover_privacycentric_online_services_including_email_providers_VPN_operators_DNS_administrators_and_moreE_113_KEY: |-
@@ -2551,9 +2524,6 @@ Discover_privacycentric_online_services_including_email_providers_VPN_operators_
 
 Find_a_web_browser_that_respects_your_privacy_and_discover_how_to_harden_your_browser_against_tracking_and_leaksP_114_KEY: |-
   Find a web browser that respects your privacy, and discover how to harden your browser against tracking and leaks.
-
-Software_8_KEY: |-
-  Software
 
 Discover_a_variety_of_open_source_software_built_to_protect_your_privacy_and_keep_your_digital_data_secureP_107_KEY: |-
   Discover a variety of open source software built to protect your privacy and keep your digital data secure.
@@ -2567,25 +2537,22 @@ PrivacyTools_Services_21_KEY: |-
 The_PrivacyTools_team_is_proud_to_launch_a_variety_of_privacycentric_online_services_including_a_Mastodon_instance_search_engine_and_moreE_142_KEY: |-
   The PrivacyTools team is proud to launch a variety of privacy-centric online services, including a Mastodon instance, search engine, and more!
 
-Donate_6_KEY: |-
-  Donate
-
 We_cant_operate_this_site_without_the_generous_contributions_we_receive_from_our_viewersP_If_you_love_privacy_and_our_website_please_consider_donating_152_KEY: |-
   We can't operate this site without the generous contributions we receive from our viewers. If you love privacy and our website please consider donating.
 
-Showcase_your_brand_as_a_sponsor_of_PrivacyTools_here_and_support_our_mission_of_creating_a_world_free_of_mass_surveillanceE_125_KEY: |-
+Showcase_your_brand_as_a_sponsor_of_PrivacyTools_here_and_support_our_mission_of_creating_a_world_free_of_mass_surveillanceE_124_KEY: |-
   Showcase your brand as a sponsor of PrivacyTools here and support our mission of creating a world free of mass surveillance!
 
-PrivacyQ_I_dont_have_anything_to_hideP_40_KEY: |-
+PrivacyQ_I_dont_have_anything_to_hideP_39_KEY: |-
   Privacy? I don't have anything to hide.
 
-httpswwwPtedPcomtalksglenn_greenwald_why_privacy_matters_62_KEY: |-
+httpswwwPtedPcomtalksglenn_greenwald_why_privacy_matters_61_KEY: |-
   https://www.ted.com/talks/glenn_greenwald_why_privacy_matters
 
-Glenn_Greenwald__Why_privacy_matters__TED_Talk_49_KEY: |-
+Glenn_Greenwald__Why_privacy_matters__TED_Talk_48_KEY: |-
   Glenn Greenwald - Why privacy matters - TED Talk
 
-Glenn_Greenwald_Why_privacy_matters_37_KEY: |-
+Glenn_Greenwald_Why_privacy_matters_36_KEY: |-
   Glenn Greenwald: Why privacy matters
 
 Over_the_last_16_months_as_Ive_debated_this_issue_around_the_world_every_single_time_somebody_has_said_to_me_I_dont_really_worry_about_invasions__805_KEY: |-
@@ -2600,28 +2567,28 @@ The_primary_reason_for_window_curtains_in_our_house_is_to_stop_people_from_being
 Joshua_in_cite_titleThe_Crypto_Papera_hrefhttpsgithubPcomcryptosebCryptoPaperletmeexplainfurtherThe_Crypto_Paperacite_142_KEY: |-
   Joshua in <cite title="The Crypto Paper"><a href="https://github.com/cryptoseb/CryptoPaper#let-me-explain-further">The Crypto Paper</a></cite>
 
-Read_also_11_KEY: |-
+Read_also_10_KEY: |-
   Read also:
 
-httpsenPwikipediaPorgwikiNothing_to_hide_argument_55_KEY: |-
+httpsenPwikipediaPorgwikiNothing_to_hide_argument_54_KEY: |-
   https://en.wikipedia.org/wiki/Nothing_to_hide_argument
 
-Nothing_to_hide_argument_Wikipedia_37_KEY: |-
+Nothing_to_hide_argument_Wikipedia_36_KEY: |-
   Nothing to hide argument (Wikipedia)
 
-httpswwwPredditPcomrprivacycomments3hynvphow_do_you_counter_the_i_have_nothing_to_hide_96_KEY: |-
+httpswwwPredditPcomrprivacycomments3hynvphow_do_you_counter_the_i_have_nothing_to_hide_95_KEY: |-
   https://www.reddit.com/r/privacy/comments/3hynvp/how_do_you_counter_the_i_have_nothing_to_hide/
 
-How_do_you_counter_the_I_have_nothing_to_hideQ_argumentQ_redditPcom_72_KEY: |-
+How_do_you_counter_the_I_have_nothing_to_hideQ_argumentQ_redditPcom_71_KEY: |-
   How do you counter the "I have nothing to hide?" argument? (reddit.com)
 
-httpspapersPssrnPcomsol3papersPcfmQabstract_id998565_59_KEY: |-
+httpspapersPssrnPcomsol3papersPcfmQabstract_id998565_58_KEY: |-
   https://papers.ssrn.com/sol3/papers.cfm?abstract_id=998565
 
 Ive_Got_Nothing_to_Hide_and_Other_Misunderstandings_of_Privacy_Daniel_JP_Solove__San_Diego_Law_Review_107_KEY: |-
   'I've Got Nothing to Hide' and Other Misunderstandings of Privacy (Daniel J. Solove - San Diego Law Review)
 
-Quotes_7_KEY: |-
+Quotes_6_KEY: |-
   Quotes
 
 Arguing_that_you_dont_care_about_the_right_to_privacy_because_you_have_nothing_to_hide_is_no_different_than_saying_you_dont_care_about_free_speech_be_181_KEY: |-
@@ -2630,7 +2597,7 @@ Arguing_that_you_dont_care_about_the_right_to_privacy_because_you_have_nothing_t
 Edward_Snowden_on_cite_titleJust_days_left_to_kill_mass_surveillance_under_Section_215_of_the_Patriot_ActP_We_are_Edward_Snowden_and_the_ACLUs_Jame_296_KEY: |-
   Edward Snowden on <cite title="Just days left to kill mass surveillance under Section 215 of the Patriot Act. We are Edward Snowden and the ACLU's Jameel Jaffer. AUA."><a href="https://www.reddit.com/r/IAmA/comments/36ru89/just_days_left_to_kill_mass_surveillance_under/crglgh2">Reddit</a></cite>
 
-The_NSA_has_built_an_infrastructure_that_allows_it_to_intercept_almost_everythingP_With_this_capability_the_vast_majority_of_human_communications_are__550_KEY: |-
+The_NSA_has_built_an_infrastructure_that_allows_it_to_intercept_almost_everythingP_With_this_capability_the_vast_majority_of_human_communications_are__549_KEY: |-
   The NSA has built an infrastructure that allows it to intercept almost everything. With this capability, the vast majority of human communications are automatically ingested without targeting. If I wanted to see your emails or your wife's phone, all I have to do is use intercepts. I can get your emails, passwords, phone records, credit cards. I don't want to live in a society that does these sort of things... I do not want to live in a world where everything I do and say is recorded. That is not something I am willing to support or live under.
 
 Edward_Snowden_in_cite_titleEdward_Snowden_NSA_files_source_If_they_want_to_get_you_in_time_they_willa_hrefhttpswwwPtheguardianPcomwor_227_KEY: |-
@@ -2642,235 +2609,232 @@ We_all_need_places_where_we_can_go_to_explore_without_the_judgmental_eyes_of_oth
 Glenn_Greenwald_in_cite_titleGlenn_Greenwald_On_Why_Privacy_Is_Vital_Even_If_You_Have_Nothing_To_Hidea_hrefhttpswwwPhuffingtonpostPcom201_225_KEY: |-
   Glenn Greenwald in <cite title="Glenn Greenwald On Why Privacy Is Vital, Even If You 'Have Nothing To Hide"><a href="https://www.huffingtonpost.com/2014/06/20/glenn-greenwald-privacy_n_5509704.html">Huffington Post</a></cite>
 
-More_Privacy_Resources_23_KEY: |-
+More_Privacy_Resources_22_KEY: |-
   More Privacy Resources
 
-Guides_7_KEY: |-
+Guides_6_KEY: |-
   Guides
 
-httpsssdPeffPorg_21_KEY: |-
+httpsssdPeffPorg_20_KEY: |-
   https://ssd.eff.org/
 
-Surveillance_SelfDefense_by_EFF_33_KEY: |-
+Surveillance_SelfDefense_by_EFF_32_KEY: |-
   Surveillance Self-Defense by EFF
 
-Guide_to_defending_yourself_from_surveillance_by_using_secure_technology_and_developing_careful_practicesP_107_KEY: |-
+Guide_to_defending_yourself_from_surveillance_by_using_secure_technology_and_developing_careful_practicesP_106_KEY: |-
   Guide to defending yourself from surveillance by using secure technology and developing careful practices.
 
-httpsgithubPcomcryptosebCryptoPaper_41_KEY: |-
+httpsgithubPcomcryptosebCryptoPaper_40_KEY: |-
   https://github.com/cryptoseb/CryptoPaper
 
-The_Crypto_Paper_17_KEY: |-
+The_Crypto_Paper_16_KEY: |-
   The Crypto Paper
 
-Privacy_Security_and_Anonymity_for_Every_Internet_UserP_57_KEY: |-
+Privacy_Security_and_Anonymity_for_Every_Internet_UserP_56_KEY: |-
   Privacy, Security and Anonymity for Every Internet User.
 
-httpsemailselfdefensePfsfPorgen_37_KEY: |-
+httpsemailselfdefensePfsfPorgen_36_KEY: |-
   https://emailselfdefense.fsf.org/en/
 
-Email_SelfDefense_by_FSF_26_KEY: |-
+Email_SelfDefense_by_FSF_25_KEY: |-
   Email Self-Defense by FSF
 
-A_guide_to_fighting_surveillance_with_GnuPG_encryptionP_56_KEY: |-
+A_guide_to_fighting_surveillance_with_GnuPG_encryptionP_55_KEY: |-
   A guide to fighting surveillance with GnuPG encryption.
 
-httpswwwPbestvpnPcomtheultimateprivacyguide_52_KEY: |-
+httpswwwPbestvpnPcomtheultimateprivacyguide_51_KEY: |-
   https://www.bestvpn.com/the-ultimate-privacy-guide/
 
-The_Ultimate_Privacy_Guide_27_KEY: |-
+The_Ultimate_Privacy_Guide_26_KEY: |-
   The Ultimate Privacy Guide
 
-Excellent_privacy_guide_written_by_the_creators_of_the_bestVPNPcom_websiteP_76_KEY: |-
+Excellent_privacy_guide_written_by_the_creators_of_the_bestVPNPcom_websiteP_75_KEY: |-
   Excellent privacy guide written by the creators of the bestVPN.com website.
 
-httpswwwPivpnPnetprivacyguides_36_KEY: |-
+httpswwwPivpnPnetprivacyguides_35_KEY: |-
   https://www.ivpn.net/privacy-guides
 
-IVPN_Privacy_Guides_20_KEY: |-
+IVPN_Privacy_Guides_19_KEY: |-
   IVPN Privacy Guides
 
-These_privacy_guides_explain_how_to_obtain_vastly_greater_freedom_privacy_and_anonymity_through_compartmentalization_and_isolationP_133_KEY: |-
+These_privacy_guides_explain_how_to_obtain_vastly_greater_freedom_privacy_and_anonymity_through_compartmentalization_and_isolationP_132_KEY: |-
   These privacy guides explain how to obtain vastly greater freedom, privacy and anonymity through compartmentalization and isolation.
 
-httpsfriedPcomprivacy_26_KEY: |-
+httpsfriedPcomprivacy_25_KEY: |-
   https://fried.com/privacy
 
-The_Ultimate_Guide_to_Online_Privacy_37_KEY: |-
+The_Ultimate_Guide_to_Online_Privacy_36_KEY: |-
   The Ultimate Guide to Online Privacy
 
-Comprehensive_Ninja_Privacy_Tips_and_150_toolsP_51_KEY: |-
+Comprehensive_Ninja_Privacy_Tips_and_150_toolsP_50_KEY: |-
   Comprehensive "Ninja Privacy Tips" and 150+ tools.
 
-Information_12_KEY: |-
+Information_11_KEY: |-
   Information
 
-httpsfreedomPpress_23_KEY: |-
+httpsfreedomPpress_22_KEY: |-
   https://freedom.press/
 
-Freedom_of_the_Press_Foundation_32_KEY: |-
+Freedom_of_the_Press_Foundation_31_KEY: |-
   Freedom of the Press Foundation
 
-Supporting_and_defending_journalism_dedicated_to_transparency_and_accountability_since_2012P_93_KEY: |-
+Supporting_and_defending_journalism_dedicated_to_transparency_and_accountability_since_2012P_92_KEY: |-
   Supporting and defending journalism dedicated to transparency and accountability since 2012.
 
-httpswwwPerfahrungenPcommitanonymisierungt_50_KEY: |-
+httpswwwPerfahrungenPcommitanonymisierungt_49_KEY: |-
   https://www.erfahrungen.com/mit/anonymisierung/t/
 
-ErfahrungenPcom_16_KEY: |-
+ErfahrungenPcom_15_KEY: |-
   Erfahrungen.com
 
-German_review_aggregator_website_of_privacyrelated_servicesP_62_KEY: |-
+German_review_aggregator_website_of_privacyrelated_servicesP_61_KEY: |-
   German review aggregator website of privacy-related services.
 
-httpsopenwirelessPorg_26_KEY: |-
+httpsopenwirelessPorg_25_KEY: |-
   https://openwireless.org/
 
-Open_Wireless_Movement_23_KEY: |-
+Open_Wireless_Movement_22_KEY: |-
   Open Wireless Movement
 
-a_coalition_of_Internet_freedom_advocates_companies_organizations_and_technologists_working_to_develop_new_wireless_technologies_and_to_inspire_a_mo_180_KEY: |-
+a_coalition_of_Internet_freedom_advocates_companies_organizations_and_technologists_working_to_develop_new_wireless_technologies_and_to_inspire_a_mo_179_KEY: |-
   a coalition of Internet freedom advocates, companies, organizations, and technologists working to develop new wireless technologies and to inspire a movement of Internet openness.
 
-httpsprivacyPnetusgovernmentsurveillancespyingdata_59_KEY: |-
+httpsprivacyPnetusgovernmentsurveillancespyingdata_58_KEY: |-
   https://privacy.net/us-government-surveillance-spying-data
 
-privacyPnet_12_KEY: |-
+privacyPnet_11_KEY: |-
   privacy.net
 
-What_does_the_US_government_know_about_youQ_44_KEY: |-
+What_does_the_US_government_know_about_youQ_43_KEY: |-
   What does the US government know about you?
 
-httpswwwPredditPcomrprivacytoolsIOwikiindex_51_KEY: |-
+httpswwwPredditPcomrprivacytoolsIOwikiindex_50_KEY: |-
   https://www.reddit.com/r/privacytoolsIO/wiki/index
 
-rprivacytoolsIO_Wiki_22_KEY: |-
+rprivacytoolsIO_Wiki_21_KEY: |-
   r/privacytoolsIO Wiki
 
-Our_Wiki_on_redditPcomP_24_KEY: |-
+Our_Wiki_on_redditPcomP_23_KEY: |-
   Our Wiki on reddit.com.
 
-httpswwwPgrcPcomsecuritynowPhtm_36_KEY: |-
+httpswwwPgrcPcomsecuritynowPhtm_35_KEY: |-
   https://www.grc.com/securitynow.htm
 
-Security_NowE_14_KEY: |-
+Security_NowE_13_KEY: |-
   Security Now!
 
-Weekly_Internet_Security_Podcast_by_Steve_Gibson_and_Leo_LaporteP_66_KEY: |-
+Weekly_Internet_Security_Podcast_by_Steve_Gibson_and_Leo_LaporteP_65_KEY: |-
   Weekly Internet Security Podcast by Steve Gibson and Leo Laporte.
 
-httpswwwPjupiterbroadcastingPcomshowtechsnap_51_KEY: |-
+httpswwwPjupiterbroadcastingPcomshowtechsnap_50_KEY: |-
   https://www.jupiterbroadcasting.com/show/techsnap/
 
-TechSNAP_9_KEY: |-
+TechSNAP_8_KEY: |-
   TechSNAP
 
-Weekly_Systems_Network_and_Administration_PodcastP_Every_week_TechSNAP_covers_the_stories_that_impact_those_of_us_in_the_tech_industryP_138_KEY: |-
+Weekly_Systems_Network_and_Administration_PodcastP_Every_week_TechSNAP_covers_the_stories_that_impact_those_of_us_in_the_tech_industryP_137_KEY: |-
   Weekly Systems, Network, and Administration Podcast. Every week TechSNAP covers the stories that impact those of us in the tech industry.
 
-httpstosdrPorg_19_KEY: |-
-  https://tosdr.org/
-
-Terms_of_Service_Didnt_Read_30_KEY: |-
+Terms_of_Service_Didnt_Read_29_KEY: |-
   Terms of Service; Didn't Read
 
-I_have_read_and_agree_to_the_Terms_is_the_biggest_lie_on_the_webP_We_aim_to_fix_thatP_88_KEY: |-
+I_have_read_and_agree_to_the_Terms_is_the_biggest_lie_on_the_webP_We_aim_to_fix_thatP_87_KEY: |-
   "I have read and agree to the Terms" is the biggest lie on the web. We aim to fix that.
 
-httpscodebergPorgcrimeflarecloudflaretor_47_KEY: |-
+httpscodebergPorgcrimeflarecloudflaretor_46_KEY: |-
   https://codeberg.org/crimeflare/cloudflare-tor
 
-The_Great_Cloudwall_20_KEY: |-
+The_Great_Cloudwall_19_KEY: |-
   The Great Cloudwall
 
-Critique_and_information_on_why_to_avoid_Cloudflare_a_big_company_with_a_huge_portion_of_the_internet_behind_itP_114_KEY: |-
+Critique_and_information_on_why_to_avoid_Cloudflare_a_big_company_with_a_huge_portion_of_the_internet_behind_itP_113_KEY: |-
   Critique and information on why to avoid Cloudflare, a big company with a huge portion of the internet behind it.
 
-Tools_6_KEY: |-
+Tools_5_KEY: |-
   Tools
 
-httpsipleakPnet_20_KEY: |-
+httpsipleakPnet_19_KEY: |-
   https://ipleak.net/
 
-ipleakPnet_11_KEY: |-
+ipleakPnet_10_KEY: |-
   ipleak.net
 
-IPDNS_Detect__What_is_your_IP_what_is_your_DNS_what_informations_you_send_to_websitesP_91_KEY: |-
+IPDNS_Detect__What_is_your_IP_what_is_your_DNS_what_informations_you_send_to_websitesP_90_KEY: |-
   IP/DNS Detect - What is your IP, what is your DNS, what informations you send to websites.
 
-httpswwwPghacksPnet20151228theultimateonlineprivacytestresourcelist_82_KEY: |-
+httpswwwPghacksPnet20151228theultimateonlineprivacytestresourcelist_81_KEY: |-
   https://www.ghacks.net/2015/12/28/the-ultimate-online-privacy-test-resource-list/
 
-The_ultimate_Online_Privacy_Test_Resource_List_47_KEY: |-
+The_ultimate_Online_Privacy_Test_Resource_List_46_KEY: |-
   The ultimate Online Privacy Test Resource List
 
-A_collection_of_Internet_sites_that_check_whether_your_web_browser_leaks_informationP_86_KEY: |-
+A_collection_of_Internet_sites_that_check_whether_your_web_browser_leaks_informationP_85_KEY: |-
   A collection of Internet sites that check whether your web browser leaks information.
 
-httpsprismbreakPorg_25_KEY: |-
+httpsprismbreakPorg_24_KEY: |-
   https://prism-break.org/
 
-PRISM_Break_12_KEY: |-
+PRISM_Break_11_KEY: |-
   PRISM Break
 
-We_all_have_a_right_to_privacy_which_you_can_exercise_today_by_encrypting_your_communications_and_ending_your_reliance_on_proprietary_servicesP_145_KEY: |-
+We_all_have_a_right_to_privacy_which_you_can_exercise_today_by_encrypting_your_communications_and_ending_your_reliance_on_proprietary_servicesP_144_KEY: |-
   We all have a right to privacy, which you can exercise today by encrypting your communications and ending your reliance on proprietary services.
 
-httpssecurityinaboxPorg_28_KEY: |-
+httpssecurityinaboxPorg_27_KEY: |-
   https://securityinabox.org/
 
-Security_inaBox_18_KEY: |-
+Security_inaBox_17_KEY: |-
   Security in-a-Box
 
-A_guide_to_digital_security_for_activists_and_human_rights_defenders_throughout_the_worldP_91_KEY: |-
+A_guide_to_digital_security_for_activists_and_human_rights_defenders_throughout_the_worldP_90_KEY: |-
   A guide to digital security for activists and human rights defenders throughout the world.
 
-httpssecuredropPorg_24_KEY: |-
+httpssecuredropPorg_23_KEY: |-
   https://securedrop.org/
 
-SecureDrop_11_KEY: |-
+SecureDrop_10_KEY: |-
   SecureDrop
 
-An_opensource_whistleblower_submission_system_that_media_organizations_can_use_to_securely_accept_documents_from_and_communicate_with_anonymous_source_266_KEY: |-
+An_opensource_whistleblower_submission_system_that_media_organizations_can_use_to_securely_accept_documents_from_and_communicate_with_anonymous_source_265_KEY: |-
   An open-source whistleblower submission system that media organizations can use to securely accept documents from and communicate with anonymous sources. It was originally created by the late Aaron Swartz and is currently managed by Freedom of the Press Foundation.
 
-httpspackPresetthenetPorg_30_KEY: |-
+httpspackPresetthenetPorg_29_KEY: |-
   https://pack.resetthenet.org/
 
-Reset_The_Net__Privacy_Pack_29_KEY: |-
+Reset_The_Net__Privacy_Pack_28_KEY: |-
   Reset The Net - Privacy Pack
 
-Help_fight_to_end_mass_surveillanceP_Get_these_tools_to_protect_yourself_and_your_friendsP_91_KEY: |-
+Help_fight_to_end_mass_surveillanceP_Get_these_tools_to_protect_yourself_and_your_friendsP_90_KEY: |-
   Help fight to end mass surveillance. Get these tools to protect yourself and your friends.
 
-httpssecfirstPorg_22_KEY: |-
+httpssecfirstPorg_21_KEY: |-
   https://secfirst.org/
 
-Security_First_15_KEY: |-
+Security_First_14_KEY: |-
   Security First
 
-Umbrella_is_an_Android_app_that_provides_all_the_advice_needed_to_operate_safely_in_a_hostile_environmentP_107_KEY: |-
+Umbrella_is_an_Android_app_that_provides_all_the_advice_needed_to_operate_safely_in_a_hostile_environmentP_106_KEY: |-
   Umbrella is an Android app that provides all the advice needed to operate safely in a hostile environment.
 
-httpswwwPosaltPcom_23_KEY: |-
+httpswwwPosaltPcom_22_KEY: |-
   https://www.osalt.com/
 
-Osalt_6_KEY: |-
+Osalt_5_KEY: |-
   Osalt
 
-A_directory_to_help_you_find_open_source_alternatives_to_proprietary_toolsP_76_KEY: |-
+A_directory_to_help_you_find_open_source_alternatives_to_proprietary_toolsP_75_KEY: |-
   A directory to help you find open source alternatives to proprietary tools.
 
-httpsalternativetoPnet_27_KEY: |-
+httpsalternativetoPnet_26_KEY: |-
   https://alternativeto.net/
 
-AlternativeTo_14_KEY: |-
+AlternativeTo_13_KEY: |-
   AlternativeTo
 
-A_directory_to_help_find_alternatives_to_other_software_with_the_option_to_only_show_open_source_software_107_KEY: |-
+A_directory_to_help_find_alternatives_to_other_software_with_the_option_to_only_show_open_source_software_106_KEY: |-
   A directory to help find alternatives to other software, with the option to only show open source software
 
-Note_Just_being_open_source_does_not_make_software_secureE_60_KEY: |-
+Note_Just_being_open_source_does_not_make_software_secureE_59_KEY: |-
   Note: Just being open source does not make software secure!
 
 Participate_with_suggestions_and_constructive_criticism_55_KEY: |-
@@ -2879,10 +2843,10 @@ Participate_with_suggestions_and_constructive_criticism_55_KEY: |-
 Its_important_for_a_website_like__sitePname__to_stay_uptodateP_Keep_an_eye_on_software_updates_for_the_applications_listed_on_our_siteP_Follow_r_748_KEY: |-
   It's important for a website like {{ site.name }} to stay up-to-date. Keep an eye on software updates for the applications listed on our site. Follow recent news about providers that we recommend. We try our best to keep up, but we're not perfect and the internet is changing fast. If you find an error, or you think a provider should not be listed here, or a qualified service provider is missing, or a browser plugin is not the best choice anymore, or anything else... <strong>Talk to us please.</strong> You can also find us on <a rel="me" href="https://social.privacytools.io/@privacytools">our own Mastodon instance</a> or on <a href="https://chat.privacytools.io">Matrix</a> at <code class="highlighter-rouge">#general:privacytools.io</code>.
 
-Reddit_7_KEY: |-
+Reddit_6_KEY: |-
   Reddit
 
-Contributor_List_17_KEY: |-
+Contributor_List_16_KEY: |-
   Contributor List
 
 Discourse__Reddit_18_KEY: |-
@@ -2906,9 +2870,6 @@ Get_the_latest_privacyrelated_updates_from_our_Mastodon_FeedP_Follow_us_todayE_7
 httpssocialPprivacytoolsPio_31_KEY: |-
   https://social.privacytools.io/
 
-Mastodon_8_KEY: |-
-  Mastodon
-
 Develop_on_GitHub_17_KEY: |-
   Develop on GitHub
 
@@ -2921,14 +2882,11 @@ httpsgithubPcomprivacytoolsIOprivacytoolsPio_49_KEY: |-
 GitHub_6_KEY: |-
   GitHub
 
-This_is_a_community_project_aiming_to_deliver_the_best_information_available_to_improve_privacy_onlineP_Thank_you_for_participatingP_This_project_needs_157_KEY: |-
+This_is_a_community_project_aiming_to_deliver_the_best_information_available_to_improve_privacy_onlineP_Thank_you_for_participatingP_This_project_needs_156_KEY: |-
   This is a community project aiming to deliver the best information available to improve privacy online. Thank you for participating. This project needs you.
 
-If_you_are_currently_browsing_a_hrefhttpsenPwikipediaPorgwikiSurface_Webclearneta_and_want_to_access_the_a_hrefhttpsenPwikipediaPorg_206_KEY: |-
+If_you_are_currently_browsing_a_hrefhttpsenPwikipediaPorgwikiSurface_Webclearneta_and_want_to_access_the_a_hrefhttpsenPwikipediaPorg_205_KEY: |-
   If you are currently browsing <a href="https://en.wikipedia.org/wiki/Surface_Web">clearnet</a> and want to access the <a href="https://en.wikipedia.org/wiki/Dark_web">dark web</a>, this section is for you.
-
-Tor_3_KEY: |-
-  Tor
 
 The_Tor_network_is_a_group_of_volunteeroperated_servers_that_allows_people_to_improve_their_privacy_and_security_on_the_InternetP_Tors_users_employ_t_430_KEY: |-
   The Tor network is a group of volunteer-operated servers that allows people to improve their privacy and security on the Internet. Tor's users employ this network by connecting through a series of virtual tunnels rather than making a direct connection, thus allowing both organizations and individuals to share information over public networks without compromising their privacy. Tor is an effective censorship circumvention tool.
@@ -2957,7 +2915,7 @@ The_Invisible_Internet_Project_I2P_is_a_computer_network_layer_that_allows_appli
 httpsgeti2pPnet_19_KEY: |-
   https://geti2p.net/
 
-Requires_specific_software_to_access_geti2pPnet_49_KEY: |-
+Requires_specific_software_to_access_geti2pPnet_48_KEY: |-
   Requires specific software to access: geti2p.net
 
 httpsgeti2pPnetendownloadwindows_38_KEY: |-
@@ -3011,46 +2969,40 @@ httpsfreenetprojectPorgpagesdownloadPhtmlgnulinuxposix_61_KEY: |-
 httpsgithubPcomfreenet_27_KEY: |-
   https://github.com/freenet/
 
-httpsdarknetdiariesPcom_28_KEY: |-
+httpsdarknetdiariesPcom_27_KEY: |-
   https://darknetdiaries.com/
 
-darknetdiariesPcom_19_KEY: |-
+darknetdiariesPcom_18_KEY: |-
   darknetdiaries.com
 
-True_stories_from_the_dark_side_of_the_InternetP_49_KEY: |-
+True_stories_from_the_dark_side_of_the_InternetP_48_KEY: |-
   True stories from the dark side of the Internet.
 
-httpszeronetPio_20_KEY: |-
+httpszeronetPio_19_KEY: |-
   https://zeronet.io/
 
-ZeroNet_8_KEY: |-
+ZeroNet_7_KEY: |-
   ZeroNet
 
 Open_free_and_uncensorable_websites_using_Bitcoin_cryptography_and_BitTorrent_networkP_89_KEY: |-
   Open, free, and uncensorable websites, using Bitcoin cryptography and BitTorrent network.
 
-Your_IP_address_isnt_hidden_by_default_and_wont_be_unless_you_enforce_Tor_usageP_84_KEY: |-
+Your_IP_address_isnt_hidden_by_default_and_wont_be_unless_you_enforce_Tor_usageP_83_KEY: |-
   Your IP address isn't hidden by default and won't be, unless you enforce Tor usage.
 
-privacy_warning_16_KEY: |-
+privacy_warning_15_KEY: |-
   privacy warning
 
-httpsretrosharePcc_23_KEY: |-
-  https://retroshare.cc/
-
-RetroShare_11_KEY: |-
-  RetroShare
-
-An_open_source_crossplatform_friendtofriend_secure_and_decentralized_communication_platformP_100_KEY: |-
+An_open_source_crossplatform_friendtofriend_secure_and_decentralized_communication_platformP_99_KEY: |-
   An open source, cross-platform, friend-to-friend, secure, and decentralized communication platform.
 
-httpsgnunetPorg_20_KEY: |-
+httpsgnunetPorg_19_KEY: |-
   https://gnunet.org/
 
-GNUnet_7_KEY: |-
+GNUnet_6_KEY: |-
   GNUnet
 
-GNUnet_provides_a_strong_foundation_of_free_software_for_a_global_distributed_network_that_provides_security_and_privacyP_123_KEY: |-
+GNUnet_provides_a_strong_foundation_of_free_software_for_a_global_distributed_network_that_provides_security_and_privacyP_122_KEY: |-
   GNUnet provides a strong foundation of free software for a global, distributed network that provides security and privacy.
 
 a_hrefhttpsipfsPioIPFSa_emandem_a_hrefhttpsgithubPcomipfsshipyardipfscompanionIPFS_Companiona_125_KEY: |-
@@ -3059,31 +3011,28 @@ a_hrefhttpsipfsPioIPFSa_emandem_a_hrefhttpsgithubPcomipfsshipyardipfscompanionIP
 A_peertopeer_hypermedia_protocol_to_make_the_web_faster_safer_and_more_openP_IPFS_Companion_is_a_browser_extension_for_redirecting_queries_to_a_gat_189_KEY: |-
   A peer-to-peer hypermedia protocol to make the web faster, safer, and more open. IPFS Companion is a browser extension for redirecting queries to a gateway of your choice (generally local).
 
-Important_privacy_warning_26_KEY: |-
+Important_privacy_warning_25_KEY: |-
   Important privacy warning
 
-httpsyggdrasilnetworkPgithubPio_37_KEY: |-
+httpsyggdrasilnetworkPgithubPio_36_KEY: |-
   https://yggdrasil-network.github.io/
 
-Yggdrasil_10_KEY: |-
+Yggdrasil_9_KEY: |-
   Yggdrasil
 
 An_earlystage_implementation_of_a_fully_endtoend_encrypted_IPv6_networkP_It_is_lightweight_selfarranging_supported_on_multiple_platforms_and_all_340_KEY: |-
   An early-stage implementation of a fully end-to-end encrypted IPv6 network. It is lightweight, self-arranging, supported on multiple platforms, and allows pretty much any IPv6-capable application to communicate securely with other Yggdrasil nodes. Yggdrasil does not require you to have IPv6 Internet connectivity - it also works over IPv4.
 
-The_project_is_currently_in_early_stages_but_it_is_being_actively_developedP_77_KEY: |-
+The_project_is_currently_in_early_stages_but_it_is_being_actively_developedP_76_KEY: |-
   The project is currently in early stages but it is being actively developed.
 
-experimental_13_KEY: |-
+experimental_12_KEY: |-
   experimental
 
-Yggdrasil_doesnt_have_a_goal_of_providing_anonymity_and_your_peers_know_your_IP_address_unless_you_are_only_using_TorI2P_peersP_130_KEY: |-
+Yggdrasil_doesnt_have_a_goal_of_providing_anonymity_and_your_peers_know_your_IP_address_unless_you_are_only_using_TorI2P_peersP_129_KEY: |-
   Yggdrasil doesn't have a goal of providing anonymity and your peers know your IP address unless you are only using Tor/I2P peers.
 
-privacy_warning_15_KEY: |-
-  privacy warning
-
-If_you_are_currently_using_an_application_like_Evernote_Google_Keep_or_Microsoft_OneNote_you_should_pick_an_alternative_hereP_129_KEY: |-
+If_you_are_currently_using_an_application_like_Evernote_Google_Keep_or_Microsoft_OneNote_you_should_pick_an_alternative_hereP_128_KEY: |-
   If you are currently using an application like Evernote, Google Keep, or Microsoft OneNote, you should pick an alternative here.
 
 Joplin_6_KEY: |-
@@ -3170,478 +3119,478 @@ httpsplayPgooglePcomstoreappsdetailsQidcomPlyonbrosPturtl_64_KEY: |-
 httpsgithubPcomturtl_24_KEY: |-
   https://github.com/turtl
 
-Warning_8_KEY: |-
+Warning_7_KEY: |-
   Warning
 
 Note_As_of_Dec_2018_Joplin_does_not_support_passwordpin_protection_for_the_application_itself_or_individual_notesnotebooksP_Data_is_still_encrypted_206_KEY: |-
   Note: As of Dec 2018, Joplin does not support password/pin protection for the application itself or individual notes/notebooks. Data is still encrypted in transit and at sync location using your master key.
 
-See_a_hrefhttpsgithubPcomlaurent22joplinissues289open_issueaP_77_KEY: |-
+See_a_hrefhttpsgithubPcomlaurent22joplinissues289open_issueaP_76_KEY: |-
   See <a href='https://github.com/laurent22/joplin/issues/289'>open issue</a>.
 
-httpsgithubPcomnotablenotable_35_KEY: |-
+httpsgithubPcomnotablenotable_34_KEY: |-
   https://github.com/notable/notable
 
-Notable_8_KEY: |-
+Notable_7_KEY: |-
   Notable
 
-The_markdownbased_notetaking_app_that_doesnt_suckP_54_KEY: |-
+The_markdownbased_notetaking_app_that_doesnt_suckP_53_KEY: |-
   The markdown-based note-taking app that doesn't suck.
 
-httpspaperworkPcloud_25_KEY: |-
+httpspaperworkPcloud_24_KEY: |-
   https://paperwork.cloud/
 
-Paperwork_10_KEY: |-
+Paperwork_9_KEY: |-
   Paperwork
 
-An_opensource_and_selfhosted_solutionP_For_PHP__MySQL_serversP_66_KEY: |-
+An_opensource_and_selfhosted_solutionP_For_PHP__MySQL_serversP_65_KEY: |-
   An open-source and self-hosted solution. For PHP / MySQL servers.
 
-httpsorgmodePorg_20_KEY: |-
+httpsorgmodePorg_19_KEY: |-
   https://orgmode.org
 
-Orgmode_9_KEY: |-
+Orgmode_8_KEY: |-
   Org-mode
 
-A_major_mode_for_GNU_EmacsP_Orgmode_is_for_keeping_notes_maintaining_TODO_lists_planning_projects_and_authoring_documents_with_a_fast_and_effective_171_KEY: |-
+A_major_mode_for_GNU_EmacsP_Orgmode_is_for_keeping_notes_maintaining_TODO_lists_planning_projects_and_authoring_documents_with_a_fast_and_effective_170_KEY: |-
   A major mode for GNU Emacs. Org-mode is for keeping notes, maintaining TODO lists, planning projects, and authoring documents with a fast and effective plain-text system.
 
-We_will_try_and_keep_this_page_uptodate_with_added_sections_and_other_content_but_to_be_guaranteed_the_latest_recommendations_we_recommend_you_chec_232_KEY: |-
+We_will_try_and_keep_this_page_uptodate_with_added_sections_and_other_content_but_to_be_guaranteed_the_latest_recommendations_we_recommend_you_chec_231_KEY: |-
   We will try and keep this page up-to-date with added sections and other content, but to be guaranteed the latest recommendations, we recommend you check out our new Providers, Browsers, Software, and OS pages in the navbar above :)
 
-Global_Mass_Surveillance__The_Fourteen_Eyes_45_KEY: |-
+Global_Mass_Surveillance__The_Fourteen_Eyes_44_KEY: |-
   Global Mass Surveillance - The Fourteen Eyes
 
-UKUSA_Agreement_16_KEY: |-
+UKUSA_Agreement_15_KEY: |-
   UKUSA Agreement
 
-The_UKUSA_Agreement_is_an_agreement_between_the_United_Kingdom_United_States_Australia_Canada_and_New_Zealand_to_cooperatively_collect_analyze_an_1246_KEY: |-
+The_UKUSA_Agreement_is_an_agreement_between_the_United_Kingdom_United_States_Australia_Canada_and_New_Zealand_to_cooperatively_collect_analyze_an_1245_KEY: |-
   The UKUSA Agreement is an agreement between the United Kingdom, United States, Australia, Canada, and New Zealand to cooperatively collect, analyze, and share intelligence. Members of this group, known as the <a href="https://www.giswatch.org/en/communications-surveillance/unmasking-five-eyes-global-surveillance-practices">Five Eyes</a>, focus on gathering and analyzing intelligence from different parts of the world. While Five Eyes countries have agreed to <a href="https://www.pbs.org/newshour/world/an-exclusive-club-the-five-countries-that-dont-spy-on-each-other">not spy on each other</a> as adversaries, leaks by Snowden have revealed that some Five Eyes members monitor each other's citizens and <a href="https://www.theguardian.com/uk/2013/jun/21/gchq-cables-secret-world-communications-nsa">share intelligence</a> to <a href="https://www.theguardian.com/politics/2013/jun/10/nsa-offers-intelligence-british-counterparts-blunkett">avoid breaking domestic laws</a> that prohibit them from spying on their own citizens. The Five Eyes alliance also cooperates with groups of third-party countries to share intelligence (forming the Nine Eyes and Fourteen Eyes); however, Five Eyes and third-party countries can and do spy on each other.
 
-Australia_10_KEY: |-
+Australia_9_KEY: |-
   Australia
 
-Canada_7_KEY: |-
+Canada_6_KEY: |-
   Canada
 
-New_Zealand_12_KEY: |-
+New_Zealand_11_KEY: |-
   New Zealand
 
-United_Kingdom_15_KEY: |-
+United_Kingdom_14_KEY: |-
   United Kingdom
 
-United_States_of_America_25_KEY: |-
+United_States_of_America_24_KEY: |-
   United States of America
 
 Five_Eyes_9_KEY: |-
   Five Eyes
 
-France_7_KEY: |-
+France_6_KEY: |-
   France
 
 Nine_Eyes_9_KEY: |-
   Nine Eyes
 
-Italy_6_KEY: |-
+Italy_5_KEY: |-
   Italy
 
-Spain_6_KEY: |-
+Spain_5_KEY: |-
   Spain
 
-Sweden_7_KEY: |-
+Sweden_6_KEY: |-
   Sweden
 
 Fourteen_Eyes_13_KEY: |-
   Fourteen Eyes
 
-Key_Disclosure_Law_19_KEY: |-
+Key_Disclosure_Law_18_KEY: |-
   Key Disclosure Law
 
-Who_is_required_to_hand_over_the_encryption_keys_to_authoritiesQ_65_KEY: |-
+Who_is_required_to_hand_over_the_encryption_keys_to_authoritiesQ_64_KEY: |-
   Who is required to hand over the encryption keys to authorities?
 
-Mandatory_a_hrefhttpsenPwikipediaPorgwikiKey_disclosure_lawkey_disclosure_lawsa_require_individuals_to_turn_over_encryption_keys_to_law_en_981_KEY: |-
+Mandatory_a_hrefhttpsenPwikipediaPorgwikiKey_disclosure_lawkey_disclosure_lawsa_require_individuals_to_turn_over_encryption_keys_to_law_en_980_KEY: |-
   Mandatory <a href="https://en.wikipedia.org/wiki/Key_disclosure_law">key disclosure laws</a> require individuals to turn over encryption keys to law enforcement conducting a criminal investigation. How these laws are implemented (who may be legally compelled to assist) vary from nation to nation, but a warrant is generally required. Defenses against key disclosure laws include steganography and encrypting data in a way that provides plausible deniability.</p>  <p><a href="https://en.wikipedia.org/wiki/Steganography">Steganography</a> involves hiding sensitive information (which may be encrypted) inside of ordinary data (for example, encrypting an image file and then hiding it in an audio file). With plausible deniability, data is encrypted in a way that prevents an adversary from being able to prove that the information they are after exists (for example, one password may decrypt benign data and another password, used on the same file, could decrypt sensitive data).
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawAntigua_and_Barbuda_69_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawAntigua_and_Barbuda_68_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Antigua_and_Barbuda
 
-Antigua_and_Barbuda_20_KEY: |-
+Antigua_and_Barbuda_19_KEY: |-
   Antigua and Barbuda
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawAustralia_59_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawAustralia_58_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Australia
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawCanada_56_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawCanada_55_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Canada
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawFrance_56_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawFrance_55_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#France
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawIndia_55_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawIndia_54_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#India
 
-India_6_KEY: |-
+India_5_KEY: |-
   India
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawIreland_57_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawIreland_56_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Ireland
 
-Ireland_8_KEY: |-
+Ireland_7_KEY: |-
   Ireland
 
-httpsedriPorgnorwayintroducesforcedbiometricauthentication_68_KEY: |-
+httpsedriPorgnorwayintroducesforcedbiometricauthentication_67_KEY: |-
   https://edri.org/norway-introduces-forced-biometric-authentication/
 
-httpswwwPbloombergPcomnewsarticles20180320telegramlosesbidtostoprussiafromgettingencryptionkeys_114_KEY: |-
+httpswwwPbloombergPcomnewsarticles20180320telegramlosesbidtostoprussiafromgettingencryptionkeys_113_KEY: |-
   https://www.bloomberg.com/news/articles/2018-03-20/telegram-loses-bid-to-stop-russia-from-getting-encryption-keys
 
-Russia_7_KEY: |-
+Russia_6_KEY: |-
   Russia
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawSouth_Africa_62_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawSouth_Africa_61_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#South_Africa
 
-South_Africa_13_KEY: |-
+South_Africa_12_KEY: |-
   South Africa
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawUnited_Kingdom_64_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawUnited_Kingdom_63_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#United_Kingdom
 
 Key_disclosure_laws_apply_25_KEY: |-
   Key disclosure laws apply
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawBelgium_57_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawBelgium_56_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Belgium
 
-Belgium__10_KEY: |-
+Belgium__9_KEY: |-
   Belgium *
 
-httpswwwPriigiteatajaPeeakt106012016019_45_KEY: |-
+httpswwwPriigiteatajaPeeakt106012016019_44_KEY: |-
   https://www.riigiteataja.ee/akt/106012016019
 
-Estonia_8_KEY: |-
+Estonia_7_KEY: |-
   Estonia
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawFinland_57_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawFinland_56_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Finland
 
-Finland__10_KEY: |-
+Finland__9_KEY: |-
   Finland *
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawNew_Zealand_61_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawNew_Zealand_60_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#New_Zealand
 
-unclear_8_KEY: |-
+unclear_7_KEY: |-
   unclear
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawThe_Netherlands_65_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawThe_Netherlands_64_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#The_Netherlands
 
-The_Netherlands__18_KEY: |-
+The_Netherlands__17_KEY: |-
   The Netherlands *
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawUnited_States_63_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawUnited_States_62_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#United_States
 
-United_States_14_KEY: |-
+United_States_13_KEY: |-
   United States
 
-see_related_info_17_KEY: |-
+see_related_info_16_KEY: |-
   see related info
 
 Key_disclosure_laws_may_apply_29_KEY: |-
   Key disclosure laws may apply
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawCzech_Republic_64_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawCzech_Republic_63_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Czech_Republic
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawGermany_57_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawGermany_56_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Germany
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawIceland_57_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawIceland_56_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Iceland
 
-Iceland_8_KEY: |-
+Iceland_7_KEY: |-
   Iceland
 
-httpsiclgPcompracticeareascybersecuritylawsandregulationsitaly_73_KEY: |-
+httpsiclgPcompracticeareascybersecuritylawsandregulationsitaly_72_KEY: |-
   https://iclg.com/practice-areas/cybersecurity-laws-and-regulations/italy
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawPoland_56_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawPoland_55_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Poland
 
-Poland_7_KEY: |-
+Poland_6_KEY: |-
   Poland
 
-httpsenPwikipediaPorgwikiKey_disclosure_lawSweden_56_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_lawSweden_55_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law#Sweden
 
-proposed_9_KEY: |-
+proposed_8_KEY: |-
   proposed
 
-httpswwwPwikipediaPorgwikiKey_disclosure_lawSwitzerland_62_KEY: |-
+httpswwwPwikipediaPorgwikiKey_disclosure_lawSwitzerland_61_KEY: |-
   https://www.wikipedia.org/wiki/Key_disclosure_law#Switzerland
 
 Key_disclosure_laws_dont_apply_31_KEY: |-
   Key disclosure laws don't apply
 
-_people_who_know_how_to_access_a_system_may_be_ordered_to_share_their_knowledge_stronghowever_this_doesnt_apply_to_the_suspect_itself_or_family__170_KEY: |-
+_people_who_know_how_to_access_a_system_may_be_ordered_to_share_their_knowledge_stronghowever_this_doesnt_apply_to_the_suspect_itself_or_family__169_KEY: |-
   * (people who know how to access a system may be ordered to share their knowledge, <strong>however, this doesn't apply to the suspect itself or family members.</strong>)
 
-httpsenPwikipediaPorgwikiKey_disclosure_law_49_KEY: |-
+httpsenPwikipediaPorgwikiKey_disclosure_law_48_KEY: |-
   https://en.wikipedia.org/wiki/Key_disclosure_law
 
-Wikipedia_page_on_key_disclosure_law_37_KEY: |-
+Wikipedia_page_on_key_disclosure_law_36_KEY: |-
   Wikipedia page on key disclosure law
 
-httpslawPstackexchangePcomquestions1523canauscitizenberequiredtoprovidetheauthenticationkeyforencrypteddat_126_KEY: |-
+httpslawPstackexchangePcomquestions1523canauscitizenberequiredtoprovidetheauthenticationkeyforencrypteddat_125_KEY: |-
   https://law.stackexchange.com/questions/1523/can-a-us-citizen-be-required-to-provide-the-authentication-key-for-encrypted-dat
 
-lawPstackexchangePcom_question_about_key_disclosure_law_in_US_62_KEY: |-
+lawPstackexchangePcom_question_about_key_disclosure_law_in_US_61_KEY: |-
   law.stackexchange.com question about key disclosure law in US
 
-httpspeertubePmastodonPhostvideoswatche09915eb59624830a02f8da5c2b59e71_81_KEY: |-
+httpspeertubePmastodonPhostvideoswatche09915eb59624830a02f8da5c2b59e71_80_KEY: |-
   https://peertube.mastodon.host/videos/watch/e09915eb-5962-4830-a02f-8da5c2b59e71
 
-DEFCON_20_Crypto_and_the_Cops_the_Law_of_Key_Disclosure_and_Forced_Decryption_80_KEY: |-
+DEFCON_20_Crypto_and_the_Cops_the_Law_of_Key_Disclosure_and_Forced_Decryption_79_KEY: |-
   DEFCON 20: Crypto and the Cops: the Law of Key Disclosure and Forced Decryption
 
-Why_is_it_not_recommended_to_choose_a_USbased_serviceQ_56_KEY: |-
+Why_is_it_not_recommended_to_choose_a_USbased_serviceQ_55_KEY: |-
   Why is it not recommended to choose a US-based service?
 
-USA_4_KEY: |-
+USA_3_KEY: |-
   USA
 
-Services_based_in_the_United_States_are_not_recommended_because_of_the_countrys_surveillance_programs_and_use_of_a_hrefhttpswwwPeffPorgissuesn_558_KEY: |-
+Services_based_in_the_United_States_are_not_recommended_because_of_the_countrys_surveillance_programs_and_use_of_a_hrefhttpswwwPeffPorgissuesn_557_KEY: |-
   Services based in the United States are not recommended because of the country's surveillance programs and use of <a href="https://www.eff.org/issues/national-security-letters/faq">National Security Letters</a> (NSLs) with accompanying gag orders, which forbid the recipient from talking about the request. This combination allows the government to <a href="https://www.schneier.com/blog/archives/2013/08/more_on_the_nsa.html">secretly force</a> companies to grant complete access to customer data and transform the service into a tool of mass surveillance.
 
 An_example_of_this_is_a_hrefhttpsenPwikipediaPorgwikiLavabitSuspension_and_gag_orderLavabita__a_secure_email_service_created_by_Ladar_Le_676_KEY: |-
   An example of this is <a href="https://en.wikipedia.org/wiki/Lavabit#Suspension_and_gag_order">Lavabit</a> – a secure email service created by Ladar Levison. The FBI <a href="https://www.vice.com/en_us/article/nzz888/lavabit-founder-ladar-levison-discusses-his-federal-battle-for-privacy">requested</a> Snowden's records after finding out that he used the service. Since Lavabit did not keep logs and email content was stored encrypted, the FBI served a subpoena (with a gag order) for the service's SSL keys. Having the SSL keys would allow them to access communications (both metadata and unencrypted content) in real time for all of Lavabit's customers, not just Snowden's.
 
-Ultimately_Levison_turned_over_the_SSL_keys_and_a_hrefhttpswwwPtheguardianPcomcommentisfree2014may20whydidlavabitshutdownsnowdenemail_374_KEY: |-
+Ultimately_Levison_turned_over_the_SSL_keys_and_a_hrefhttpswwwPtheguardianPcomcommentisfree2014may20whydidlavabitshutdownsnowdenemail_373_KEY: |-
   Ultimately, Levison turned over the SSL keys and <a href="https://www.theguardian.com/commentisfree/2014/may/20/why-did-lavabit-shut-down-snowden-email">shut down</a> the service at the same time. The US government then <a href="https://www.cnbc.com/id/100962389">threatened Levison with arrest</a>, saying that shutting down the service was a violation of the court order.
 
-httpswwwPbestvpnPcomtheultimateprivacyguideavoidus_60_KEY: |-
+httpswwwPbestvpnPcomtheultimateprivacyguideavoidus_59_KEY: |-
   https://www.bestvpn.com/the-ultimate-privacy-guide/#avoidus
 
-Avoid_all_US_and_UK_based_services_35_KEY: |-
+Avoid_all_US_and_UK_based_services_34_KEY: |-
   Avoid all US and UK based services
 
-httpsenPwikipediaPorgwikiSurespotHistory_47_KEY: |-
+httpsenPwikipediaPorgwikiSurespotHistory_46_KEY: |-
   https://en.wikipedia.org/wiki/Surespot#History
 
-Proof_that_warrant_canaries_work_based_on_the_surespot_exampleP_64_KEY: |-
+Proof_that_warrant_canaries_work_based_on_the_surespot_exampleP_63_KEY: |-
   Proof that warrant canaries work based on the surespot example.
 
-httpsenPwikipediaPorgwikiUKUSA_Agreement_46_KEY: |-
+httpsenPwikipediaPorgwikiUKUSA_Agreement_45_KEY: |-
   https://en.wikipedia.org/wiki/UKUSA_Agreement
 
-The_United_Kingdom__United_States_of_America_Agreement_UKUSA_64_KEY: |-
+The_United_Kingdom__United_States_of_America_Agreement_UKUSA_63_KEY: |-
   The United Kingdom – United States of America Agreement (UKUSA)
 
-httpsenPwikipediaPorgwikiLavabitSuspension_and_gag_order_63_KEY: |-
+httpsenPwikipediaPorgwikiLavabitSuspension_and_gag_order_62_KEY: |-
   https://en.wikipedia.org/wiki/Lavabit#Suspension_and_gag_order
 
-Lavabit_Suspension_and_gag_order_34_KEY: |-
+Lavabit_Suspension_and_gag_order_33_KEY: |-
   Lavabit: Suspension and gag order
 
-Key_disclosure_law_19_KEY: |-
+Key_disclosure_law_18_KEY: |-
   Key disclosure law
 
-httpsenPwikipediaPorgwikiPortalMass_surveillance_55_KEY: |-
+httpsenPwikipediaPorgwikiPortalMass_surveillance_54_KEY: |-
   https://en.wikipedia.org/wiki/Portal:Mass_surveillance
 
-Wikipedia_Portal_Mass_surveillance_36_KEY: |-
+Wikipedia_Portal_Mass_surveillance_35_KEY: |-
   Wikipedia Portal: Mass_surveillance
 
-Recommended_VPN_Service_24_KEY: |-
+Recommended_VPN_Service_23_KEY: |-
   Recommended VPN Service
 
-Our_recommended_provider_is_outside_the_US_uses_encryption_accepts_Bitcoin_supports_OpenVPN_and_has_a_no_logging_policyP_a_hrefcriteriaRead_o_202_KEY: |-
+Our_recommended_provider_is_outside_the_US_uses_encryption_accepts_Bitcoin_supports_OpenVPN_and_has_a_no_logging_policyP_a_hrefcriteriaRead_o_201_KEY: |-
   Our recommended provider is outside the US, uses encryption, accepts Bitcoin, supports OpenVPN, and has a no logging policy. <a href="#criteria">Read our full list of criteria for more information</a>.
 
-Mullvad_8_KEY: |-
+Mullvad_7_KEY: |-
   Mullvad
 
-EUR_4_KEY: |-
+EUR_3_KEY: |-
   EUR
 
-60Year_9_KEY: |-
+60Year_8_KEY: |-
   €60/Year
 
-strongMullvadstrong_is_a_fast_and_inexpensive_VPN_with_a_serious_focus_on_transparency_and_securityP_They_have_been_in_operation_since_strong200_424_KEY: |-
+strongMullvadstrong_is_a_fast_and_inexpensive_VPN_with_a_serious_focus_on_transparency_and_securityP_They_have_been_in_operation_since_strong200_423_KEY: |-
   <strong>Mullvad</strong> is a fast and inexpensive VPN with a serious focus on transparency and security. They have been in operation since <strong>2009</strong>. It is the only VPN provider that currently meets our criteria for recommendation. Mullvad is based in <span class="flag-icon flag-icon-se"></span> Sweden and does not have a free trial. Visit <a href="https://mullvad.net/">mullvad.net</a> to create an account.
 
-406_Servers_13_KEY: |-
+406_Servers_12_KEY: |-
   406+ Servers
 
-Mullvad_has_409_servers_in_39_countries_at_the_time_of_writing_this_pageP_Typically_the_more_servers_a_provider_offers_the_better_With_hundreds_of_se_265_KEY: |-
+Mullvad_has_409_servers_in_39_countries_at_the_time_of_writing_this_pageP_Typically_the_more_servers_a_provider_offers_the_better_With_hundreds_of_se_264_KEY: |-
   Mullvad has 409 servers in 39 countries at the time of writing this page. Typically the more servers a provider offers, the better: With hundreds of servers in operation, you are far more likely to find a fast connection and a server geographically closest to you.
 
-WireGuard_Support_18_KEY: |-
+WireGuard_Support_17_KEY: |-
   WireGuard Support
 
-In_addition_to_standard_OpenVPN_connections_Mullvad_supports_WireGuardP_WireGuard_is_an_experimental_protocol_with_theoretically_better_security_and_h_231_KEY: |-
+In_addition_to_standard_OpenVPN_connections_Mullvad_supports_WireGuardP_WireGuard_is_an_experimental_protocol_with_theoretically_better_security_and_h_230_KEY: |-
   In addition to standard OpenVPN connections, Mullvad supports WireGuard. WireGuard is an experimental protocol with theoretically better security and higher reliability, although it is not currently recommended for production use.
 
-Independently_Audited_22_KEY: |-
+Independently_Audited_21_KEY: |-
   Independently Audited
 
 Mullvads_VPN_clients_have_been_audited_by_Cure53_and_Assured_AB_in_a_pentest_report_a_hrefhttpscure53Pdepentestreport_mullvad_v2Ppdfpublishe_170_KEY: |-
   Mullvad's VPN clients have been audited by Cure53 and Assured AB in a pentest report <a href="https://cure53.de/pentest-report_mullvad_v2.pdf">published at cure53.de</a>.
 
-The_security_researchers_concluded_36_KEY: |-
+The_security_researchers_concluded_35_KEY: |-
   The security researchers concluded:
 
-PPPCure53_and_Assured_AB_are_happy_with_the_results_of_the_audit_and_the_software_leaves_an_overall_positive_impressionP_With_security_dedication_of_th_294_KEY: |-
+PPPCure53_and_Assured_AB_are_happy_with_the_results_of_the_audit_and_the_software_leaves_an_overall_positive_impressionP_With_security_dedication_of_th_293_KEY: |-
   ...Cure53 and Assured AB are happy with the results of the audit and the software leaves an overall positive impression. With security dedication of the in-house team at the Mullvad VPN compound, the testers have no doubts about the project being on the right track from a security standpoint.
 
-Accepts_Bitcoin_16_KEY: |-
+Accepts_Bitcoin_15_KEY: |-
   Accepts Bitcoin
 
-Mullvad_in_addition_to_accepting_creditdebit_cards_and_PayPal_accepts_strongBitcoinstrong_strongBitcoin_Cashstrong_and_strongcashlocal_249_KEY: |-
+Mullvad_in_addition_to_accepting_creditdebit_cards_and_PayPal_accepts_strongBitcoinstrong_strongBitcoin_Cashstrong_and_strongcashlocal_248_KEY: |-
   Mullvad in addition to accepting credit/debit cards and PayPal, accepts <strong>Bitcoin</strong>, <strong>Bitcoin Cash</strong>, and <strong>cash/local currency</strong> as anonymous forms of payment. They also accept Swish and bank wire transfers.
 
-No_Mobile_Clients_18_KEY: |-
+No_Mobile_Clients_17_KEY: |-
   No Mobile Clients
 
-While_iOS_and_Android_clients_are_reportedly_in_the_works_mobile_users_will_need_to_use_a_traditional_OpenVPN_client_and_configuration_files_which_ar_188_KEY: |-
+While_iOS_and_Android_clients_are_reportedly_in_the_works_mobile_users_will_need_to_use_a_traditional_OpenVPN_client_and_configuration_files_which_ar_187_KEY: |-
   While iOS and Android clients are reportedly in the works, mobile users will need to use a traditional OpenVPN client and configuration files, which are a bit more difficult to configure.
 
-Extra_Functionality_20_KEY: |-
+Extra_Functionality_19_KEY: |-
   Extra Functionality
 
-The_Mullvad_VPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPNP_They_also_are_able_to_automatically_start_on_bootP_271_KEY: |-
+The_Mullvad_VPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPNP_They_also_are_able_to_automatically_start_on_bootP_270_KEY: |-
   The Mullvad VPN clients have a built-in killswitch to block internet connections outside of the VPN. They also are able to automatically start on boot. The Mullvad website is also accessible via Tor at <a href="http://xcln5hkbriyklr6n.onion/">xcln5hkbriyklr6n.onion</a>.
 
-Note_Using_a_VPN_provider_will_not_make_you_anonymous_but_it_will_give_you_better_privacy_in_certain_situationsP_A_VPN_is_not_a_tool_for_illegal_acti_192_KEY: |-
+Note_Using_a_VPN_provider_will_not_make_you_anonymous_but_it_will_give_you_better_privacy_in_certain_situationsP_A_VPN_is_not_a_tool_for_illegal_acti_191_KEY: |-
   Note: Using a VPN provider will not make you anonymous, but it will give you better privacy in certain situations. A VPN is not a tool for illegal activities. Don't rely on a "no log" policy.
 
-Other_Providers_Worth_Mentioning_33_KEY: |-
+Other_Providers_Worth_Mentioning_32_KEY: |-
   Other Providers Worth Mentioning
 
-ProtonVPN_10_KEY: |-
+ProtonVPN_9_KEY: |-
   ProtonVPN
 
-USD_4_KEY: |-
+USD_3_KEY: |-
   USD
 
-96year_9_KEY: |-
+96year_8_KEY: |-
   $96/year
 
-strongProtonVPNstrong_is_a_strong_contender_in_the_VPN_space_and_they_have_been_in_operation_since_strong2016strongP_ProtonVPN_is_based_in__418_KEY: |-
+strongProtonVPNstrong_is_a_strong_contender_in_the_VPN_space_and_they_have_been_in_operation_since_strong2016strongP_ProtonVPN_is_based_in__417_KEY: |-
   <strong>ProtonVPN</strong> is a strong contender in the VPN space, and they have been in operation since <strong>2016</strong>. ProtonVPN is based in <span class="flag-icon flag-icon-ch"></span> Switzerland and offers a limited free pricing tier, as well as premium options. Unfortunately due to its lack of an independent security audit it does not meet the complete criteria for recommendation, see our notes below.
 
-Not_Audited_12_KEY: |-
+Not_Audited_11_KEY: |-
   Not Audited
 
-ProtonVPN_has_not_undergone_a_security_audit_by_an_independent_third_party_and_therefore_cannot_be_strongly_recommended_at_this_timeP_We_have_still_ch_237_KEY: |-
+ProtonVPN_has_not_undergone_a_security_audit_by_an_independent_third_party_and_therefore_cannot_be_strongly_recommended_at_this_timeP_We_have_still_ch_236_KEY: |-
   ProtonVPN has not undergone a security audit by an independent third party, and therefore cannot be strongly recommended at this time. We have still chosen to list it on this page with the assumption that an audit will be published soon
 
-We_are_currently_undergoing_a_complete_security_audit_of_our_VPN_applications_by_a_reputable_Swiss_security_companyP_The_results_of_the_audit_will_be_s_201_KEY: |-
+We_are_currently_undergoing_a_complete_security_audit_of_our_VPN_applications_by_a_reputable_Swiss_security_companyP_The_results_of_the_audit_will_be_s_200_KEY: |-
   We are currently undergoing a complete security audit of our VPN applications by a reputable Swiss security company. The results of the audit will be summarized in a public report for cases like this.
 
-Marc_Loebekken_ProtonVPN_AG_Legal_counsel_43_KEY: |-
+Marc_Loebekken_ProtonVPN_AG_Legal_counsel_42_KEY: |-
   Marc Loebekken, ProtonVPN AG Legal counsel
 
-We_will_reevaluate_this_listing_at_the_end_of_2019_or_when_the_aforementioned_report_has_been_published_whichever_is_soonerP_126_KEY: |-
+We_will_reevaluate_this_listing_at_the_end_of_2019_or_when_the_aforementioned_report_has_been_published_whichever_is_soonerP_125_KEY: |-
   We will reevaluate this listing at the end of 2019 or when the aforementioned report has been published, whichever is sooner.
 
-526_Servers_13_KEY: |-
+526_Servers_12_KEY: |-
   526+ Servers
 
-ProtonVPN_has_526_servers_in_42_countries_at_the_time_of_writing_this_pageP_Typically_the_more_servers_a_provider_offers_the_better_With_hundreds_of__267_KEY: |-
+ProtonVPN_has_526_servers_in_42_countries_at_the_time_of_writing_this_pageP_Typically_the_more_servers_a_provider_offers_the_better_With_hundreds_of__266_KEY: |-
   ProtonVPN has 526 servers in 42 countries at the time of writing this page. Typically the more servers a provider offers, the better: With hundreds of servers in operation, you are far more likely to find a fast connection and a server geographically closest to you.
 
-ProtonVPN_does_technically_accept_Bitcoin_payments_however_you_either_need_to_have_an_existing_account_or_contact_their_support_team_in_advance_to_r_173_KEY: |-
+ProtonVPN_does_technically_accept_Bitcoin_payments_however_you_either_need_to_have_an_existing_account_or_contact_their_support_team_in_advance_to_r_172_KEY: |-
   ProtonVPN does technically accept Bitcoin payments; however, you either need to have an existing account, or contact their support team in advance to register with Bitcoin.
 
-Mobile_Clients_15_KEY: |-
+Mobile_Clients_14_KEY: |-
   Mobile Clients
 
-In_addition_to_providing_standard_OpenVPN_configuration_files_ProtonVPN_has_mobile_clients_for_iOS_or_Android_allowing_for_easy_connections_to_their_s_159_KEY: |-
+In_addition_to_providing_standard_OpenVPN_configuration_files_ProtonVPN_has_mobile_clients_for_iOS_or_Android_allowing_for_easy_connections_to_their_s_158_KEY: |-
   In addition to providing standard OpenVPN configuration files, ProtonVPN has mobile clients for iOS or Android allowing for easy connections to their servers.
 
-The_ProtonVPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPNP_They_also_are_able_to_automatically_start_on_bootP_P_314_KEY: |-
+The_ProtonVPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPNP_They_also_are_able_to_automatically_start_on_bootP_P_313_KEY: |-
   The ProtonVPN clients have a built-in killswitch to block internet connections outside of the VPN. They also are able to automatically start on boot. ProtonVPN also offers "Tor" servers allowing you to easily connect to onion sites, but we still strongly recommend using the official Tor Browser for this purpose.
 
-IVPN_5_KEY: |-
+IVPN_4_KEY: |-
   IVPN
 
-100Year_10_KEY: |-
+100Year_9_KEY: |-
   $100/Year
 
-strongIVPNstrong_is_another_strong_premium_VPN_provider_and_they_have_been_in_operation_since_strong2009strongP_IVPN_is_based_in_span_class_371_KEY: |-
+strongIVPNstrong_is_another_strong_premium_VPN_provider_and_they_have_been_in_operation_since_strong2009strongP_IVPN_is_based_in_span_class_370_KEY: |-
   <strong>IVPN</strong> is another strong premium VPN provider, and they have been in operation since <strong>2009</strong>. IVPN is based in <span class="flag-icon flag-icon-gi"></span> Gibraltar and offers a 3 day free trial. Unfortunately, due to its lack of an independent security audit, it does not meet the complete criteria for recommendation, see our notes below.
 
-No_Security_Audit_18_KEY: |-
+No_Security_Audit_17_KEY: |-
   No Security Audit
 
 IVPN_has_undergone_a_a_hrefhttpscure53Pdeauditreport_ivpnPpdfnologging_audit_from_Cure53a_which_concluded_in_agreement_with_IVPNs_nolog_561_KEY: |-
   IVPN has undergone a <a href="https://cure53.de/audit-report_ivpn.pdf">no-logging audit from Cure53</a> which concluded in agreement with IVPN's no-logging claim. However, IVPN has not undergone a more comprehensive security audit by an independent third party, and therefore cannot be strongly recommended at this time. We have still chosen to list it on this page with the assumption that an audit will be published soon: The IVPN team <a href="https://twitter.com/yaelwrites/status/1161796418220089344">reportedly plans to begin the process in September</a>.
 
-77_Servers_12_KEY: |-
+77_Servers_11_KEY: |-
   77+ Servers
 
-IVPN_has_77_servers_in_31_countries_at_the_time_of_writing_this_pageP_Typically_the_more_servers_a_provider_offers_the_betterP_IVPN_has_a_decent_but__244_KEY: |-
+IVPN_has_77_servers_in_31_countries_at_the_time_of_writing_this_pageP_Typically_the_more_servers_a_provider_offers_the_betterP_IVPN_has_a_decent_but__243_KEY: |-
   IVPN has 77 servers in 31 countries at the time of writing this page. Typically the more servers a provider offers, the better. IVPN has a decent (but not exceptional) server count that will most likely provide adequate coverage to most users.
 
-In_addition_to_accepting_creditdebit_cards_and_PayPal_IVPN_accepts_strongBitcoinstrong_and_strongcashlocal_currencystrong_on_annual_plans_184_KEY: |-
+In_addition_to_accepting_creditdebit_cards_and_PayPal_IVPN_accepts_strongBitcoinstrong_and_strongcashlocal_currencystrong_on_annual_plans_183_KEY: |-
   In addition to accepting credit/debit cards and PayPal, IVPN accepts <strong>Bitcoin</strong> and <strong>cash/local currency</strong> (on annual plans) as anonymous forms of payment.
 
-In_addition_to_providing_standard_OpenVPN_configuration_files_IVPN_has_mobile_clients_for_iOS_or_Android_allowing_for_easy_connections_to_their_server_154_KEY: |-
+In_addition_to_providing_standard_OpenVPN_configuration_files_IVPN_has_mobile_clients_for_iOS_or_Android_allowing_for_easy_connections_to_their_server_153_KEY: |-
   In addition to providing standard OpenVPN configuration files, IVPN has mobile clients for iOS or Android allowing for easy connections to their servers.
 
-The_IVPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPNP_They_also_are_able_to_automatically_start_on_bootP_IVPN_a_264_KEY: |-
+The_IVPN_clients_have_a_builtin_killswitch_to_block_internet_connections_outside_of_the_VPNP_They_also_are_able_to_automatically_start_on_bootP_IVPN_a_263_KEY: |-
   The IVPN clients have a built-in killswitch to block internet connections outside of the VPN. They also are able to automatically start on boot. IVPN also provides "AntiTracker" functionality, which blocks advertising networks and trackers from the network level.
 
-What_is_a_warrant_canaryQ_26_KEY: |-
+What_is_a_warrant_canaryQ_25_KEY: |-
   What is a warrant canary?
 
-Warrant_Canary_Example_23_KEY: |-
+Warrant_Canary_Example_22_KEY: |-
   Warrant Canary Example
 
-A_warrant_canary_is_a_posted_document_stating_that_an_organization_has_not_received_any_secret_subpoenas_during_a_specific_period_of_timeP_If_this_docu_310_KEY: |-
+A_warrant_canary_is_a_posted_document_stating_that_an_organization_has_not_received_any_secret_subpoenas_during_a_specific_period_of_timeP_If_this_docu_309_KEY: |-
   A warrant canary is a posted document stating that an organization has not received any secret subpoenas during a specific period of time. If this document fails to be updated during the specified time then the user is to assume that the service has received such a subpoena and should stop using the service.
 
-Warrant_Canary_Examples_25_KEY: |-
+Warrant_Canary_Examples_24_KEY: |-
   Warrant Canary Examples:
 
-httpsproxyPshcanary_24_KEY: |-
+httpsproxyPshcanary_23_KEY: |-
   https://proxy.sh/canary
 
-httpswwwPivpnPnetresourcescanaryPtxt_42_KEY: |-
+httpswwwPivpnPnetresourcescanaryPtxt_41_KEY: |-
   https://www.ivpn.net/resources/canary.txt
 
-httpswwwPbolehvpnPnetcanaryPtxt_36_KEY: |-
+httpswwwPbolehvpnPnetcanaryPtxt_35_KEY: |-
   https://www.bolehvpn.net/canary.txt
 
-httpswwwPipredatorPsestaticdownloadscanaryPtxt_53_KEY: |-
+httpswwwPipredatorPsestaticdownloadscanaryPtxt_52_KEY: |-
   https://www.ipredator.se/static/downloads/canary.txt
 
-Related_Warrant_Canary_Information_35_KEY: |-
+Related_Warrant_Canary_Information_34_KEY: |-
   Related Warrant Canary Information
 
-httpswwwPeffPorgdeeplinks201404warrantcanaryfaq_57_KEY: |-
+httpswwwPeffPorgdeeplinks201404warrantcanaryfaq_56_KEY: |-
   https://www.eff.org/deeplinks/2014/04/warrant-canary-faq
 
-Warrant_Canary_Frequently_Asked_Questions_42_KEY: |-
+Warrant_Canary_Frequently_Asked_Questions_41_KEY: |-
   Warrant Canary Frequently Asked Questions
 
-httpsenPwikipediaPorgwikiWarrant_canaryCompanies_and_organizations_with_warrant_canaries_95_KEY: |-
+httpsenPwikipediaPorgwikiWarrant_canaryCompanies_and_organizations_with_warrant_canaries_94_KEY: |-
   https://en.wikipedia.org/wiki/Warrant_canary#Companies_and_organizations_with_warrant_canaries
 
-Companies_and_organizations_with_warrant_canaries_50_KEY: |-
+Companies_and_organizations_with_warrant_canaries_49_KEY: |-
   Companies and organizations with warrant canaries
 
-httpswwwPschneierPcomblogarchives201503australia_outlaPhtml_68_KEY: |-
+httpswwwPschneierPcomblogarchives201503australia_outlaPhtml_67_KEY: |-
   https://www.schneier.com/blog/archives/2015/03/australia_outla.html
 
-Warrant_canary_criticism_by_Bruce_Schneier_and_an_example_of_a_law_against_warrant_canariesP_93_KEY: |-
+Warrant_canary_criticism_by_Bruce_Schneier_and_an_example_of_a_law_against_warrant_canariesP_92_KEY: |-
   Warrant canary criticism by Bruce Schneier and an example of a law against warrant canaries.
 
-PrivacyRespecting_Search_Engines_34_KEY: |-
+PrivacyRespecting_Search_Engines_33_KEY: |-
   Privacy-Respecting Search Engines
 
 If_you_are_currently_using_search_engines_like_Google_Bing_or_Yahoo_you_should_pick_an_alternative_hereP_107_KEY: |-
@@ -3683,61 +3632,61 @@ httpswwwPqwantPcom_22_KEY: |-
 httpsgithubPcomQwant_25_KEY: |-
   https://github.com/Qwant/
 
-Firefox_Addon_14_KEY: |-
+Firefox_Addon_13_KEY: |-
   Firefox Addon
 
 httpsaddonsPmozillaPorgfirefoxaddongooglesearchlinkfix_64_KEY: |-
   https://addons.mozilla.org/firefox/addon/google-search-link-fix/
 
-Google_search_link_fix_23_KEY: |-
+Google_search_link_fix_22_KEY: |-
   Google search link fix
 
 Firefox_extension_that_prevents_Google_and_Yandex_search_pages_from_modifying_search_result_links_when_you_click_themP_This_is_useful_when_copying_link_239_KEY: |-
   Firefox extension that prevents Google and Yandex search pages from modifying search result links when you click them. This is useful when copying links but it also helps privacy by preventing the search engines from recording your clicks.
 
-Open_Source_12_KEY: |-
+Open_Source_11_KEY: |-
   Open Source
 
 httpsyacyPnet_17_KEY: |-
   https://yacy.net/
 
-YaCy_5_KEY: |-
+YaCy_4_KEY: |-
   YaCy
 
-A_freesoftware_P2P_search_engine_powered_by_its_usersP_56_KEY: |-
+A_freesoftware_P2P_search_engine_powered_by_its_usersP_55_KEY: |-
   A free-software P2P search engine powered by its users.
 
 httpsjivesearchPcom_23_KEY: |-
   https://jivesearch.com/
 
-Jive_Search_12_KEY: |-
+Jive_Search_11_KEY: |-
   Jive Search
 
-A_freesoftware_search_engine_with_a_similar_look_and_feel_to_GoogleP_70_KEY: |-
+A_freesoftware_search_engine_with_a_similar_look_and_feel_to_GoogleP_69_KEY: |-
   A free-software search engine with a similar look and feel to Google.
 
 httpsmetagerPdeen_22_KEY: |-
   https://metager.de/en/
 
-MetaGer_8_KEY: |-
+MetaGer_7_KEY: |-
   MetaGer
 
-An_opensource_metasearch_engine_which_is_based_in_GermanyP_It_focuses_on_protecting_the_users_privacyP_106_KEY: |-
+An_opensource_metasearch_engine_which_is_based_in_GermanyP_It_focuses_on_protecting_the_users_privacyP_105_KEY: |-
   An open-source metasearch engine, which is based in Germany. It focuses on protecting the user's privacy.
 
-httpswwwPmojeekPcom_24_KEY: |-
+httpswwwPmojeekPcom_23_KEY: |-
   https://www.mojeek.com/
 
-Mojeek_7_KEY: |-
+Mojeek_6_KEY: |-
   Mojeek
 
-Independent_and_unbiased_search_results_with_no_user_trackingP_63_KEY: |-
+Independent_and_unbiased_search_results_with_no_user_trackingP_62_KEY: |-
   Independent and unbiased search results with no user tracking.
 
-Encrypted_Instant_Messenger_28_KEY: |-
+Encrypted_Instant_Messenger_27_KEY: |-
   Encrypted Instant Messenger
 
-If_you_are_currently_using_an_Instant_Messenger_like_Telegram_LINE_Viber_a_hrefhttpswwwPeffPorgdeeplinks201610wherewhatsappwentwrongef_250_KEY: |-
+If_you_are_currently_using_an_Instant_Messenger_like_Telegram_LINE_Viber_a_hrefhttpswwwPeffPorgdeeplinks201610wherewhatsappwentwrongef_249_KEY: |-
   If you are currently using an Instant Messenger like Telegram, LINE, Viber, <a href="https://www.eff.org/deeplinks/2016/10/where-whatsapp-went-wrong-effs-four-biggest-security-concerns">WhatsApp</a>, or plain SMS you should pick an alternative here.
 
 Signal_6_KEY: |-
@@ -3767,187 +3716,184 @@ httpsappsPapplePcomusappsignalprivatemessengerid874139669_66_KEY: |-
 httpsgithubPcomsignalapp_28_KEY: |-
   https://github.com/signalapp
 
-Complete_Comparison_20_KEY: |-
+Complete_Comparison_19_KEY: |-
   Complete Comparison
 
-httpssecurechatguidePorgeffguidePhtml_42_KEY: |-
+httpssecurechatguidePorgeffguidePhtml_41_KEY: |-
   https://securechatguide.org/effguide.html
 
-securechatguidePorg_20_KEY: |-
+securechatguidePorg_19_KEY: |-
   securechatguide.org
 
-Guide_to_Choosing_a_MessengerP_31_KEY: |-
+Guide_to_Choosing_a_MessengerP_30_KEY: |-
   Guide to Choosing a Messenger.
 
-httpswwwPsecuremessagingappsPcom_37_KEY: |-
+httpswwwPsecuremessagingappsPcom_36_KEY: |-
   https://www.securemessagingapps.com/
 
-securemessagingappsPcom_24_KEY: |-
+securemessagingappsPcom_23_KEY: |-
   securemessagingapps.com
 
-Secure_Messaging_Apps_ComparisonP_34_KEY: |-
+Secure_Messaging_Apps_ComparisonP_33_KEY: |-
   Secure Messaging Apps Comparison.
 
-httpswwwPthinkprivacyPiomessengersPhtml_44_KEY: |-
+httpswwwPthinkprivacyPiomessengersPhtml_43_KEY: |-
   https://www.thinkprivacy.io/messengers.html
 
-thinkprivacyPio_16_KEY: |-
+thinkprivacyPio_15_KEY: |-
   thinkprivacy.io
 
-Simple_Secure_Messaging_Apps_ComparisonP_41_KEY: |-
+Simple_Secure_Messaging_Apps_ComparisonP_40_KEY: |-
   Simple Secure Messaging Apps Comparison.
 
-httpsbriarprojectPorg_26_KEY: |-
+httpsbriarprojectPorg_25_KEY: |-
   https://briarproject.org/
 
-Briar_6_KEY: |-
+Briar_5_KEY: |-
   Briar
 
-An_ultrasecure_peertopeer_instant_messenger_that_connects_to_contacts_via_Direct_WiFi_Bluetooth_or_Tor_over_the_internet_keeping_its_users_prote_190_KEY: |-
+An_ultrasecure_peertopeer_instant_messenger_that_connects_to_contacts_via_Direct_WiFi_Bluetooth_or_Tor_over_the_internet_keeping_its_users_prote_189_KEY: |-
   An ultra-secure peer-to-peer instant messenger that connects to contacts via Direct Wi-Fi, Bluetooth, or Tor over the internet, keeping its users protected from surveillance and censorship.
 
-httpsaboutPriotPim_23_KEY: |-
+httpsaboutPriotPim_22_KEY: |-
   https://about.riot.im/
 
-Riot_5_KEY: |-
+Riot_4_KEY: |-
   Riot
 
-An_opensource_federated_messenger_that_utilizes_the_Matrix_protocolP_This_application_is_primarily_recommended_as_a_large_groupteam_chat_solutionP_W_275_KEY: |-
+An_opensource_federated_messenger_that_utilizes_the_Matrix_protocolP_This_application_is_primarily_recommended_as_a_large_groupteam_chat_solutionP_W_274_KEY: |-
   An open-source, federated messenger that utilizes the Matrix protocol. This application is primarily recommended as a large group/team chat solution. While Riot has the ability to perform 1-on-1 communications we believe there are better solutions for direct communications.
 
-An_endtoend_encrypted_instant_messaging_and_voicevideo_call_clientP_RetroShare_supports_both_TOR_and_I2PP_110_KEY: |-
+An_endtoend_encrypted_instant_messaging_and_voicevideo_call_clientP_RetroShare_supports_both_TOR_and_I2PP_108_KEY: |-
   An end-to-end encrypted instant messaging and voice/video call client. RetroShare supports both TOR and I2P.
 
-httpsxmppPorg_18_KEY: |-
+httpsxmppPorg_17_KEY: |-
   https://xmpp.org/
 
-XMPP_5_KEY: |-
+XMPP_4_KEY: |-
   XMPP
 
-Federated_instant_messaging_protocol_with_a_hrefhttpsconversationsPimomemoOMEMOa_OTR_or_OpenPGP_endtoend_encryption_134_KEY: |-
+Federated_instant_messaging_protocol_with_a_hrefhttpsconversationsPimomemoOMEMOa_OTR_or_OpenPGP_endtoend_encryption_133_KEY: |-
   Federated instant messaging protocol with <a href="https://conversations.im/omemo/">OMEMO</a>, OTR, or OpenPGP end-to-end encryption:
 
-httpsconversationsPim_26_KEY: |-
+httpsconversationsPim_25_KEY: |-
   https://conversations.im/
 
-Conversations_14_KEY: |-
+Conversations_13_KEY: |-
   Conversations
 
-Android_8_KEY: |-
+Android_7_KEY: |-
   Android
 
-An_opensource_JabberXMPP_client_for_Android_4P4_smartphonesP_64_KEY: |-
+An_opensource_JabberXMPP_client_for_Android_4P4_smartphonesP_63_KEY: |-
   An open-source Jabber/XMPP client for Android 4.4+ smartphones.
 
-OMEMO_6_KEY: |-
+OMEMO_5_KEY: |-
   OMEMO
 
-httpsgajimPorg_19_KEY: |-
+httpsgajimPorg_18_KEY: |-
   https://gajim.org/
 
-Gajim_6_KEY: |-
+Gajim_5_KEY: |-
   Gajim
 
-FreeBSD_Linux_Windows_24_KEY: |-
+FreeBSD_Linux_Windows_23_KEY: |-
   FreeBSD, Linux, Windows
 
 An_opensource_fully_featured_XMPP_clientP_42_KEY: |-
   An open-source fully featured XMPP client.
 
-httpsmonalPim_18_KEY: |-
+httpsmonalPim_17_KEY: |-
   https://monal.im/
 
-Monal_6_KEY: |-
+Monal_5_KEY: |-
   Monal
 
-iOS_MacOS_11_KEY: |-
+iOS_MacOS_10_KEY: |-
   iOS, MacOS
 
-An_XMPP_client_in_active_developmentP_38_KEY: |-
+An_XMPP_client_in_active_developmentP_37_KEY: |-
   An XMPP client in active development.
 
-VoIP_5_KEY: |-
-  VoIP
-
-httpsomemoPtop_19_KEY: |-
+httpsomemoPtop_18_KEY: |-
   https://omemo.top/
 
-Other_OMEMOready_clients_26_KEY: |-
+Other_OMEMOready_clients_25_KEY: |-
   Other OMEMO-ready clients
 
-httpswwwPkontalkPorg_25_KEY: |-
+httpswwwPkontalkPorg_24_KEY: |-
   https://www.kontalk.org/
 
-Kontalk_8_KEY: |-
+Kontalk_7_KEY: |-
   Kontalk
 
-A_communitydriven_instant_messaging_networkP_Supports_endtoend_encryptionP_Both_clienttoserver_and_servertoserver_channels_are_fully_encryptedP_151_KEY: |-
+A_communitydriven_instant_messaging_networkP_Supports_endtoend_encryptionP_Both_clienttoserver_and_servertoserver_channels_are_fully_encryptedP_150_KEY: |-
   A community-driven instant messaging network. Supports end-to-end encryption. Both client-to-server and server-to-server channels are fully encrypted.
 
-httpskeybasePio_20_KEY: |-
+httpskeybasePio_19_KEY: |-
   https://keybase.io/
 
-Keybase_8_KEY: |-
+Keybase_7_KEY: |-
   Keybase
 
-This_software_relies_on_a_closedsource_central_serverP_56_KEY: |-
+This_software_relies_on_a_closedsource_central_serverP_55_KEY: |-
   This software relies on a closed-source central server.
 
-Endtoend_encrypted_messaging_with_social_verificationP_57_KEY: |-
+Endtoend_encrypted_messaging_with_social_verificationP_56_KEY: |-
   End-to-end encrypted messaging with social verification.
 
-httpsstatusPim_19_KEY: |-
+httpsstatusPim_18_KEY: |-
   https://status.im/
 
-Status_7_KEY: |-
+Status_6_KEY: |-
   Status
 
-Experimental_13_KEY: |-
+Experimental_12_KEY: |-
   Experimental
 
-A_free_and_opensource_peertopeer_encrypted_instant_messanger_with_support_for_DAPPsP_90_KEY: |-
+A_free_and_opensource_peertopeer_encrypted_instant_messanger_with_support_for_DAPPsP_89_KEY: |-
   A free and open-source, peer-to-peer, encrypted instant messanger with support for DAPPs.
 
-httpstoxPchat_18_KEY: |-
+httpstoxPchat_17_KEY: |-
   https://tox.chat/
 
-Tox_4_KEY: |-
+Tox_3_KEY: |-
   Tox
 
 A_free_and_opensource_peertopeer_encrypted_instant_messaging_and_video_calling_softwareP_94_KEY: |-
   A free and open-source, peer-to-peer, encrypted instant messaging, and video calling software.
 
-httpsjamiPnet_18_KEY: |-
+httpsjamiPnet_17_KEY: |-
   https://jami.net/
 
-Jami_formerly_RingSFLphone_30_KEY: |-
+Jami_formerly_RingSFLphone_29_KEY: |-
   Jami (formerly Ring/SFLphone)
 
-Gives_you_full_control_over_your_communications_and_an_unmatched_level_of_privacyP_Jami_has_text_messaging_video_and_audio_calls_file_transfer_and_v_170_KEY: |-
+Gives_you_full_control_over_your_communications_and_an_unmatched_level_of_privacyP_Jami_has_text_messaging_video_and_audio_calls_file_transfer_and_v_169_KEY: |-
   Gives you full control over your communications and an unmatched level of privacy. Jami has text messaging, video and audio calls, file transfer, and video conferencing.
 
-httpsfirstlookPorgtheintercept20150714communicatingsecretwatched_76_KEY: |-
+httpsfirstlookPorgtheintercept20150714communicatingsecretwatched_75_KEY: |-
   https://firstlook.org/theintercept/2015/07/14/communicating-secret-watched/
 
-Chatting_in_Secret_While_Were_All_Being_Watched__firstlookPorg_65_KEY: |-
+Chatting_in_Secret_While_Were_All_Being_Watched__firstlookPorg_64_KEY: |-
   Chatting in Secret While We're All Being Watched - firstlook.org
 
-httpssignalPorgandroidapk_32_KEY: |-
+httpssignalPorgandroidapk_31_KEY: |-
   https://signal.org/android/apk/
 
-Advanced_users_with_special_needs_can_download_the_Signal_APK_directlyP_Most_users_should_not_do_this_under_normal_circumstancesP_130_KEY: |-
+Advanced_users_with_special_needs_can_download_the_Signal_APK_directlyP_Most_users_should_not_do_this_under_normal_circumstancesP_129_KEY: |-
   Advanced users with special needs can download the Signal APK directly. Most users should not do this under normal circumstances.
 
-Independent_security_audits_28_KEY: |-
+Independent_security_audits_27_KEY: |-
   Independent security audits
 
-a_hrefhttpseprintPiacrPorg20161013PpdfA_Formal_Security_Analysis_of_the_Signal_Messaging_Protocol_2019a_by_Katriel_CohnGordon_Cas_Crem_207_KEY: |-
+a_hrefhttpseprintPiacrPorg20161013PpdfA_Formal_Security_Analysis_of_the_Signal_Messaging_Protocol_2019a_by_Katriel_CohnGordon_Cas_Crem_206_KEY: |-
   <a href="https://eprint.iacr.org/2016/1013.pdf">A Formal Security Analysis of the Signal Messaging Protocol (2019)</a> by Katriel Cohn-Gordon, Cas Cremers, Benjamin Dowling, Luke Garratt and Douglas Stebila
 
-a_hrefhttpskeybasePiodocsassetsblogNCC_Group_Keybase_KB2018_Public_Report_20190227_v1P3PpdfKeybases_Protocol_Security_Review_2019a__206_KEY: |-
+a_hrefhttpskeybasePiodocsassetsblogNCC_Group_Keybase_KB2018_Public_Report_20190227_v1P3PpdfKeybases_Protocol_Security_Review_2019a__205_KEY: |-
   <a href="https://keybase.io/docs-assets/blog/NCC_Group_Keybase_KB2018_Public_Report_2019-02-27_v1.3.pdf">Keybase's Protocol Security Review (2019)</a> by <a href="https://www.nccgroup.trust/">NCC Group</a>
 
-VideoVoice_Calling_20_KEY: |-
+VideoVoice_Calling_19_KEY: |-
   Video/Voice Calling
 
 If_you_are_currently_using_a_VideoVoice_Calling_app_like_Skype_Viber_or_Google_Hangouts_you_should_pick_an_alternative_hereP_127_KEY: |-
@@ -4001,34 +3947,34 @@ httpsappsPapplePcomusappmumbleid443472808Qls1_53_KEY: |-
 httpsgithubPcommumblevoip_31_KEY: |-
   https://github.com/mumble-voip/
 
-httpsjitsiPorg_19_KEY: |-
+httpsjitsiPorg_18_KEY: |-
   https://jitsi.org/
 
-Jitsi_Meet_11_KEY: |-
+Jitsi_Meet_10_KEY: |-
   Jitsi Meet
 
-Jitsi_Meet_is_a_free_and_opensource_multiplatform_voice_VoIP_video_conferencing_and_instant_messaging_applicationP_120_KEY: |-
+Jitsi_Meet_is_a_free_and_opensource_multiplatform_voice_VoIP_video_conferencing_and_instant_messaging_applicationP_119_KEY: |-
   Jitsi Meet is a free and open-source multiplatform voice (VoIP), video conferencing, and instant messaging application.
 
-Our_Firefox_tweaks_recommend_disabling_WebRTC_as_it_can_be_used_to_leak_your_IP_address_even_behind_a_VPN_which_is_why_Tor_Browser_disables_itP_145_KEY: |-
+Our_Firefox_tweaks_recommend_disabling_WebRTC_as_it_can_be_used_to_leak_your_IP_address_even_behind_a_VPN_which_is_why_Tor_Browser_disables_itP_144_KEY: |-
   Our Firefox tweaks recommend disabling WebRTC as it can be used to leak your IP address even behind a VPN, which is why Tor Browser disables it.
 
-Requires_WebRTC_16_KEY: |-
+Requires_WebRTC_15_KEY: |-
   Requires WebRTC
 
-More_information_about_Mumble_31_KEY: |-
+More_information_about_Mumble_30_KEY: |-
   More information about Mumble:
 
-a_href_httpswikiPmumblePinfowikiRunning_MurmurRunning_Mumble_Servera_and_a_hrefhttpswikiPmumblePinfowikiMurmurPiniits_config_fil_352_KEY: |-
+a_href_httpswikiPmumblePinfowikiRunning_MurmurRunning_Mumble_Servera_and_a_hrefhttpswikiPmumblePinfowikiMurmurPiniits_config_fil_351_KEY: |-
   <a href=" https://wiki.mumble.info/wiki/Running_Murmur">Running Mumble Server</a> and <a href="https://wiki.mumble.info/wiki/Murmur.ini">its config file</a>, particularly <a href="https://wiki.mumble.info/wiki/Murmur.ini#obfuscate">obfuscating IPv4 addresses</a> and <a href="https://wiki.mumble.info/wiki/Murmur.ini#Process_Administrivia">logging</a>
 
-a_hrefhttpstracPtorprojectPorgprojectstorwikidocTorifyHOWTOMumbleTorifying_Mumble_96_KEY: |-
+a_hrefhttpstracPtorprojectPorgprojectstorwikidocTorifyHOWTOMumbleTorifying_Mumble_95_KEY: |-
   <a href="https://trac.torproject.org/projects/tor/wiki/doc/TorifyHOWTO/Mumble">Torifying Mumble
 
-Team_Chat_Platforms_20_KEY: |-
+Team_Chat_Platforms_19_KEY: |-
   Team Chat Platforms
 
-If_your_project_or_organization_currently_uses_a_platform_like_a_hrefhttpstosdrPorgdiscordDiscorda_or_a_hrefhttpsdrewdevaultPcom201_236_KEY: |-
+If_your_project_or_organization_currently_uses_a_platform_like_a_hrefhttpstosdrPorgdiscordDiscorda_or_a_hrefhttpsdrewdevaultPcom201_235_KEY: |-
   If your project or organization currently uses a platform like <a href="https://tosdr.org/#discord">Discord</a> or <a href="https://drewdevault.com/2015/11/01/Please-stop-using-slack.html">Slack</a> you should pick an alternative here.
 
 RiotPim_Matrix_16_KEY: |-
@@ -4042,9 +3988,6 @@ The_endtoend_encryption_is_currently_in_beta_and_the_mobile_client_states_Endtoe
 
 a_hrefgithubPcomvectorimriotwebissues6779Experimental_E2EEa_73_KEY: |-
   <a href=//github.com/vector-im/riot-web/issues/6779>Experimental E2EE</a>
-
-httpsaboutPriotPim_22_KEY: |-
-  https://about.riot.im/
 
 httpsriotPimdownloaddesktop_33_KEY: |-
   https://riot.im/download/desktop/
@@ -4097,9 +4040,6 @@ httpsitunesPapplePcomapprocketchatid1148741252_53_KEY: |-
 httpsgithubPcomrocketchat_30_KEY: |-
   https://github.com/rocketchat/
 
-Keybase_7_KEY: |-
-  Keybase
-
 Keybase_provides_a_hosted_team_chat_with_endtoend_encryptionP_It_has_also_been_a_hrefhttpskeybasePiodocsassetsblogNCC_Group_Keybase_KB2018__218_KEY: |-
   Keybase provides a hosted team chat with end-to-end encryption. It has also been <a href="https://keybase.io/docs-assets/blog/NCC_Group_Keybase_KB2018_Public_Report_2019-02-27_v1.3.pdf">independently audited (PDF)</a>.
 
@@ -4108,9 +4048,6 @@ The_server_side_of_Keybase_runs_on_proprietary_code_and_is_centralizedP_71_KEY: 
 
 a_hrefgithubPcomkeybaseclientissues6374Warninga_59_KEY: |-
   <a href=//github.com/keybase/client/issues/6374>Warning</a>
-
-httpskeybasePio_19_KEY: |-
-  https://keybase.io/
 
 httpskeybasePiodocsthe_appinstall_windows_47_KEY: |-
   https://keybase.io/docs/the_app/install_windows
@@ -4151,25 +4088,16 @@ Nextcloud__Choose_your_hoster_30_KEY: |-
 Nextcloud_is_similar_in_functionality_to_the_widelyused_Dropbox_with_the_difference_being_that_Nextcloud_is_free_and_opensource_thereby_allowing_an_285_KEY: |-
   Nextcloud is similar in functionality to the widely-used Dropbox, with the difference being that Nextcloud is free and open-source, thereby allowing anyone to install and operate it without charge on a private server, with no limits on storage space or the number of connected clients.
 
-Worth_Mentioning_16_KEY: |-
-  Worth Mentioning
-
-Free_clientside_AES_encryption_for_your_cloud_filesP_Open_source_software_No_backdoors_no_registrationP_107_KEY: |-
-  Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.
-
-Cryptomators_mobile_apps_are_not_opensourceP_46_KEY: |-
-  Cryptomator's mobile apps are not open-source.
-
-httpscryptpadPfr_20_KEY: |-
+httpscryptpadPfr_19_KEY: |-
   https://cryptpad.fr
 
-Free_and_endtoend_encrypted_real_time_collaboration_sharing_folders_media_and_documentsP_93_KEY: |-
+Free_and_endtoend_encrypted_real_time_collaboration_sharing_folders_media_and_documentsP_92_KEY: |-
   Free and end-to-end encrypted real time collaboration sharing folders, media, and documents.
 
-Password_Manager_Software_26_KEY: |-
+Password_Manager_Software_25_KEY: |-
   Password Manager Software
 
-If_you_are_currently_using_a_password_manager_software_like_1Password_LastPass_Roboform_or_iCloud_Keychain_you_should_pick_an_alternative_hereP_148_KEY: |-
+If_you_are_currently_using_a_password_manager_software_like_1Password_LastPass_Roboform_or_iCloud_Keychain_you_should_pick_an_alternative_hereP_147_KEY: |-
   If you are currently using a password manager software like 1Password, LastPass, Roboform, or iCloud Keychain, you should pick an alternative here.
 
 Bitwarden__CloudSelfhost_27_KEY: |-
@@ -4286,40 +4214,40 @@ httpsplayPgooglePcomstoreappsdetailsQidcomPlesspassPandroid_66_KEY: |-
 httpsgithubPcomlesspasslesspass_36_KEY: |-
   https://github.com/lesspass/lesspass
 
-httpsmasterpasswordPapp_27_KEY: |-
+httpsmasterpasswordPapp_26_KEY: |-
   https://masterpassword.app
 
-Master_Password_16_KEY: |-
+Master_Password_15_KEY: |-
   Master Password
 
-A_password_manager_based_on_an_ingenious_passwordgeneration_algorithm_that_guarantees_your_passwords_can_never_be_lostP_Its_passwords_arent_stored_t_279_KEY: |-
+A_password_manager_based_on_an_ingenious_passwordgeneration_algorithm_that_guarantees_your_passwords_can_never_be_lostP_Its_passwords_arent_stored_t_278_KEY: |-
   A password manager based on an ingenious password-generation algorithm that guarantees your passwords can never be lost. Its passwords aren't stored: they are generated on-demand from your name, the site, and your master password. No syncing, backups, or internet access needed.
 
-httpspsonoPcom_19_KEY: |-
+httpspsonoPcom_18_KEY: |-
   https://psono.com/
 
-Psono_6_KEY: |-
+Psono_5_KEY: |-
   Psono
 
-Free_and_open_source_password_manager_for_teams_with_client_side_encryption_and_secure_sharing_of_passwords_files_bookmarks_emailsP_All_secrets_are__289_KEY: |-
+Free_and_open_source_password_manager_for_teams_with_client_side_encryption_and_secure_sharing_of_passwords_files_bookmarks_emailsP_All_secrets_are__288_KEY: |-
   Free and open source password manager for teams with client side encryption and secure sharing of passwords, files, bookmarks, emails. All secrets are protected by a master password. Uses <a href="https://nacl.cr.yp.to/">NACL Crypto</a>, a combination of Curve25519, Salsa20 and Poly1305.
 
-httpspwsafePorg_20_KEY: |-
+httpspwsafePorg_19_KEY: |-
   https://pwsafe.org/
 
-Password_Safe_14_KEY: |-
+Password_Safe_13_KEY: |-
   Password Safe
 
-Whether_the_answer_is_one_or_hundreds_Password_Safe_allows_you_to_safely_and_easily_create_a_secured_and_encrypted_usernamepassword_listP_With_Passwo_309_KEY: |-
+Whether_the_answer_is_one_or_hundreds_Password_Safe_allows_you_to_safely_and_easily_create_a_secured_and_encrypted_usernamepassword_listP_With_Passwo_308_KEY: |-
   Whether the answer is one or hundreds, Password Safe allows you to safely and easily create a secured and encrypted username/password list. With Password Safe all you have to do is create and remember a single "Master Password" of your choice in order to unlock and access your entire username/password list.
 
-httpspeertubePmastodonPhostvideoswatch4cdedd90a5b44022b93d828e85ed58cd_81_KEY: |-
+httpspeertubePmastodonPhostvideoswatch4cdedd90a5b44022b93d828e85ed58cd_80_KEY: |-
   https://peertube.mastodon.host/videos/watch/4cdedd90-a5b4-4022-b93d-828e85ed58cd
 
-Edward_Snowden_on_Passwords_on_Peertube_40_KEY: |-
+Edward_Snowden_on_Passwords_on_Peertube_39_KEY: |-
   Edward Snowden on Passwords on Peertube
 
-Decentralized_Social_Networks_30_KEY: |-
+Decentralized_Social_Networks_29_KEY: |-
   Decentralized Social Networks
 
 If_you_are_currently_using_Social_Networks_like_Facebook_or_Twitter_you_should_pick_an_alternative_hereP_105_KEY: |-
@@ -4397,88 +4325,88 @@ httpsgnuPiosocial_22_KEY: |-
 httpsgitPgnuPiognugnusocial_34_KEY: |-
   https://git.gnu.io/gnu/gnu-social/
 
-httpswwwPmindsPcom_23_KEY: |-
+httpswwwPmindsPcom_22_KEY: |-
   https://www.minds.com/
 
-Minds_6_KEY: |-
+Minds_5_KEY: |-
   Minds
 
-An_a_hrefhttpsgitlabPcommindsopensourcea_and_distributed_social_networking_service_integrating_the_blockchain_to_reward_the_communityP_149_KEY: |-
+An_a_hrefhttpsgitlabPcommindsopensourcea_and_distributed_social_networking_service_integrating_the_blockchain_to_reward_the_communityP_148_KEY: |-
   An <a href="https://gitlab.com/minds">open-source</a> and distributed social networking service, integrating the blockchain to reward the community.
 
-httpsmovimPeu_18_KEY: |-
+httpsmovimPeu_17_KEY: |-
   https://movim.eu/
 
-Movim_6_KEY: |-
+Movim_5_KEY: |-
   Movim
 
-A_federated_social_platform_that_relies_on_the_XMPP_standard_and_therefore_allows_you_to_exchange_with_many_other_clients_on_all_devicesP_138_KEY: |-
+A_federated_social_platform_that_relies_on_the_XMPP_standard_and_therefore_allows_you_to_exchange_with_many_other_clients_on_all_devicesP_137_KEY: |-
   A federated social platform that relies on the XMPP standard and therefore allows you to exchange with many other clients on all devices.
 
-httpsaddonsPmozillaPorgfirefoxaddonmastodonsimplifiedfederation_73_KEY: |-
+httpsaddonsPmozillaPorgfirefoxaddonmastodonsimplifiedfederation_72_KEY: |-
   https://addons.mozilla.org/firefox/addon/mastodon-simplified-federation/
 
-Mastodon_Simplified_Federation_32_KEY: |-
+Mastodon_Simplified_Federation_31_KEY: |-
   Mastodon: Simplified Federation
 
-Firefox_Extension_to_improve_usability_for_remote_Mastodon_instancesP_70_KEY: |-
+Firefox_Extension_to_improve_usability_for_remote_Mastodon_instancesP_69_KEY: |-
   Firefox Extension to improve usability for remote Mastodon instances.
 
-httpsjustdeletemePxyz_26_KEY: |-
+httpsjustdeletemePxyz_25_KEY: |-
   https://justdeleteme.xyz/
 
-JustDeleteMe_13_KEY: |-
+JustDeleteMe_12_KEY: |-
   JustDeleteMe
 
-A_directory_of_direct_links_to_delete_your_account_from_web_servicesP_70_KEY: |-
+A_directory_of_direct_links_to_delete_your_account_from_web_servicesP_69_KEY: |-
   A directory of direct links to delete your account from web services.
 
-httpsforgetPcodlPfr_24_KEY: |-
+httpsforgetPcodlPfr_23_KEY: |-
   https://forget.codl.fr/
 
-Forget_7_KEY: |-
+Forget_6_KEY: |-
   Forget
 
-A_service_that_automatically_deletes_your_old_posts_on_Twitter_and_Mastodon_that_everyone_has_forgotten_aboutP_111_KEY: |-
+A_service_that_automatically_deletes_your_old_posts_on_Twitter_and_Mastodon_that_everyone_has_forgotten_aboutP_110_KEY: |-
   A service that automatically deletes your old posts on Twitter and Mastodon that everyone has forgotten about.
 
-Facebook_Related_17_KEY: |-
+Facebook_Related_16_KEY: |-
   Facebook Related
 
-httpswwwPfacebookPcomhelpdelete_account_45_KEY: |-
+httpswwwPfacebookPcomhelpdelete_account_44_KEY: |-
   https://www.facebook.com/help/delete_account
 
-Delete_your_Facebook_account_29_KEY: |-
+Delete_your_Facebook_account_28_KEY: |-
   Delete your Facebook account
 
-Direct_link_to_delete_your_Facebook_account_without_being_able_to_reactivate_it_againP_87_KEY: |-
+Direct_link_to_delete_your_Facebook_account_without_being_able_to_reactivate_it_againP_86_KEY: |-
   Direct link to delete your Facebook account without being able to reactivate it again.
 
-httpsdeletefacebookPcom_28_KEY: |-
+httpsdeletefacebookPcom_27_KEY: |-
   https://deletefacebook.com/
 
-How_To_Permanently_Delete_A_Facebook_Account_45_KEY: |-
+How_To_Permanently_Delete_A_Facebook_Account_44_KEY: |-
   How To Permanently Delete A Facebook Account
 
-This_guide_will_take_you_through_a_smooth_and_successful_Facebook_account_deletionP_84_KEY: |-
+This_guide_will_take_you_through_a_smooth_and_successful_Facebook_account_deletionP_83_KEY: |-
   This guide will take you through a smooth and successful Facebook account deletion.
 
-httpsaddonsPmozillaPorgfirefoxaddonfacebookcontainer_61_KEY: |-
+httpsaddonsPmozillaPorgfirefoxaddonfacebookcontainer_60_KEY: |-
   https://addons.mozilla.org/firefox/addon/facebook-container/
 
-Facebook_Container_by_Mozilla_30_KEY: |-
+Facebook_Container_by_Mozilla_29_KEY: |-
   Facebook Container by Mozilla
 
-Prevent_Facebook_from_tracking_you_around_the_webP_51_KEY: |-
+Prevent_Facebook_from_tracking_you_around_the_webP_50_KEY: |-
   Prevent Facebook from tracking you around the web.
 
-httpswwwPstopusingfacebookPco_34_KEY: |-
+httpswwwPstopusingfacebookPco_33_KEY: |-
   https://www.stopusingfacebook.co/
 
-Stop_using_Facebook_20_KEY: |-
+Stop_using_Facebook_19_KEY: |-
   Stop using Facebook
 
-A_curated_list_of_reasons_to_stop_using_Facebook_and_how_to_do_itP_67_KEY: |-
+A_curated_list_of_reasons_to_stop_using_Facebook_and_how_to_do_itP_66_KEY: |-
   A curated list of reasons to stop using Facebook and how to do it.
 
 If_you_are_currently_using_a_online_bulletin_board_like_Reddit_you_should_pick_an_alternative_hereP_100_KEY: |-
@@ -4523,34 +4451,34 @@ httpsraddlePme_17_KEY: |-
 httpsgitlabPcompostmill_28_KEY: |-
   https://gitlab.com/postmill/
 
-httpsbetaPakashaPworld_27_KEY: |-
+httpsbetaPakashaPworld_26_KEY: |-
   https://beta.akasha.world/
 
-Akasha_7_KEY: |-
+Akasha_6_KEY: |-
   Akasha
 
-A_decentralized_online_bulletin_board_using_a_hrefhttpswwwPwikipediaPorgwikiInterPlanetary_File_SystemIPFSa_and_a_hrefhttpswwwPwikip_189_KEY: |-
+A_decentralized_online_bulletin_board_using_a_hrefhttpswwwPwikipediaPorgwikiInterPlanetary_File_SystemIPFSa_and_a_hrefhttpswwwPwikip_188_KEY: |-
   A decentralized online bulletin board using <a href="https://www.wikipedia.org/wiki/InterPlanetary_File_System">IPFS</a> and <a href="https://www.wikipedia.org/wiki/Ethereum">Ethereum</a>.
 
-httpsdevPlemmyPml_22_KEY: |-
+httpsdevPlemmyPml_21_KEY: |-
   https://dev.lemmy.ml/
 
-Lemmy_6_KEY: |-
+Lemmy_5_KEY: |-
   Lemmy
 
-An_a_hrefhttpsgithubPcomdessalineslemmyblobmasterLICENSEAGPLalicensed_selfhostable_link_aggregator_intended_to_work_in_the_a_hrefh_207_KEY: |-
+An_a_hrefhttpsgithubPcomdessalineslemmyblobmasterLICENSEAGPLalicensed_selfhostable_link_aggregator_intended_to_work_in_the_a_hrefh_206_KEY: |-
   An <a href="https://github.com/dessalines/lemmy/blob/master/LICENSE">AGPL</a>-licensed self-hostable link aggregator intended to work in the <a href="https://www.wikipedia.org/wiki/Fediverse">Fediverse</a>.
 
-httpsnotabugPio_20_KEY: |-
+httpsnotabugPio_19_KEY: |-
   https://notabug.io/
 
-notabugPio_11_KEY: |-
+notabugPio_10_KEY: |-
   notabug.io
 
-A_a_hrefhttpsgithubPcomnotabugionotabugblobmasterLICENSEPmdfree_and_opensourcea_P2P_link_aggregator_with_a_strong_resemblance_to_oldPr_235_KEY: |-
+A_a_hrefhttpsgithubPcomnotabugionotabugblobmasterLICENSEPmdfree_and_opensourcea_P2P_link_aggregator_with_a_strong_resemblance_to_oldPr_234_KEY: |-
   A <a href="https://github.com/notabugio/notabug/blob/master/LICENSE.md">free and open-source</a> P2P link aggregator with a strong resemblance to old.reddit.com (not to be confused with <a href="https://notabug.org/">NotABug.org</a>).
 
-Pastebin_Services_18_KEY: |-
+Pastebin_Services_17_KEY: |-
   Pastebin Services
 
 PrivateBin_10_KEY: |-
@@ -4565,9 +4493,6 @@ httpsprivatebinPinfo_24_KEY: |-
 httpsgithubPcomPrivateBinPrivateBin_40_KEY: |-
   https://github.com/PrivateBin/PrivateBin
 
-CryptPad_8_KEY: |-
-  CryptPad
-
 CryptPad_is_an_opensource_zero_knowledge_and_realtime_collaborative_editorP_Data_is_encrypteddecrypted_in_the_browser_using_Salsa20_with_Poly1305_168_KEY: |-
   CryptPad is an open-source, zero knowledge, and real-time collaborative editor. Data is encrypted/decrypted in the browser, using Salsa20 with Poly1305 to encrypt pads.
 
@@ -4579,6 +4504,9 @@ httpsgithubPcomxwikilabscryptpad_38_KEY: |-
 
 strongCryptPadstrong_is_a_privatebydesign_alternative_to_popular_office_tools_and_cloud_servicesP_All_content_is_endtoend_encryptedP_It_is_fre_366_KEY: |-
   <strong>CryptPad</strong> is a private-by-design alternative to popular office tools and cloud services. All content is end-to-end encrypted. It is free and open-source, enabling anyone to verify its security by auditing the code. The development team is supported by donations and grants. No registration is required, and it can be used anonymously via Tor Browser.
+
+httpscryptpadPfr_20_KEY: |-
+  https://cryptpad.fr/
 
 Etherpad_8_KEY: |-
   Etherpad
@@ -4631,67 +4559,67 @@ httpswritePaspad_20_KEY: |-
 httpscodePaswriteas_23_KEY: |-
   https://code.as/writeas
 
-httpscryptPee_18_KEY: |-
+httpscryptPee_17_KEY: |-
   https://crypt.ee/
 
-Cryptee_8_KEY: |-
+Cryptee_7_KEY: |-
   Cryptee
 
-Free_privacyfriendly_service_for_storing_Documents_files_and_Photos_70_KEY: |-
+Free_privacyfriendly_service_for_storing_Documents_files_and_Photos_69_KEY: |-
   Free privacy-friendly service for storing Documents, files and Photos
 
-httpsethercalcPnet_23_KEY: |-
+httpsethercalcPnet_22_KEY: |-
   https://ethercalc.net/
 
-EtherCalc_10_KEY: |-
+EtherCalc_9_KEY: |-
   EtherCalc
 
-EtherCalc_is_a_web_spreadsheetP_Data_is_saved_on_the_web_and_people_can_edit_the_same_document_at_the_same_timeP_Changes_are_instantly_reflected_on_al_247_KEY: |-
+EtherCalc_is_a_web_spreadsheetP_Data_is_saved_on_the_web_and_people_can_edit_the_same_document_at_the_same_timeP_Changes_are_instantly_reflected_on_al_246_KEY: |-
   EtherCalc is a web spreadsheet. Data is saved on the web, and people can edit the same document at the same time. Changes are instantly reflected on all screens. Work together on inventories, survey forms, list management, brainstorming sessions.
 
-httpsdisrootPorg_21_KEY: |-
+httpsdisrootPorg_20_KEY: |-
   https://disroot.org/
 
-Disroot_8_KEY: |-
+Disroot_7_KEY: |-
   Disroot
 
-Free_privacyfriendly_service_that_offers_Etherpad_EtherCalc_and_PrivateBinP_78_KEY: |-
+Free_privacyfriendly_service_that_offers_Etherpad_EtherCalc_and_PrivateBinP_77_KEY: |-
   Free privacy-friendly service that offers Etherpad, EtherCalc and PrivateBin.
 
-httpsdudlePinfPtudresdenPdeanonymous_43_KEY: |-
+httpsdudlePinfPtudresdenPdeanonymous_42_KEY: |-
   https://dudle.inf.tu-dresden.de/anonymous/
 
-dudle_6_KEY: |-
+dudle_5_KEY: |-
   dudle
 
-An_online_scheduling_application_free_and_opensourceP_Schedule_meetings_or_make_small_online_pollsP_No_email_collection_or_the_need_of_registrationP_151_KEY: |-
+An_online_scheduling_application_free_and_opensourceP_Schedule_meetings_or_make_small_online_pollsP_No_email_collection_or_the_need_of_registrationP_150_KEY: |-
   An online scheduling application, free and open-source. Schedule meetings or make small online polls. No email collection or the need of registration.
 
-httpsframadatePorg_23_KEY: |-
+httpsframadatePorg_22_KEY: |-
   https://framadate.org/
 
-Framadate_10_KEY: |-
+Framadate_9_KEY: |-
   Framadate
 
-A_free_and_opensource_online_service_for_planning_an_appointment_or_making_a_decision_quickly_and_easilyP_No_registration_is_requiredP_136_KEY: |-
+A_free_and_opensource_online_service_for_planning_an_appointment_or_making_a_decision_quickly_and_easilyP_No_registration_is_requiredP_135_KEY: |-
   A free and open-source online service for planning an appointment or making a decision quickly and easily. No registration is required.
 
-httpswwwPlibreofficePorg_29_KEY: |-
+httpswwwPlibreofficePorg_28_KEY: |-
   https://www.libreoffice.org/
 
-LibreOffice_12_KEY: |-
+LibreOffice_11_KEY: |-
   LibreOffice
 
-Free_and_opensource_office_suiteP_35_KEY: |-
+Free_and_opensource_office_suiteP_34_KEY: |-
   Free and open-source office suite.
 
-httpsvscodiumPcom_22_KEY: |-
+httpsvscodiumPcom_21_KEY: |-
   https://vscodium.com/
 
-VSCodium_9_KEY: |-
+VSCodium_8_KEY: |-
   VSCodium
 
-Fork_of_Microsofts_Visual_Studio_Code_editor_without_branding_or_telemetryP_77_KEY: |-
+Fork_of_Microsofts_Visual_Studio_Code_editor_without_branding_or_telemetryP_76_KEY: |-
   Fork of Microsoft's Visual Studio Code editor without branding or telemetry.
 
 MAT2_4_KEY: |-
@@ -4706,10 +4634,10 @@ https0xacabPorgjvoisinmat2_31_KEY: |-
 httpspypiPorgprojectmat2_30_KEY: |-
   https://pypi.org/project/mat2/
 
-PC_Operating_Systems_21_KEY: |-
+PC_Operating_Systems_20_KEY: |-
   PC Operating Systems
 
-If_you_are_currently_using_a_operating_system_like_Windows_10_you_should_pick_an_alternative_hereP_100_KEY: |-
+If_you_are_currently_using_a_operating_system_like_Windows_10_you_should_pick_an_alternative_hereP_99_KEY: |-
   If you are currently using a operating system like Windows 10, you should pick an alternative here.
 
 Qubes_OS_8_KEY: |-
@@ -4760,29 +4688,23 @@ httpswwwPdebianPorg_23_KEY: |-
 httpssalsaPdebianPorgqadebsources_38_KEY: |-
   https://salsa.debian.org/qa/debsources
 
-httpswwwPopenbsdPorg_25_KEY: |-
+httpswwwPopenbsdPorg_24_KEY: |-
   https://www.openbsd.org/
 
-OpenBSD_8_KEY: |-
+OpenBSD_7_KEY: |-
   OpenBSD
 
-BSD_4_KEY: |-
+BSD_3_KEY: |-
   BSD
 
-A_project_that_produces_a_free_multiplatform_4P4BSDbased_UNIXlike_operating_systemP_Emphasizes_portability_standardization_correctness_proactive_190_KEY: |-
+A_project_that_produces_a_free_multiplatform_4P4BSDbased_UNIXlike_operating_systemP_Emphasizes_portability_standardization_correctness_proactive_189_KEY: |-
   A project that produces a free, multi-platform 4.4BSD-based UNIX-like operating system. Emphasizes portability, standardization, correctness, proactive security and integrated cryptography.
 
-httpswwwParchlinuxPorg_27_KEY: |-
+httpswwwParchlinuxPorg_26_KEY: |-
   https://www.archlinux.org/
 
-Arch_Linux_11_KEY: |-
+Arch_Linux_10_KEY: |-
   Arch Linux
-
-GNULinux_10_KEY: |-
-  GNU/Linux
-
-contrib_8_KEY: |-
-  contrib
 
 A_simple_lightweight_Linux_distributionP_It_is_composed_predominantly_of_free_and_opensource_software_and_supports_community_involvementP_140_KEY: |-
   A simple, lightweight Linux distribution. It is composed predominantly of free and open-source software, and supports community involvement.
@@ -4791,34 +4713,34 @@ a_hrefhttpswwwPparabolaPnuParabolaa_is_a____completely_open_source_version_of_Ar
   <a href="https://www.parabola.nu/">Parabola</a> is a
     completely open source version of Arch Linux.
 
-httpstrisquelPinfo_23_KEY: |-
+httpstrisquelPinfo_22_KEY: |-
   https://trisquel.info/
 
-Trisquel_9_KEY: |-
+Trisquel_8_KEY: |-
   Trisquel
 
-Derived_from_Ubuntu_this_project_aims_for_a_fully_free_software_system_without_proprietary_software_or_firmware_and_uses_Linuxlibre_a_version_of_the_212_KEY: |-
+Derived_from_Ubuntu_this_project_aims_for_a_fully_free_software_system_without_proprietary_software_or_firmware_and_uses_Linuxlibre_a_version_of_the_211_KEY: |-
   Derived from Ubuntu, this project aims for a fully free software system without proprietary software or firmware and uses Linux-libre, a version of the Linux kernel with the non-free code (binary blobs) removed.
 
-httpswwwPwhonixPorg_24_KEY: |-
+httpswwwPwhonixPorg_23_KEY: |-
   https://www.whonix.org/
 
-Whonix_7_KEY: |-
+Whonix_6_KEY: |-
   Whonix
 
-A_Debianbased_securityfocused_Linux_distributionP_It_aims_to_provide_privacy_security_and_anonymity_on_the_internetP_The_operating_system_consists_o_285_KEY: |-
+A_Debianbased_securityfocused_Linux_distributionP_It_aims_to_provide_privacy_security_and_anonymity_on_the_internetP_The_operating_system_consists_o_284_KEY: |-
   A Debian-based security-focused Linux distribution. It aims to provide privacy, security and anonymity on the internet. The operating system consists of two virtual machines, a "Workstation" and a Tor "Gateway". All communication are forced through the Tor network to accomplish this.
 
-Dont_use_Windows_10__Its_a_privacy_nightmare_48_KEY: |-
+Dont_use_Windows_10__Its_a_privacy_nightmare_47_KEY: |-
   Don't use Windows 10 - It's a privacy nightmare
 
-Remember_to_check_CPU_vulnerability_mitigations_48_KEY: |-
+Remember_to_check_CPU_vulnerability_mitigations_47_KEY: |-
   Remember to check CPU vulnerability mitigations
 
 a_href_httpssupportPmicrosoftPcomenushelp4073757protectwindowsdevicesfromspeculativeexecutionsidechannelattackThis_also_affects_Wi_421_KEY: |-
   <a href=" https://support.microsoft.com/en-us/help/4073757/protect-windows-devices-from-speculative-execution-side-channel-attack">This also affects Windows 10</a>, but it doesn't expose this information or mitigation instructions as easily. MacOS users check <a href="https://support.apple.com/en-us/HT210108">How to enable full mitigation for Microarchitectural Data Sampling (MDS) vulnerabilities on Apple Support</a>.
 
-When_running_a_recent_enough_Linux_kernel_you_can_check_the_CPU_vulnerabilities_it_detects_by_codetail_n_1_sysdevicessystemcpuvulnerabilities_257_KEY: |-
+When_running_a_recent_enough_Linux_kernel_you_can_check_the_CPU_vulnerabilities_it_detects_by_codetail_n_1_sysdevicessystemcpuvulnerabilities_256_KEY: |-
   When running a recent enough Linux kernel, you can check the CPU vulnerabilities it detects by <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code>. By using <code>tail -n +1</code> instead of <code>cat</code>, the file names are also visible.
 
 In_case_you_have_an_Intel_CPU_you_may_notice_SMT_vulnerable_display_after_running_the_codetailcode_commandP_To_mitigate_this_disable_a_href_237_KEY: |-
@@ -4827,64 +4749,64 @@ In_case_you_have_an_Intel_CPU_you_may_notice_SMT_vulnerable_display_after_runnin
 You_can_also_take_the_following_mitigation_steps_below_if_your_systemdistribution_uses_GRUB_and_supports_codeetcdefaultgrubPdcode_140_KEY: |-
   You can also take the following mitigation steps below if your system/distribution uses GRUB and supports <code>/etc/default/grub.d/</code>:
 
-to_create_a_directory_for_additional_grub_configuration_56_KEY: |-
+to_create_a_directory_for_additional_grub_configuration_55_KEY: |-
   to create a directory for additional grub configuration
 
-to_create_a_new_grub_config_file_source_with_the_echoed_content_64_KEY: |-
+to_create_a_new_grub_config_file_source_with_the_echoed_content_63_KEY: |-
   to create a new grub config file source with the echoed content
 
-to_generate_a_new_grub_config_file_including_these_new_kernel_boot_flags_73_KEY: |-
+to_generate_a_new_grub_config_file_including_these_new_kernel_boot_flags_72_KEY: |-
   to generate a new grub config file including these new kernel boot flags
 
-to_reboot_10_KEY: |-
+to_reboot_9_KEY: |-
   to reboot
 
-after_the_reboot_check_codetail_n_1_sysdevicessystemcpuvulnerabilitiescode_again_to_see_that_everything_referring_to_SMT_now_says_SMT_d_161_KEY: |-
+after_the_reboot_check_codetail_n_1_sysdevicessystemcpuvulnerabilitiescode_again_to_see_that_everything_referring_to_SMT_now_says_SMT_d_160_KEY: |-
   after the reboot, check <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code> again to see that everything referring to SMT now says "SMT disabled."
 
-Further_reading_16_KEY: |-
+Further_reading_15_KEY: |-
   Further reading
 
-httpscpuPfail_18_KEY: |-
+httpscpuPfail_17_KEY: |-
   https://cpu.fail/
 
-CPUPfail_9_KEY: |-
+CPUPfail_8_KEY: |-
   CPU.fail
 
-httpswwwPkernelPorgdochtmllatestadminguidehwvuln_60_KEY: |-
+httpswwwPkernelPorgdochtmllatestadminguidehwvuln_59_KEY: |-
   https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/
 
-Hardware_vulnerabilities_index_on_The_Linux_kernel_users_and_administrators_guide_84_KEY: |-
+Hardware_vulnerabilities_index_on_The_Linux_kernel_users_and_administrators_guide_83_KEY: |-
   Hardware vulnerabilities index on The Linux kernel user's and administrator's guide
 
-httpswwwPcybercitiPbizfaqinstallupdateintelmicrocodefirmwarelinux_77_KEY: |-
+httpswwwPcybercitiPbizfaqinstallupdateintelmicrocodefirmwarelinux_76_KEY: |-
   https://www.cyberciti.biz/faq/install-update-intel-microcode-firmware-linux/
 
-How_to_installupdate_CPU_microcode_firmware_on_Linux_54_KEY: |-
+How_to_installupdate_CPU_microcode_firmware_on_Linux_53_KEY: |-
   How to install/update CPU microcode firmware on Linux
 
-Regardless_of_your_CPU_manufacturer_you_should_always_install_the_latest_microcode_packages_available_to_be_protected_from_CPU_vulnerabilities_especi_230_KEY: |-
+Regardless_of_your_CPU_manufacturer_you_should_always_install_the_latest_microcode_packages_available_to_be_protected_from_CPU_vulnerabilities_especi_229_KEY: |-
   Regardless of your CPU manufacturer, you should always install the latest microcode packages available to be protected from CPU vulnerabilities, especially if the command above reports <strong>no microcode</strong> in its output.
 
-httpswwwPkernelPorgdochtmllatestadminguidehwvulnmdsPhtml_68_KEY: |-
+httpswwwPkernelPorgdochtmllatestadminguidehwvulnmdsPhtml_67_KEY: |-
   https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html
 
-MDS__Microarchitectural_Data_Sampling_on_The_Linux_kernel_users_and_administrators_guide_92_KEY: |-
+MDS__Microarchitectural_Data_Sampling_on_The_Linux_kernel_users_and_administrators_guide_91_KEY: |-
   MDS - Microarchitectural Data Sampling on The Linux kernel user's and administrator's guide
 
-httpsmdsattacksPcom_24_KEY: |-
+httpsmdsattacksPcom_23_KEY: |-
   https://mdsattacks.com/
 
-RIDL_and_Fallout_MDS_attacks_on_mdsattacksPcom_48_KEY: |-
+RIDL_and_Fallout_MDS_attacks_on_mdsattacksPcom_47_KEY: |-
   RIDL and Fallout: MDS attacks on mdsattacks.com
 
-httpsenPwikipediaPorgwikiSimultaneous_multithreading_58_KEY: |-
+httpsenPwikipediaPorgwikiSimultaneous_multithreading_57_KEY: |-
   https://en.wikipedia.org/wiki/Simultaneous_multithreading
 
-Simultaneous_multithreading_on_Wikipedia_41_KEY: |-
+Simultaneous_multithreading_on_Wikipedia_40_KEY: |-
   Simultaneous multithreading on Wikipedia
 
-Live_CD_Operating_Systems_26_KEY: |-
+Live_CD_Operating_Systems_25_KEY: |-
   Live CD Operating Systems
 
 Tails_5_KEY: |-
@@ -4923,22 +4845,19 @@ httppuppylinuxPorg_22_KEY: |-
 httpdistroPibiblioPorgpuppylinux_37_KEY: |-
   http://distro.ibiblio.org/puppylinux/
 
-httpsdistroPibiblioPorgtinycorelinux_42_KEY: |-
+httpsdistroPibiblioPorgtinycorelinux_41_KEY: |-
   https://distro.ibiblio.org/tinycorelinux/
 
-Tiny_Core_Linux_16_KEY: |-
+Tiny_Core_Linux_15_KEY: |-
   Tiny Core Linux
-
-This_software_may_depend_on_or_recommend_nonfree_softwareP_60_KEY: |-
-  This software may depend on or recommend non-free software.
 
 A_minimal_Linux_operating_system_focusing_on_providing_a_base_system_using_BusyBox_and_FLTKP_The_distribution_is_notable_for_its_size_15_MB_and_minim_211_KEY: |-
   A minimal Linux operating system focusing on providing a base system using BusyBox and FLTK. The distribution is notable for its size (15 MB) and minimalism, with additional functionality provided by extensions.
 
-Mobile_Operating_Systems_25_KEY: |-
+Mobile_Operating_Systems_24_KEY: |-
   Mobile Operating Systems
 
-Even_though_the_source_code_of_the_following_OS_is_provided_installing_Google_Apps_may_compromise_your_setupP_111_KEY: |-
+Even_though_the_source_code_of_the_following_OS_is_provided_installing_Google_Apps_may_compromise_your_setupP_110_KEY: |-
   Even though the source code of the following OS is provided, installing Google Apps may compromise your setup.
 
 GrapheneOS_10_KEY: |-
@@ -4980,55 +4899,52 @@ httpsubuntutouchPio_24_KEY: |-
 httpsgithubPcomubports_26_KEY: |-
   https://github.com/ubports
 
-httpswwwPreplicantPus_26_KEY: |-
+httpswwwPreplicantPus_25_KEY: |-
   https://www.replicant.us/
 
-Replicant_10_KEY: |-
+Replicant_9_KEY: |-
   Replicant
 
-AOSP_5_KEY: |-
-  AOSP
-
-An_opensource_operating_system_based_on_Android_aiming_to_replace_all_proprietary_components_with_free_softwareP_115_KEY: |-
+An_opensource_operating_system_based_on_Android_aiming_to_replace_all_proprietary_components_with_free_softwareP_114_KEY: |-
   An open-source operating system based on Android, aiming to replace all proprietary components with free software.
 
-httpswwwPomniromPorg_25_KEY: |-
+httpswwwPomniromPorg_24_KEY: |-
   https://www.omnirom.org/
 
-OmniROM_8_KEY: |-
+OmniROM_7_KEY: |-
   OmniROM
 
-A_freesoftware_operating_system_for_smartphones_and_tablet_computers_based_on_the_Android_mobile_platformP_109_KEY: |-
+A_freesoftware_operating_system_for_smartphones_and_tablet_computers_based_on_the_Android_mobile_platformP_108_KEY: |-
   A free-software operating system for smartphones and tablet computers, based on the Android mobile platform.
 
-httpsmicrogPorg_20_KEY: |-
+httpsmicrogPorg_19_KEY: |-
   https://microg.org/
 
-MicroG_7_KEY: |-
+MicroG_6_KEY: |-
   MicroG
 
-Addon_Package_15_KEY: |-
+Addon_Package_14_KEY: |-
   Add-on Package
 
-A_project_that_aims_to_reimplement_the_proprietary_Google_Play_Services_in_the_Android_operating_system_with_a_FLOSS_replacementP_The_microG_project_al_286_KEY: |-
+A_project_that_aims_to_reimplement_the_proprietary_Google_Play_Services_in_the_Android_operating_system_with_a_FLOSS_replacementP_The_microG_project_al_285_KEY: |-
   A project that aims to reimplement the proprietary Google Play Services in the Android operating system with a FLOSS replacement. The microG project also maintains a fork of LineageOS with microG and F-Droid preinstalled at <a href="https://lineage.microg.org/">Lineage for microG</a>.
 
-Improve_your_privacy_with_these_addons_for_AndroidP_53_KEY: |-
+Improve_your_privacy_with_these_addons_for_AndroidP_52_KEY: |-
   Improve your privacy with these add-ons for Android.
 
-NetGuard_9_KEY: |-
+NetGuard_8_KEY: |-
   NetGuard
 
-Control_your_traffic_with_a_hrefhttpswwwPnetguardPmeNetGuarda_74_KEY: |-
+Control_your_traffic_with_a_hrefhttpswwwPnetguardPmeNetGuarda_73_KEY: |-
   Control your traffic with <a href="https://www.netguard.me/">NetGuard</a>
 
-strongNetGuardstrong_provides_simple_and_advanced_ways_to_block_certain_apps_access_to_the_internet_without_the_help_of_root_privilegesP_Applicat_320_KEY: |-
+strongNetGuardstrong_provides_simple_and_advanced_ways_to_block_certain_apps_access_to_the_internet_without_the_help_of_root_privilegesP_Applicat_319_KEY: |-
   <strong>NetGuard</strong> provides simple and advanced ways to block certain apps' access to the internet without the help of root privileges. Applications and addresses can individually be allowed or denied access to your Wi-Fi and/or mobile connection, allowing you to control which apps are able to call home or not.
 
-Orbot_6_KEY: |-
+Orbot_5_KEY: |-
   Orbot
 
-Tor_for_Android_with_a_hrefhttpsguardianprojectPinfoappsorbotOrbota_82_KEY: |-
+Tor_for_Android_with_a_hrefhttpsguardianprojectPinfoappsorbotOrbota_81_KEY: |-
   Tor for Android with <a href="https://guardianproject.info/apps/orbot/">Orbot</a>
 
 strongOrbotstrong_is_a_free_proxy_app_that_empowers_other_apps_to_use_the_internet_more_securelyP_Orbot_uses_Tor_to_encrypt_your_Internet_traffic__228_KEY: |-
@@ -5037,13 +4953,13 @@ strongOrbotstrong_is_a_free_proxy_app_that_empowers_other_apps_to_use_the_intern
 strongRoot_Modestrong_Orbot_can_be_configured_to_transparently_proxy_all_of_your_Internet_traffic_through_TorP_You_can_also_choose_which_specific_185_KEY: |-
   <strong>Root Mode:</strong> Orbot can be configured to transparently proxy all of your Internet traffic through Tor. You can also choose which specific apps you want to use through Tor.
 
-See_also_9_KEY: |-
+See_also_8_KEY: |-
   See also
 
 Our_DNS_pagea_which_also_has_information_on_encrypting_DNS_on_AndroidP_73_KEY: |-
   Our DNS page</a> which also has information on encrypting DNS on Android.
 
-Open_Source_Router_Firmware_28_KEY: |-
+Open_Source_Router_Firmware_27_KEY: |-
   Open Source Router Firmware
 
 OpenWrt_7_KEY: |-
@@ -5063,9 +4979,6 @@ httpsgitPopenwrtPorg_24_KEY: |-
 
 pfSense_7_KEY: |-
   pfSense
-
-BSD_3_KEY: |-
-  BSD
 
 pfSense_is_an_open_source_firewallrouter_computer_software_distribution_based_on_FreeBSDP_It_is_installed_on_a_computer_to_make_a_dedicated_firewallr_410_KEY: |-
   pfSense is an open source firewall/router computer software distribution based on FreeBSD. It is installed on a computer to make a dedicated firewall/router for a network and is noted for its reliability and offering features often only found in expensive commercial firewalls. pfSense is commonly deployed as a perimeter firewall, router, wireless access point, DHCP server, DNS server, and as a VPN endpoint.
@@ -5088,771 +5001,744 @@ httpslibrecmcPorg_20_KEY: |-
 httpsgogsPlibrecmcPorglibreCMClibreCMC_43_KEY: |-
   https://gogs.librecmc.org/libreCMC/libreCMC
 
-httpsddwrtPcom_20_KEY: |-
+httpsddwrtPcom_19_KEY: |-
   https://dd-wrt.com/
 
-DDWRT_7_KEY: |-
+DDWRT_6_KEY: |-
   DD-WRT
-
-Linux_6_KEY: |-
-  Linux
 
 A_Linuxbased_opensource_firmware_compatible_with_several_models_of_routers_and_access_pointsP_95_KEY: |-
   A Linux-based open-source firmware compatible with several models of routers and access points.
 
-Microsoft_introduced_a_lot_of_new_features_in_Windows_10_such_as_CortanaP_However_most_of_them_are_violating_your_privacyP_124_KEY: |-
+Microsoft_introduced_a_lot_of_new_features_in_Windows_10_such_as_CortanaP_However_most_of_them_are_violating_your_privacyP_123_KEY: |-
   Microsoft introduced a lot of new features in Windows 10 such as Cortana. However, most of them are violating your privacy.
 
-Windows_10_Privacy_19_KEY: |-
+Windows_10_Privacy_18_KEY: |-
   Windows 10 Privacy
 
-Data_syncing_is_by_default_enabledP_36_KEY: |-
+Data_syncing_is_by_default_enabledP_35_KEY: |-
   Data syncing is by default enabled.
 
-Browsing_history_and_open_websitesP_36_KEY: |-
+Browsing_history_and_open_websitesP_35_KEY: |-
   Browsing history and open websites.
 
-Apps_settingsP_15_KEY: |-
+Apps_settingsP_14_KEY: |-
   Apps settings.
 
-WiFi_hotspot_names_and_passwordsP_34_KEY: |-
+WiFi_hotspot_names_and_passwordsP_33_KEY: |-
   WiFi hotspot names and passwords.
 
-Your_device_is_by_default_tagged_with_a_unique_advertising_IDP_63_KEY: |-
+Your_device_is_by_default_tagged_with_a_unique_advertising_IDP_62_KEY: |-
   Your device is by default tagged with a unique advertising ID.
 
-Used_to_serve_you_with_personalized_advertisements_by_thirdparty_advertisers_and_ad_networksP_95_KEY: |-
+Used_to_serve_you_with_personalized_advertisements_by_thirdparty_advertisers_and_ad_networksP_94_KEY: |-
   Used to serve you with personalized advertisements by third-party advertisers and ad networks.
 
-Cortana_can_collect_any_of_your_dataP_38_KEY: |-
+Cortana_can_collect_any_of_your_dataP_37_KEY: |-
   Cortana can collect any of your data.
 
-Your_keystrokes_searches_and_mic_inputP_41_KEY: |-
+Your_keystrokes_searches_and_mic_inputP_40_KEY: |-
   Your keystrokes, searches and mic input.
 
-Calendar_dataP_15_KEY: |-
+Calendar_dataP_14_KEY: |-
   Calendar data.
 
-Music_you_listen_toP_21_KEY: |-
+Music_you_listen_toP_20_KEY: |-
   Music you listen to.
 
-Credit_Card_informationP_25_KEY: |-
+Credit_Card_informationP_24_KEY: |-
   Credit Card information.
 
-PurchasesP_11_KEY: |-
+PurchasesP_10_KEY: |-
   Purchases.
 
-Microsoft_can_collect_any_personal_dataP_41_KEY: |-
+Microsoft_can_collect_any_personal_dataP_40_KEY: |-
   Microsoft can collect any personal data.
 
-Your_identityP_15_KEY: |-
+Your_identityP_14_KEY: |-
   Your identity.
 
-PasswordsP_11_KEY: |-
+PasswordsP_10_KEY: |-
   Passwords.
 
-DemographicsP_14_KEY: |-
+DemographicsP_13_KEY: |-
   Demographics.
 
-Interests_and_habitsP_22_KEY: |-
+Interests_and_habitsP_21_KEY: |-
   Interests and habits.
 
-Usage_dataP_12_KEY: |-
+Usage_dataP_11_KEY: |-
   Usage data.
 
-Contacts_and_relationshipsP_28_KEY: |-
+Contacts_and_relationshipsP_27_KEY: |-
   Contacts and relationships.
 
-Location_dataP_15_KEY: |-
+Location_dataP_14_KEY: |-
   Location data.
 
-Content_like_emails_instant_messages_caller_list_audio_and_video_recordingsP_80_KEY: |-
+Content_like_emails_instant_messages_caller_list_audio_and_video_recordingsP_79_KEY: |-
   Content like emails, instant messages, caller list, audio and video recordings.
 
-Your_data_can_be_sharedP_25_KEY: |-
+Your_data_can_be_sharedP_24_KEY: |-
   Your data can be shared.
 
-When_downloading_Windows_10_you_are_authorizing_Microsoft_to_share_any_of_abovementioned_data_with_any_thirdparty_with_or_without_your_consentP_148_KEY: |-
+When_downloading_Windows_10_you_are_authorizing_Microsoft_to_share_any_of_abovementioned_data_with_any_thirdparty_with_or_without_your_consentP_147_KEY: |-
   When downloading Windows 10, you are authorizing Microsoft to share any of above-mentioned data with any third-party, with or without your consent.
 
-httpswwwPwinprivacyPdeenglishhome_40_KEY: |-
+httpswwwPwinprivacyPdeenglishhome_39_KEY: |-
   https://www.winprivacy.de/english-home/
 
-Download_W10Privacy_21_KEY: |-
+Download_W10Privacy_20_KEY: |-
   Download: W10Privacy
 
-This_tool_uses_some_known_methods_that_attempt_to_disable_major_tracking_features_in_Windows_10P_97_KEY: |-
+This_tool_uses_some_known_methods_that_attempt_to_disable_major_tracking_features_in_Windows_10P_96_KEY: |-
   This tool uses some known methods that attempt to disable major tracking features in Windows 10.
 
-httpsprivacyPmicrosoftPcomenusprivacystatement_53_KEY: |-
+httpsprivacyPmicrosoftPcomenusprivacystatement_52_KEY: |-
   https://privacy.microsoft.com/en-us/privacystatement
 
-Microsoft_Privacy_Statement_28_KEY: |-
+Microsoft_Privacy_Statement_27_KEY: |-
   Microsoft Privacy Statement
 
-Microsoft_collects_uses_and_discloses_personal_information_as_described_hereP_This_allows_OneDrive_data_Cortana_searches_and_MS_browser_history_to_b_176_KEY: |-
+Microsoft_collects_uses_and_discloses_personal_information_as_described_hereP_This_allows_OneDrive_data_Cortana_searches_and_MS_browser_history_to_b_175_KEY: |-
   Microsoft collects, uses and discloses personal information as described here. This allows OneDrive data, Cortana searches, and MS browser history to be sold to third parties.
 
-httpssupportPmicrosoftPcomenushelp4468233cortanaandprivacymicrosoftprivacy_87_KEY: |-
+httpssupportPmicrosoftPcomenushelp4468233cortanaandprivacymicrosoftprivacy_86_KEY: |-
   https://support.microsoft.com/en-us/help/4468233/cortana-and-privacy-microsoft-privacy
 
-Cortana_and_privacy_20_KEY: |-
+Cortana_and_privacy_19_KEY: |-
   Cortana and privacy
 
-To_personalize_your_experience_and_provide_the_best_possible_suggestions_Cortana_accesses_your_email_and_other_communications_and_collects_data_about__398_KEY: |-
+To_personalize_your_experience_and_provide_the_best_possible_suggestions_Cortana_accesses_your_email_and_other_communications_and_collects_data_about__397_KEY: |-
   To personalize your experience and provide the best possible suggestions, Cortana accesses your email and other communications and collects data about your contacts (People), like their title, suffix, first name, last name, middle name, nicknames, and company name. If you call, email, or text someone or they call, email, or text you, Cortana collects that person’s email address or phone number.
 
-Some_good_news_15_KEY: |-
+Some_good_news_14_KEY: |-
   Some good news
 
-httpsgithubPcomcrazymaxWindowsSpyBlockerreleases_56_KEY: |-
+httpsgithubPcomcrazymaxWindowsSpyBlockerreleases_55_KEY: |-
   https://github.com/crazy-max/WindowsSpyBlocker/releases
 
-WindowsSpyBlocker_18_KEY: |-
+WindowsSpyBlocker_17_KEY: |-
   WindowsSpyBlocker
 
-Opensource_tool_that_blocks_data_collectionP_46_KEY: |-
+Opensource_tool_that_blocks_data_collectionP_45_KEY: |-
   Open-source tool that blocks data collection.
 
-httpswwwPghacksPnet20150814comparisonofwindows10privacytools_74_KEY: |-
+httpswwwPghacksPnet20150814comparisonofwindows10privacytools_73_KEY: |-
   https://www.ghacks.net/2015/08/14/comparison-of-windows-10-privacy-tools/
 
-Comparison_of_Windows_10_Privacy_tools_39_KEY: |-
+Comparison_of_Windows_10_Privacy_tools_38_KEY: |-
   Comparison of Windows 10 Privacy tools
 
-More_bad_news_14_KEY: |-
+More_bad_news_13_KEY: |-
   More bad news
 
-httpsthehackernewsPcom201602microsoftwindows10privacyPhtml_67_KEY: |-
+httpsthehackernewsPcom201602microsoftwindows10privacyPhtml_66_KEY: |-
   https://thehackernews.com/2016/02/microsoft-windows10-privacy.html
 
-Windows_10_Sends_Your_Data_5500_Times_Every_Day_Even_After_Tweaking_Privacy_Settings_85_KEY: |-
+Windows_10_Sends_Your_Data_5500_Times_Every_Day_Even_After_Tweaking_Privacy_Settings_84_KEY: |-
   Windows 10 Sends Your Data 5500 Times Every Day Even After Tweaking Privacy Settings
 
-The_Hacker_NewsP_17_KEY: |-
+The_Hacker_NewsP_16_KEY: |-
   The Hacker News.
 
-httpsarstechnicaPcominformationtechnology201508evenwhentoldnottowindows10justcantstoptalkingtomicrosoft_125_KEY: |-
+httpsarstechnicaPcominformationtechnology201508evenwhentoldnottowindows10justcantstoptalkingtomicrosoft_124_KEY: |-
   https://arstechnica.com/information-technology/2015/08/even-when-told-not-to-windows-10-just-cant-stop-talking-to-microsoft/
 
-Even_when_told_not_to_Windows_10_just_cant_stop_talking_to_MicrosoftP_Its_no_wonder_that_privacy_activists_are_up_in_armsP_126_KEY: |-
+Even_when_told_not_to_Windows_10_just_cant_stop_talking_to_MicrosoftP_Its_no_wonder_that_privacy_activists_are_up_in_armsP_125_KEY: |-
   Even when told not to, Windows 10 just can't stop talking to Microsoft. It's no wonder that privacy activists are up in arms.
 
-Ars_TechnicaP_14_KEY: |-
+Ars_TechnicaP_13_KEY: |-
   Ars Technica.
 
-httpswwwPtechdirtPcomarticles2015082006171332012windows10reservesrighttoblockpiratedgamesunauthorizedhardwarePshtml_132_KEY: |-
+httpswwwPtechdirtPcomarticles2015082006171332012windows10reservesrighttoblockpiratedgamesunauthorizedhardwarePshtml_131_KEY: |-
   https://www.techdirt.com/articles/20150820/06171332012/windows-10-reserves-right-to-block-pirated-games-unauthorized-hardware.shtml
 
-Windows_10_Reserves_The_Right_To_Block_Pirated_Games_And_Unauthorized_HardwareP_82_KEY: |-
+Windows_10_Reserves_The_Right_To_Block_Pirated_Games_And_Unauthorized_HardwareP_81_KEY: |-
   Windows 10 Reserves The Right To Block Pirated Games And 'Unauthorized' Hardware.
 
-TechdirtP_10_KEY: |-
+TechdirtP_9_KEY: |-
   Techdirt.
 
-Who_is__sitePname_Q_24_KEY: |-
+Who_is__sitePname_Q_23_KEY: |-
   Who is {{ site.name }}?
 
-_sitePname__is_an_unincorporated_community_developing_this_website_and_a_number_of_privacyfriendly_servicesP_The_current_list_of_public_team_membe_350_KEY: |-
+_sitePname__is_an_unincorporated_community_developing_this_website_and_a_number_of_privacyfriendly_servicesP_The_current_list_of_public_team_membe_349_KEY: |-
   {{ site.name }} is an unincorporated community developing this website and a number of privacy-friendly services. The current list of public team members [can be found on GitHub](https://github.com/orgs/privacytoolsIO/people). In order to operate these services, {{ site.name }} receives hosting and administration services from Aragon Ventures LLC.
 
-How_does__sitePname__collect_data_about_meQ_48_KEY: |-
+How_does__sitePname__collect_data_about_meQ_47_KEY: |-
   How does {{ site.name }} collect data about me?
 
-We_collect_data_17_KEY: |-
+We_collect_data_16_KEY: |-
   We collect data:
 
-When_you_browse_a_website_forum_or_other__sitePname__serviceP_68_KEY: |-
+When_you_browse_a_website_forum_or_other__sitePname__serviceP_67_KEY: |-
   When you browse a website, forum, or other {{ site.name }} service.
 
-When_you_create_an_account_on_a__sitePname__serviceP_57_KEY: |-
+When_you_create_an_account_on_a__sitePname__serviceP_56_KEY: |-
   When you create an account on a {{ site.name }} service.
 
-When_you_post_send_private_messages_or_otherwise_participate_on_a__sitePname__serviceP_93_KEY: |-
+When_you_post_send_private_messages_or_otherwise_participate_on_a__sitePname__serviceP_92_KEY: |-
   When you post, send private messages, or otherwise participate on a {{ site.name }} service.
 
-This_data_will_be_collected_regardless_of_browser_device_or_app_used_to_access_our_servicesP_We_do_not_buy_or_otherwise_receive_data_from_data_broker_154_KEY: |-
+This_data_will_be_collected_regardless_of_browser_device_or_app_used_to_access_our_servicesP_We_do_not_buy_or_otherwise_receive_data_from_data_broker_153_KEY: |-
   This data will be collected regardless of browser, device, or app used to access our services. We do not buy or otherwise receive data from data brokers.
 
-What_data_do_you_collect_and_whyQ_34_KEY: |-
+What_data_do_you_collect_and_whyQ_33_KEY: |-
   What data do you collect and why?
 
-We_collect_data_about_visits_to_our_websitesP_46_KEY: |-
+We_collect_data_about_visits_to_our_websitesP_45_KEY: |-
   We collect data about visits to our websites.
 
-When_you_visit_a__sitePname__website_or_service_regardless_of_whether_you_have_an_account_or_not_the_website_may_use_cookies_server_logs_and_ot_194_KEY: |-
+When_you_visit_a__sitePname__website_or_service_regardless_of_whether_you_have_an_account_or_not_the_website_may_use_cookies_server_logs_and_ot_193_KEY: |-
   When you visit a {{ site.name }} website or service, regardless of whether you have an account or not, the website may use cookies, server logs, and other methods to collect the following data:
 
-What_pages_you_visit_22_KEY: |-
+What_pages_you_visit_21_KEY: |-
   What pages you visit,
 
-What_actions_you_take_on_our_website_38_KEY: |-
+What_actions_you_take_on_our_website_37_KEY: |-
   What actions you take on our website,
 
-What_browser_operating_system_and_device_you_use_52_KEY: |-
+What_browser_operating_system_and_device_you_use_51_KEY: |-
   What browser, operating system, and device you use,
 
-Search_terms_you_use_22_KEY: |-
+Search_terms_you_use_21_KEY: |-
   Search terms you use,
 
-Your_anonymized_IP_address_We_anonymize_the_last_3_bytes_of_your_IP_ePgP_192PxxxPxxxPxxxP_92_KEY: |-
+Your_anonymized_IP_address_We_anonymize_the_last_3_bytes_of_your_IP_ePgP_192PxxxPxxxPxxxP_91_KEY: |-
   Your anonymized IP address: We anonymize the last 3 bytes of your IP, e.g. 192.xxx.xxx.xxx.
 
-We_use_this_data_to_21_KEY: |-
+We_use_this_data_to_20_KEY: |-
   We use this data to:
 
-Optimize_websites_and_services_so_that_they_are_quick_and_easy_to_use_72_KEY: |-
+Optimize_websites_and_services_so_that_they_are_quick_and_easy_to_use_71_KEY: |-
   Optimize websites and services, so that they are quick and easy to use,
 
-Diagnose_and_debug_technical_errors_37_KEY: |-
+Diagnose_and_debug_technical_errors_36_KEY: |-
   Diagnose and debug technical errors,
 
-Defend_websites_and_services_from_abuse_and_technical_attacks_63_KEY: |-
+Defend_websites_and_services_from_abuse_and_technical_attacks_62_KEY: |-
   Defend websites and services from abuse and technical attacks,
 
-Compile_statistics_on_the_popularity_of_a_website_page_post_topic_etcP_and_80_KEY: |-
+Compile_statistics_on_the_popularity_of_a_website_page_post_topic_etcP_and_79_KEY: |-
   Compile statistics on the popularity of a website, page, post, topic, etc., and
 
-Compile_statistics_on_the_kinds_of_software_and_computers_visitors_useP_72_KEY: |-
+Compile_statistics_on_the_kinds_of_software_and_computers_visitors_useP_71_KEY: |-
   Compile statistics on the kinds of software and computers visitors use.
 
-This_data_is_processed_under_our_Legitimate_InteresthttpsicoPorgPukfororganisationsguidetodataprotectionguidetothegeneraldataprotecti_379_KEY: |-
+This_data_is_processed_under_our_Legitimate_InteresthttpsicoPorgPukfororganisationsguidetodataprotectionguidetothegeneraldataprotecti_378_KEY: |-
   This data is processed under our [Legitimate Interest](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/legitimate-interests/when-can-we-rely-on-legitimate-interests/) to provide our services to you in a an efficient and secure manner and to ensure the legal compliance and proper administration of our business.
 
-Raw_data_such_as_pages_visited_anonymized_visitor_IPs_and_visitor_actions_will_be_retained_for_60_daysP_In_special_circumstancessuch_as_extended_inv_417_KEY: |-
+Raw_data_such_as_pages_visited_anonymized_visitor_IPs_and_visitor_actions_will_be_retained_for_60_daysP_In_special_circumstancessuch_as_extended_inv_416_KEY: |-
   Raw data such as pages visited, anonymized visitor IPs, and visitor actions will be retained for 60 days. In special circumstances—such as extended investigations regarding a technical attack—we may preserve logged data for longer periods for analysis. We store aggregate statistics about use of the websites and services we host indefinitely, but those statistics do not include data identifiable to you personally.
 
-You_can_opt_out_of_some_website_tracking_we_do_with_Matomo_using_the_form_belowP_Our_Matomo_instance_is_blocked_by_most_adblockers_so_users_blocking__514_KEY: |-
+You_can_opt_out_of_some_website_tracking_we_do_with_Matomo_using_the_form_belowP_Our_Matomo_instance_is_blocked_by_most_adblockers_so_users_blocking__513_KEY: |-
   You can opt out of some website tracking we do with Matomo using the form below. Our Matomo instance is blocked by most ad-blockers, so users blocking the domain `stats.privacytools.io` will not need to separately opt-out with the form below. Our Matomo instance also respects the Do Not Track (DNT) setting in your browser, so users with DNT enabled will not need to complete this form. Limited data may still be collected via server-side logs after opting out here, but this data cannot be used to identify you.
 
-We_collect_account_dataP_25_KEY: |-
+We_collect_account_dataP_24_KEY: |-
   We collect account data.
 
-On_some_websites_and_services_we_provide_many_features_may_require_an_accountP_For_example_on_forumPprivacytoolsPio_an_account_is_required_to_post_an_170_KEY: |-
+On_some_websites_and_services_we_provide_many_features_may_require_an_accountP_For_example_on_forumPprivacytoolsPio_an_account_is_required_to_post_an_169_KEY: |-
   On some websites and services we provide, many features may require an account. For example, on forum.privacytools.io an account is required to post and reply to topics.
 
-To_sign_up_for_most_accounts_we_will_collect_a_name_username_email_and_passwordP_In_the_event_a_website_requires_more_information_than_just_that_da_236_KEY: |-
+To_sign_up_for_most_accounts_we_will_collect_a_name_username_email_and_passwordP_In_the_event_a_website_requires_more_information_than_just_that_da_235_KEY: |-
   To sign up for most accounts, we will collect a name, username, email, and password. In the event a website requires more information than just that data, that will be clearly marked and noted in a separate privacy statement, per-site.
 
-We_use_your_account_data_to_identify_you_on_the_website_and_to_create_pages_specific_to_you_such_as_your_profile_pageP_We_will_also_use_your_account__209_KEY: |-
+We_use_your_account_data_to_identify_you_on_the_website_and_to_create_pages_specific_to_you_such_as_your_profile_pageP_We_will_also_use_your_account__208_KEY: |-
   We use your account data to identify you on the website, and to create pages specific to you, such as your profile page. We will also use your account data to publish a public profile for you on our services.
 
-We_use_your_email_to_22_KEY: |-
+We_use_your_email_to_21_KEY: |-
   We use your email to:
 
-Notify_you_about_posts_and_other_activity_on_the_websites_or_servicesP_71_KEY: |-
+Notify_you_about_posts_and_other_activity_on_the_websites_or_servicesP_70_KEY: |-
   Notify you about posts and other activity on the websites or services.
 
-Reset_your_password_and_help_keep_your_account_secureP_55_KEY: |-
+Reset_your_password_and_help_keep_your_account_secureP_54_KEY: |-
   Reset your password and help keep your account secure.
 
-Contact_you_in_special_circumstances_related_to_your_accountP_62_KEY: |-
+Contact_you_in_special_circumstances_related_to_your_accountP_61_KEY: |-
   Contact you in special circumstances related to your account.
 
-Contact_you_about_legal_requests_such_as_DMCA_takedown_requestsP_66_KEY: |-
+Contact_you_about_legal_requests_such_as_DMCA_takedown_requestsP_65_KEY: |-
   Contact you about legal requests, such as DMCA takedown requests.
 
-On_some_websites_and_services_you_may_provide_additional_information_for_your_account_such_as_a_short_biography_avatar_your_location_or_your_birthd_345_KEY: |-
+On_some_websites_and_services_you_may_provide_additional_information_for_your_account_such_as_a_short_biography_avatar_your_location_or_your_birthd_344_KEY: |-
   On some websites and services you may provide additional information for your account, such as a short biography, avatar, your location, or your birthday. We make that information available to everyone who can access the website or service in question. This information is not required to use any of our services, and can be erased at any time.
 
-We_will_store_your_account_data_as_long_as_your_account_remains_openP_After_closing_an_account_we_may_retain_some_or_all_of_your_account_data_in_the_f_197_KEY: |-
+We_will_store_your_account_data_as_long_as_your_account_remains_openP_After_closing_an_account_we_may_retain_some_or_all_of_your_account_data_in_the_f_196_KEY: |-
   We will store your account data as long as your account remains open. After closing an account, we may retain some or all of your account data in the form of backups or archives for up to 90 days.
 
-Who_is_my_data_shared_withQ_28_KEY: |-
+Who_is_my_data_shared_withQ_27_KEY: |-
   Who is my data shared with?
 
-When_you_use_services_provided_by__sitePname__your_data_is_shared_with_Aragon_Ventures_LLC_in_order_to_facilitate_their_hosting_obligationsP_Arago_308_KEY: |-
+When_you_use_services_provided_by__sitePname__your_data_is_shared_with_Aragon_Ventures_LLC_in_order_to_facilitate_their_hosting_obligationsP_Arago_307_KEY: |-
   When you use services provided by {{ site.name }} your data is shared with Aragon Ventures LLC, in order to facilitate their hosting obligations. Aragon Ventures LLC may collect and use your data as described in their privacy statement at [https://aragon.ventures/privacy](https://aragon.ventures/privacy/).
 
-Your_account_data_posts_and_other_activities_on__sitePname__services_is_shared_with_others_as_mentioned_in_the_section_about_account_dataP_145_KEY: |-
+Your_account_data_posts_and_other_activities_on__sitePname__services_is_shared_with_others_as_mentioned_in_the_section_about_account_dataP_144_KEY: |-
   Your account data, posts, and other activities on {{ site.name }} services is shared with others as mentioned in the section about account data.
 
-Where_is_my_data_storedQ_25_KEY: |-
+Where_is_my_data_storedQ_24_KEY: |-
   Where is my data stored?
 
-Your_data_is_stored_on_servers_provided_by_Aragon_Ventures_LLC_a_company_incorporated_in_Minnesota_United_StatesP_The_primary_datacenter_for__siteP_322_KEY: |-
+Your_data_is_stored_on_servers_provided_by_Aragon_Ventures_LLC_a_company_incorporated_in_Minnesota_United_StatesP_The_primary_datacenter_for__siteP_321_KEY: |-
   Your data is stored on servers provided by Aragon Ventures LLC, a company incorporated in Minnesota, United States. The primary datacenter for {{ site.name }} is located in France. Some websites, services, or backups may reside in datacenters in multiple jurisdictions, including the United States and the European Union.
 
-Is__sitePname__GDPR_compliantQ_35_KEY: |-
+Is__sitePname__GDPR_compliantQ_34_KEY: |-
   Is {{ site.name }} GDPR compliant?
 
-We_respect_privacy_rights_under_Regulation_EU_2016679httpseurlexPeuropaPeulegalcontentENTXTQuriuriservOJPL_P2016P119P01P0001P01PENG__296_KEY: |-
+We_respect_privacy_rights_under_Regulation_EU_2016679httpseurlexPeuropaPeulegalcontentENTXTQuriuriservOJPL_P2016P119P01P0001P01PENG__295_KEY: |-
   We respect privacy rights under [Regulation (EU) 2016/679](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.L_.2016.119.01.0001.01.ENG), the European Union’s General Data Protection Regulation (GDPR). Information that GDPR requires us to give can be found throughout this document.
 
-What_are_my_data_protection_rightsQ_36_KEY: |-
+What_are_my_data_protection_rightsQ_35_KEY: |-
   What are my data protection rights?
 
-We_would_like_to_make_sure_you_are_fully_aware_of_all_of_your_data_protection_rightsP_Every_user_is_entitled_to_the_following_127_KEY: |-
+We_would_like_to_make_sure_you_are_fully_aware_of_all_of_your_data_protection_rightsP_Every_user_is_entitled_to_the_following_126_KEY: |-
   We would like to make sure you are fully aware of all of your data protection rights. Every user is entitled to the following:
 
-The_right_to_access_20_KEY: |-
+The_right_to_access_19_KEY: |-
   The right to access
 
-You_have_the_right_to_request_access_to_your_personal_data_or_copies_of_your_personal_data_from_usP_We_may_charge_you_a_small_fee_for_providing_a_copy_166_KEY: |-
+You_have_the_right_to_request_access_to_your_personal_data_or_copies_of_your_personal_data_from_usP_We_may_charge_you_a_small_fee_for_providing_a_copy_165_KEY: |-
   You have the right to request access to your personal data, or copies of your personal data from us. We may charge you a small fee for providing a copy of your data.
 
-The_right_to_rectification_27_KEY: |-
+The_right_to_rectification_26_KEY: |-
   The right to rectification
 
-You_have_the_right_to_request_that_we_correct_any_information_you_believe_is_inaccurate_or_incompleteP_103_KEY: |-
+You_have_the_right_to_request_that_we_correct_any_information_you_believe_is_inaccurate_or_incompleteP_102_KEY: |-
   You have the right to request that we correct any information you believe is inaccurate or incomplete.
 
-The_right_to_erasure_21_KEY: |-
+The_right_to_erasure_20_KEY: |-
   The right to erasure
 
-You_have_the_right_to_request_that_we_erase_your_personal_data_under_certain_conditionsP_90_KEY: |-
+You_have_the_right_to_request_that_we_erase_your_personal_data_under_certain_conditionsP_89_KEY: |-
   You have the right to request that we erase your personal data, under certain conditions.
 
-The_right_to_restrict_processing_33_KEY: |-
+The_right_to_restrict_processing_32_KEY: |-
   The right to restrict processing
 
-You_have_the_right_to_request_that_we_restrict_the_processing_of_your_personal_data_under_certain_conditionsP_111_KEY: |-
+You_have_the_right_to_request_that_we_restrict_the_processing_of_your_personal_data_under_certain_conditionsP_110_KEY: |-
   You have the right to request that we restrict the processing of your personal data, under certain conditions.
 
-The_right_to_object_to_processing_34_KEY: |-
+The_right_to_object_to_processing_33_KEY: |-
   The right to object to processing
 
-You_have_the_right_to_object_to_our_processing_of_your_personal_data_under_certain_conditionsP_96_KEY: |-
+You_have_the_right_to_object_to_our_processing_of_your_personal_data_under_certain_conditionsP_95_KEY: |-
   You have the right to object to our processing of your personal data, under certain conditions.
 
-The_right_to_data_portability_30_KEY: |-
+The_right_to_data_portability_29_KEY: |-
   The right to data portability
 
-You_have_the_right_to_request_that_we_transfer_the_data_that_we_have_collected_to_another_organization_or_directly_to_you_under_certain_conditionsP_150_KEY: |-
+You_have_the_right_to_request_that_we_transfer_the_data_that_we_have_collected_to_another_organization_or_directly_to_you_under_certain_conditionsP_149_KEY: |-
   You have the right to request that we transfer the data that we have collected to another organization, or directly to you, under certain conditions.
 
-How_can_I_contact_the__sitePname__team_about_privacyQ_58_KEY: |-
+How_can_I_contact_the__sitePname__team_about_privacyQ_57_KEY: |-
   How can I contact the {{ site.name }} team about privacy?
 
-The__sitePname__team_generally_does_not_have_access_to_personal_data_outside_of_limited_access_granted_via_some_moderation_panelsP_Inquiries_regard_269_KEY: |-
+The__sitePname__team_generally_does_not_have_access_to_personal_data_outside_of_limited_access_granted_via_some_moderation_panelsP_Inquiries_regard_268_KEY: |-
   The {{ site.name }} team generally does not have access to personal data outside of limited access granted via some moderation panels. Inquiries regarding your personal information should be sent directly to the data controller for these services, Aragon Ventures LLC:
 
-or_write_to_12_KEY: |-
+or_write_to_11_KEY: |-
   or write to
 
-For_all_other_inquiries_you_can_contact_the_team_via_methods_described_on_our_contact_page_sitePproduction_url_contactP_131_KEY: |-
+For_all_other_inquiries_you_can_contact_the_team_via_methods_described_on_our_contact_page_sitePproduction_url_contactP_130_KEY: |-
   For all other inquiries, you can contact the team via methods described on our [contact page]({{ site.production_url }}/contact/).
 
-For_complaints_under_GDPR_more_generally_European_Union_users_may_lodge_complaints_with_their_local_data_protection_supervisory_authoritiesP_142_KEY: |-
+For_complaints_under_GDPR_more_generally_European_Union_users_may_lodge_complaints_with_their_local_data_protection_supervisory_authoritiesP_141_KEY: |-
   For complaints under GDPR more generally, European Union users may lodge complaints with their local data protection supervisory authorities.
 
-How_can_I_find_out_about_changes_to_this_documentQ_51_KEY: |-
+How_can_I_find_out_about_changes_to_this_documentQ_50_KEY: |-
   How can I find out about changes to this document?
 
-This_version_of_our_privacy_statement_took_effect_October_9th_2019P_69_KEY: |-
+This_version_of_our_privacy_statement_took_effect_October_9th_2019P_68_KEY: |-
   This version of our privacy statement took effect October 9th, 2019.
 
-We_will_post_any_new_versions_of_this_statement_at__sitePproduction_url_privacy_sitePproduction_url_privacyP_We_may_change_how_we_annou_432_KEY: |-
+We_will_post_any_new_versions_of_this_statement_at__sitePproduction_url_privacy_sitePproduction_url_privacyP_We_may_change_how_we_annou_431_KEY: |-
   We will post any new versions of this statement at [{{ site.production_url }}/privacy/]({{ site.production_url }}/privacy/). We may change how we announce changes in future versions of this document. In the meantime we may update our contact information at any time without announcing a change. Please refer to [{{ site.production_url }}/privacy/]({{ site.production_url }}/privacy/) for the latest contact information at any time.
 
-A_full_revision_historyhttpsgithubPcomprivacytoolsIOprivacytoolsPiocommitsmasterpagesprivacyPmd_for_this_page_can_be_found_on_GitHubP_147_KEY: |-
+A_full_revision_historyhttpsgithubPcomprivacytoolsIOprivacytoolsPiocommitsmasterpagesprivacyPmd_for_this_page_can_be_found_on_GitHubP_146_KEY: |-
   A full [revision history](https://github.com/privacytoolsIO/privacytools.io/commits/master/pages/privacy.md) for this page can be found on GitHub.
-
-Services_8_KEY: |-
-  Services
 
 Click_on_whatever_service_you_need_to_view_our_recommendationsP_63_KEY: |-
   Click on whatever service you need to view our recommendations.
 
-DNS_3_KEY: |-
-  DNS
-
-Email_5_KEY: |-
-  Email
-
-Hosting_7_KEY: |-
-  Hosting
-
-Pastebins_9_KEY: |-
-  Pastebins
-
-Social_News_Aggregators_23_KEY: |-
-  Social News Aggregators
-
-VPN_3_KEY: |-
-  VPN
-
-We_currently_have_the_following_freetouse_services_online_nowP_65_KEY: |-
+We_currently_have_the_following_freetouse_services_online_nowP_64_KEY: |-
   We currently have the following free-to-use services online now.
 
-Searx__Privacy_Friendly_Search_at_searchPprivacytoolsPio_58_KEY: |-
+Searx__Privacy_Friendly_Search_at_searchPprivacytoolsPio_57_KEY: |-
   Searx - Privacy Friendly Search at search.privacytools.io
 
-Mastodon__Tracker_Free_Social_Networking_at_socialPprivacytoolsPio_68_KEY: |-
+Mastodon__Tracker_Free_Social_Networking_at_socialPprivacytoolsPio_67_KEY: |-
   Mastodon - Tracker Free Social Networking at social.privacytools.io
 
-Matrix__Federated_private_chat_at_chatPprivacytoolsPio_56_KEY: |-
+Matrix__Federated_private_chat_at_chatPprivacytoolsPio_55_KEY: |-
   Matrix - Federated private chat at chat.privacytools.io
 
-Discourse__Forum_at_forumPprivacytoolsPio_43_KEY: |-
+Discourse__Forum_at_forumPprivacytoolsPio_42_KEY: |-
   Discourse - Forum at forum.privacytools.io
 
-Gitea__GitRepository_Manager_at_gitPprivacytoolsPio_54_KEY: |-
+Gitea__GitRepository_Manager_at_gitPprivacytoolsPio_53_KEY: |-
   Gitea - Git-Repository Manager at git.privacytools.io
 
-Write_Freely__Federated_minimalist_blog_at_writePprivacytoolsPio_66_KEY: |-
+Write_Freely__Federated_minimalist_blog_at_writePprivacytoolsPio_65_KEY: |-
   Write Freely - Federated minimalist blog at write.privacytools.io
 
-PrivateBin__Encrypted_Pastebin_at_binPprivacytoolsPio_55_KEY: |-
+PrivateBin__Encrypted_Pastebin_at_binPprivacytoolsPio_54_KEY: |-
   PrivateBin - Encrypted Pastebin at bin.privacytools.io
 
 More_services_are_on_the_wayP_If_theres_something_that_would_be_super_beneficial_for_us_to_run_dont_hesitate_to_reach_out_and_askP_And_of_course_if_305_KEY: |-
   More services are on the way. If there's something that would be super beneficial for us to run, don't hesitate to reach out and ask. And of course, if you like our services, please consider <a href="{{ "/donate/" | translate_page }}">donating to support our server costs</a>, <em>any donation helps!</em>
 
-Sponsors_of__sitePname__28_KEY: |-
+Sponsors_of__sitePname__27_KEY: |-
   Sponsors of {{ site.name }}
 
-The__sitePname__website_and_services_are_a_community_projectP_There_is_no_advertising_affiliate_links_or_other_forms_of_monetizationPbrstrong_265_KEY: |-
+The__sitePname__website_and_services_are_a_community_projectP_There_is_no_advertising_affiliate_links_or_other_forms_of_monetizationPbrstrong_264_KEY: |-
   The {{ site.name }} website and services are a community project. There is no advertising, affiliate links, or other forms of monetization.<br><strong>Your donations here directly support hosting this website and compensating contributors to this project.</strong>
 
-Become_a_Sponsor_17_KEY: |-
+Become_a_Sponsor_16_KEY: |-
   Become a Sponsor
 
-Donate_Directly_16_KEY: |-
+Donate_Directly_15_KEY: |-
   Donate Directly
 
-Why_sponsor__sitePname_Q_29_KEY: |-
+Why_sponsor__sitePname_Q_28_KEY: |-
   Why sponsor {{ site.name }}?
 
-This_sponsorship_program_is_designed_to_allow_companies_organizations_and_individuals_partner_with_the__sitePname__team_to_support_our_vision_of__220_KEY: |-
+This_sponsorship_program_is_designed_to_allow_companies_organizations_and_individuals_partner_with_the__sitePname__team_to_support_our_vision_of__219_KEY: |-
   This sponsorship program is designed to allow companies, organizations, and individuals partner with the {{ site.name }} team to support our vision of a more privacy-respecting internet and the greater online community.
 
-With_this_exposure_and_sponsorship_your_customers_will_recognize_your_intrinsic_understanding_and_commitment_to_user_privacyP_Moreover_youll_directl_242_KEY: |-
+With_this_exposure_and_sponsorship_your_customers_will_recognize_your_intrinsic_understanding_and_commitment_to_user_privacyP_Moreover_youll_directl_241_KEY: |-
   With this exposure and sponsorship, your customers will recognize your intrinsic understanding and commitment to user privacy. Moreover, you'll directly contribute to our mission of spreading privacy-respecting tools and knowledge worldwide!
 
-As_a_sponsor_of__sitePname__your_company_will_be_widely_recognized_in_a_variety_of_ways_some_of_which_weve_detailed_belowP_130_KEY: |-
+As_a_sponsor_of__sitePname__your_company_will_be_widely_recognized_in_a_variety_of_ways_some_of_which_weve_detailed_belowP_129_KEY: |-
   As a sponsor of {{ site.name }}, your company will be widely recognized in a variety of ways, some of which we've detailed below.
 
-General_Information_20_KEY: |-
+General_Information_19_KEY: |-
   General Information
 
-This_website_receives_well_over_250000_pageviews_on_a_monthly_basis_and_is_highly_ranked_for_privacyrelated_keywordsP_In_addition_to_the_benefits_bel_278_KEY: |-
+This_website_receives_well_over_250000_pageviews_on_a_monthly_basis_and_is_highly_ranked_for_privacyrelated_keywordsP_In_addition_to_the_benefits_bel_277_KEY: |-
   This website receives well over 250,000 pageviews on a monthly basis and is highly ranked for privacy-related keywords. In addition to the benefits below your contribution will be featured on our OpenCollective page and we will thank you via social media for your contribution.
 
-Bronze_Sponsorship_19_KEY: |-
+Bronze_Sponsorship_18_KEY: |-
   Bronze Sponsorship
 
-Info_5_KEY: |-
+Info_4_KEY: |-
   Info
 
-Your_name_and_link_along_with_a_small_logo_or_avatar_on_the_sponsors_page_of_this_websiteP_91_KEY: |-
+Your_name_and_link_along_with_a_small_logo_or_avatar_on_the_sponsors_page_of_this_websiteP_90_KEY: |-
   Your name and link along with a small logo or avatar on the sponsors page of this website.
 
-Silver_Sponsorship_19_KEY: |-
+Silver_Sponsorship_18_KEY: |-
   Silver Sponsorship
 
-Your_mediumsized_logo_as_a_link_at_the_top_of_our_sponsors_pageP_66_KEY: |-
+Your_mediumsized_logo_as_a_link_at_the_top_of_our_sponsors_pageP_65_KEY: |-
   Your medium-sized logo as a link at the top of our sponsors page.
 
-Gold_Sponsorship_17_KEY: |-
+Gold_Sponsorship_16_KEY: |-
   Gold Sponsorship
 
-Your_mediumsized_logo_as_a_link_on_the__sitePname__homepage_and_at_the_very_top_of_our_sponsors_pageP_107_KEY: |-
+Your_mediumsized_logo_as_a_link_on_the__sitePname__homepage_and_at_the_very_top_of_our_sponsors_pageP_106_KEY: |-
   Your medium-sized logo as a link on the {{ site.name }} homepage and at the very top of our sponsors page.
 
-We_will_not_providePPP_23_KEY: |-
+We_will_not_providePPP_22_KEY: |-
   We will not provide...
 
-We_pride_ourselves_on_our_integrity_and_commitment_to_spreading_unbiased_and_factbased_information_regarding_privacy_and_privacyrespecting_toolsP_All_605_KEY: |-
+We_pride_ourselves_on_our_integrity_and_commitment_to_spreading_unbiased_and_factbased_information_regarding_privacy_and_privacyrespecting_toolsP_All_604_KEY: |-
   We pride ourselves on our integrity and commitment to spreading unbiased and fact-based information regarding privacy and privacy-respecting tools. All tools we recommend throughout our website are subject to strict criteria as judged by our team and the community across our various platforms. Your sponsorship will not grant your organization any special consideration when choosing our recommendations throughout the website, a process which we make clear via our transparent ledger on OpenCollective and our public discussions on GitHub. Your sponsorship benefits are limited to those outlined above.
 
-Tax_and_Financial_Information_30_KEY: |-
+Tax_and_Financial_Information_29_KEY: |-
   Tax and Financial Information
 
-Your_contribution_to__sitePname__will_be_handled_by_the_Open_Collective_Foundation_501c3P_For_US_companies_and_taxpayers_this_means_your_contr_569_KEY: |-
+Your_contribution_to__sitePname__will_be_handled_by_the_Open_Collective_Foundation_501c3P_For_US_companies_and_taxpayers_this_means_your_contr_568_KEY: |-
   Your contribution to {{ site.name }} will be handled by the Open Collective Foundation 501(c)(3). For US companies and taxpayers, this means your contribution is <strong>tax deductible</strong>. As a non-profit, your sponsorship contribution will not be used for private profit and will only be used to cover expenses incurred by the project. All of our transactions (donations and expenses) are published transparently on OpenCollective. For the benefit of our readership, anonymous contributions will not be eligible for the sponsorship opportunities outlined above.
 
-More_Information_17_KEY: |-
+More_Information_16_KEY: |-
   More Information
 
-If_you_are_interested_and_have_further_questions_you_are_welcome_to_reach_out_to_us_directly_at_a_hrefmailtosponsorsprivacytoolsPiosponsorspri_169_KEY: |-
+If_you_are_interested_and_have_further_questions_you_are_welcome_to_reach_out_to_us_directly_at_a_hrefmailtosponsorsprivacytoolsPiosponsorspri_168_KEY: |-
   If you are interested and have further questions, you are welcome to reach out to us directly at <a href="mailto:sponsors@privacytools.io">sponsors@privacytools.io</a>.
 
-Using_a_VPN_will_strongnotstrong_keep_your_browsing_habits_anonymous_nor_will_it_add_additional_security_to_nonsecure_HTTP_trafficP_141_KEY: |-
+Using_a_VPN_will_strongnotstrong_keep_your_browsing_habits_anonymous_nor_will_it_add_additional_security_to_nonsecure_HTTP_trafficP_140_KEY: |-
   Using a VPN will <strong>not</strong> keep your browsing habits anonymous, nor will it add additional security to non-secure (HTTP) traffic.
 
-If_you_are_looking_for_stronganonymitystrong_you_should_use_the_Tor_Browser_stronginsteadstrong_of_a_VPNP_117_KEY: |-
+If_you_are_looking_for_stronganonymitystrong_you_should_use_the_Tor_Browser_stronginsteadstrong_of_a_VPNP_116_KEY: |-
   If you are looking for <strong>anonymity</strong>, you should use the Tor Browser <strong>instead</strong> of a VPN.
 
-If_youre_looking_for_added_strongsecuritystrong_you_should_always_ensure_youre_connecting_to_websites_using_a_href_providersdnsicanndn_308_KEY: |-
+If_youre_looking_for_added_strongsecuritystrong_you_should_always_ensure_youre_connecting_to_websites_using_a_href_providersdnsicanndn_307_KEY: |-
   If you're looking for added <strong>security</strong>, you should always ensure you're connecting to websites using <a href="{{ /providers/dns/#icanndns | translate_page}}">encrypted DNS</a> and <a href="https://en.wikipedia.org/wiki/HTTPS">HTTPS</a>. A VPN is not a replacement for good security practices.
 
-If_youre_looking_for_additional_strongprivacystrong_from_your_ISP_on_a_public_WiFi_network_or_while_torrenting_files_a_VPN_may_be_the_solutio_227_KEY: |-
+If_youre_looking_for_additional_strongprivacystrong_from_your_ISP_on_a_public_WiFi_network_or_while_torrenting_files_a_VPN_may_be_the_solutio_226_KEY: |-
   If you're looking for additional <strong>privacy</strong> from your ISP, on a public Wi-Fi network, or while torrenting files, a VPN may be the solution for you as long as you understand <a href="#info">the risks involved</a>.
 
-httpswwwPtorprojectPorg_28_KEY: |-
-  https://www.torproject.org/
-
-Download_Tor_13_KEY: |-
+Download_Tor_12_KEY: |-
   Download Tor
 
-Tor_Myths_10_KEY: |-
+Tor_Myths_9_KEY: |-
   Tor Myths
 
-FAQ_4_KEY: |-
+FAQ_3_KEY: |-
   FAQ
 
-Our_VPN_Provider_Criteria_26_KEY: |-
+Our_VPN_Provider_Criteria_25_KEY: |-
   Our VPN Provider Criteria
 
-Please_note_we_are_not_affiliated_with_any_of_the_providers_we_recommendP_This_allows_us_to_provide_completely_objective_recommendationsP_138_KEY: |-
+Please_note_we_are_not_affiliated_with_any_of_the_providers_we_recommendP_This_allows_us_to_provide_completely_objective_recommendationsP_137_KEY: |-
   Please note we are not affiliated with any of the providers we recommend. This allows us to provide completely objective recommendations.
 
-We_have_developed_a_clear_set_of_requirements_for_any_VPN_provider_wishing_to_be_recommended_including_strong_encryption_independent_security_audits_363_KEY: |-
+We_have_developed_a_clear_set_of_requirements_for_any_VPN_provider_wishing_to_be_recommended_including_strong_encryption_independent_security_audits_362_KEY: |-
   We have developed a clear set of requirements for any VPN provider wishing to be recommended, including strong encryption, independent security audits, modern technology, and more. We suggest you familiarize yourself with this list before choosing a VPN provider, and conduct your own research to ensure the VPN provider you choose is as trustworthy as possible.
 
-Operating_outside_the_fiveninefourteeneyes_countries_is_not_a_guarantee_of_privacy_necessarily_and_there_are_other_factors_to_considerP_However_we_474_KEY: |-
+Operating_outside_the_fiveninefourteeneyes_countries_is_not_a_guarantee_of_privacy_necessarily_and_there_are_other_factors_to_considerP_However_we_473_KEY: |-
   Operating outside the five/nine/fourteen-eyes countries is not a guarantee of privacy necessarily, and there are other factors to consider. However, we believe that avoiding these countries is important if you wish to avoid mass government dragnet surveillance, especially from the United States. Read our page on <a href="{{ '/providers/#ukusa' | translate_page }}">global mass surveillance and avoiding the US and UK</a> to learn more about why we feel this is important.
 
-Minimum_to_Qualify_20_KEY: |-
+Minimum_to_Qualify_19_KEY: |-
   Minimum to Qualify:
 
-Operating_outside_the_USA_or_other_Five_Eyes_countriesP_56_KEY: |-
+Operating_outside_the_USA_or_other_Five_Eyes_countriesP_55_KEY: |-
   Operating outside the USA or other Five Eyes countries.
 
-Best_Case_11_KEY: |-
+Best_Case_10_KEY: |-
   Best Case:
 
-Operating_outside_the_USA_or_other_Fourteen_Eyes_countriesP_60_KEY: |-
+Operating_outside_the_USA_or_other_Fourteen_Eyes_countriesP_59_KEY: |-
   Operating outside the USA or other Fourteen Eyes countries.
 
-Operating_inside_a_country_with_strong_consumer_protection_lawsP_65_KEY: |-
+Operating_inside_a_country_with_strong_consumer_protection_lawsP_64_KEY: |-
   Operating inside a country with strong consumer protection laws.
 
-Technology_11_KEY: |-
+Technology_10_KEY: |-
   Technology
 
-We_require_all_our_recommended_VPN_providers_to_provide_OpenVPN_configuration_files_to_be_used_in_any_clientP_strongIfstrong_a_VPN_provides_their__241_KEY: |-
+We_require_all_our_recommended_VPN_providers_to_provide_OpenVPN_configuration_files_to_be_used_in_any_clientP_strongIfstrong_a_VPN_provides_their__240_KEY: |-
   We require all our recommended VPN providers to provide OpenVPN configuration files to be used in any client. <strong>If</strong> a VPN provides their own custom client, we require a killswitch to block network data leaks when disconnected.
 
-OpenVPN_supportP_17_KEY: |-
+OpenVPN_supportP_16_KEY: |-
   OpenVPN support.
 
-Killswitch_built_in_to_clientsP_32_KEY: |-
+Killswitch_built_in_to_clientsP_31_KEY: |-
   Killswitch built in to clients.
 
-OpenVPN_and_WireGuard_supportP_31_KEY: |-
+OpenVPN_and_WireGuard_supportP_30_KEY: |-
   OpenVPN and WireGuard support.
 
-Killswitch_with_highly_configurable_options_enabledisable_on_certain_networks_on_boot_etcP_96_KEY: |-
+Killswitch_with_highly_configurable_options_enabledisable_on_certain_networks_on_boot_etcP_95_KEY: |-
   Killswitch with highly configurable options (enable/disable on certain networks, on boot, etc.)
 
-Easytouse_mobile_clients_especially_opensourceP_52_KEY: |-
+Easytouse_mobile_clients_especially_opensourceP_51_KEY: |-
   Easy-to-use mobile clients, especially open-source.
 
-Privacy_8_KEY: |-
+Privacy_7_KEY: |-
   Privacy
 
-We_prefer_our_recommended_providers_to_collect_as_little_data_as_possibleP_Not_collecting_personal_information_on_registration_and_accepting_anonymous_183_KEY: |-
+We_prefer_our_recommended_providers_to_collect_as_little_data_as_possibleP_Not_collecting_personal_information_on_registration_and_accepting_anonymous_182_KEY: |-
   We prefer our recommended providers to collect as little data as possible. Not collecting personal information on registration, and accepting anonymous forms of payment are required.
 
-Bitcoin_or_cash_payment_optionP_32_KEY: |-
+Bitcoin_or_cash_payment_optionP_31_KEY: |-
   Bitcoin or cash payment option.
 
-No_personal_information_required_to_register_Only_username_password_and_email_at_mostP_90_KEY: |-
+No_personal_information_required_to_register_Only_username_password_and_email_at_mostP_89_KEY: |-
   No personal information required to register: Only username, password, and email at most.
 
-Accepts_Bitcoin_cash_and_other_forms_of_cryptocurrency_andor_anonymous_payment_options_gift_cards_etcP_109_KEY: |-
+Accepts_Bitcoin_cash_and_other_forms_of_cryptocurrency_andor_anonymous_payment_options_gift_cards_etcP_108_KEY: |-
   Accepts Bitcoin, cash, and other forms of cryptocurrency and/or anonymous payment options (gift cards, etc.)
 
-No_personal_information_accepted_autogenerated_username_no_email_required_etcP_83_KEY: |-
+No_personal_information_accepted_autogenerated_username_no_email_required_etcP_82_KEY: |-
   No personal information accepted (autogenerated username, no email required, etc.)
 
-Security_9_KEY: |-
+Security_8_KEY: |-
   Security
 
-A_VPN_is_pointless_if_it_cant_even_provide_adequate_securityP_We_require_all_our_recommended_providers_to_abide_by_current_security_standards_for_thei_397_KEY: |-
+A_VPN_is_pointless_if_it_cant_even_provide_adequate_securityP_We_require_all_our_recommended_providers_to_abide_by_current_security_standards_for_thei_396_KEY: |-
   A VPN is pointless if it can't even provide adequate security. We require all our recommended providers to abide by current security standards for their OpenVPN connections. Ideally, they would use more future-proof encryption schemes by default. We also require an independent third-party to audit the provider's security, ideally in a very comprehensive manner and on a repeated (yearly) basis.
 
-Strong_Encryption_Schemes_OpenVPN_with_SHA256_authentication_RSA2048_or_better_handshake_AES256GCM_or_AES256CBC_data_encryptionP_138_KEY: |-
+Strong_Encryption_Schemes_OpenVPN_with_SHA256_authentication_RSA2048_or_better_handshake_AES256GCM_or_AES256CBC_data_encryptionP_137_KEY: |-
   Strong Encryption Schemes: OpenVPN with SHA-256 authentication; RSA-2048 or better handshake; AES-256-GCM or AES-256-CBC data encryption.
 
-Perfect_Forward_Secrecy_PFSP_31_KEY: |-
+Perfect_Forward_Secrecy_PFSP_30_KEY: |-
   Perfect Forward Secrecy (PFS).
 
-Published_security_audits_from_a_reputable_thirdparty_firmP_61_KEY: |-
+Published_security_audits_from_a_reputable_thirdparty_firmP_60_KEY: |-
   Published security audits from a reputable third-party firm.
 
-Strongest_Encryption_RSA4096P_32_KEY: |-
+Strongest_Encryption_RSA4096P_31_KEY: |-
   Strongest Encryption: RSA-4096.
 
-Comprehensive_published_security_audits_from_a_reputable_thirdparty_firmP_75_KEY: |-
+Comprehensive_published_security_audits_from_a_reputable_thirdparty_firmP_74_KEY: |-
   Comprehensive published security audits from a reputable third-party firm.
 
-Bugbounty_programs_andor_a_coordinated_vulnerabilitydisclosure_processP_75_KEY: |-
+Bugbounty_programs_andor_a_coordinated_vulnerabilitydisclosure_processP_74_KEY: |-
   Bug-bounty programs and/or a coordinated vulnerability-disclosure process.
 
-Trust_6_KEY: |-
+Trust_5_KEY: |-
   Trust
 
-You_wouldnt_trust_your_finances_to_someone_with_a_fake_identity_so_why_trust_them_with_your_internet_dataQ_We_require_our_recommended_providers_to_be_314_KEY: |-
+You_wouldnt_trust_your_finances_to_someone_with_a_fake_identity_so_why_trust_them_with_your_internet_dataQ_We_require_our_recommended_providers_to_be_313_KEY: |-
   You wouldn't trust your finances to someone with a fake identity, so why trust them with your internet data? We require our recommended providers to be public about their ownership or leadership. We also would like to see frequent transparency reports, especially in regard to how government requests are handled.
 
-Publicfacing_leadership_or_ownershipP_39_KEY: |-
+Publicfacing_leadership_or_ownershipP_38_KEY: |-
   Public-facing leadership or ownership.
 
-Publicfacing_leadershipP_26_KEY: |-
+Publicfacing_leadershipP_25_KEY: |-
   Public-facing leadership.
 
-Frequent_transparency_reportsP_31_KEY: |-
+Frequent_transparency_reportsP_30_KEY: |-
   Frequent transparency reports.
 
-Additional_Functionality_25_KEY: |-
+Additional_Functionality_24_KEY: |-
   Additional Functionality
 
-While_not_strictly_requirements_there_are_some_factors_we_looked_into_when_determining_which_providers_to_recommendP_These_include_adblockingtracker_296_KEY: |-
+While_not_strictly_requirements_there_are_some_factors_we_looked_into_when_determining_which_providers_to_recommendP_These_include_adblockingtracker_295_KEY: |-
   While not strictly requirements, there are some factors we looked into when determining which providers to recommend. These include adblocking/tracker-blocking functionality, warrant canaries, multihop connections, excellent customer support, the number of allowed simultaneous connections, etc.
 
-Further_Information_and_Dangers_32_KEY: |-
+Further_Information_and_Dangers_31_KEY: |-
   Further Information and Dangers
 
-Should_I_use_a_VPNQ_20_KEY: |-
+Should_I_use_a_VPNQ_19_KEY: |-
   Should I use a VPN?
 
-The_answer_to_this_question_is_not_a_particularly_helpful_one_strongIt_dependsPstrong_It_depends_on_what_youre_expecting_a_VPN_to_do_for_you_wh_230_KEY: |-
+The_answer_to_this_question_is_not_a_particularly_helpful_one_strongIt_dependsPstrong_It_depends_on_what_youre_expecting_a_VPN_to_do_for_you_wh_229_KEY: |-
   The answer to this question is not a particularly helpful one: <strong>It depends.</strong> It depends on what you're expecting a VPN to do for you, who you're trying to hide your traffic from, and what applications you're using.
 
-strongIn_most_cases_VPNs_do_little_to_protect_your_privacy_or_enhance_your_securitystrong_unless_paired_with_other_changesP_131_KEY: |-
+strongIn_most_cases_VPNs_do_little_to_protect_your_privacy_or_enhance_your_securitystrong_unless_paired_with_other_changesP_130_KEY: |-
   <strong>In most cases, VPNs do little to protect your privacy or enhance your security</strong>, unless paired with other changes.
 
-VPNs_cannot_encrypt_data_outside_of_the_connection_between_your_device_and_the_VPN_serverP_VPN_providers_can_see_and_modify_your_traffic_the_same_way_y_247_KEY: |-
+VPNs_cannot_encrypt_data_outside_of_the_connection_between_your_device_and_the_VPN_serverP_VPN_providers_can_see_and_modify_your_traffic_the_same_way_y_246_KEY: |-
   VPNs cannot encrypt data outside of the connection between your device and the VPN server. VPN providers can see and modify your traffic the same way your ISP could. And there is no way to verify a VPN provider's "no logging" policies in any way.
 
-What_if_I_need_encryptionQ_27_KEY: |-
+What_if_I_need_encryptionQ_26_KEY: |-
   What if I need encryption?
 
-In_most_cases_most_of_your_traffic_is_already_encryptedE_Over_98_of_the_top_3000_websites_offer_strongHTTPSstrong_meaning_your_nonDNS_traffic__383_KEY: |-
+In_most_cases_most_of_your_traffic_is_already_encryptedE_Over_98_of_the_top_3000_websites_offer_strongHTTPSstrong_meaning_your_nonDNS_traffic__382_KEY: |-
   In most cases, most of your traffic is already encrypted! Over 98% of the top 3000 websites offer <strong>HTTPS</strong>, meaning your non-DNS traffic is safe regardless of using a VPN. It is incredibly rare for applications that handle personal data to not support HTTPS in 2019, especially with services like Let's Encrypt offering free HTTPS certificates to any website operator.
 
-Even_if_a_site_you_visit_doesnt_support_HTTPS_a_VPN_will_not_protect_you_because_a_VPN_cannot_magically_encrypt_the_traffic_between_the_VPNs_server_363_KEY: |-
+Even_if_a_site_you_visit_doesnt_support_HTTPS_a_VPN_will_not_protect_you_because_a_VPN_cannot_magically_encrypt_the_traffic_between_the_VPNs_server_362_KEY: |-
   Even if a site you visit doesn't support HTTPS, a VPN will not protect you, because a VPN cannot magically encrypt the traffic between the VPN's servers and the website's servers. Installing an extension like <a href="https://www.eff.org/https-everywhere">HTTPS Everywhere</a> and making sure every site you visit uses HTTPS is far more helpful than using a VPN.
 
-Should_I_use_encrypted_DNS_with_a_VPNQ_39_KEY: |-
+Should_I_use_encrypted_DNS_with_a_VPNQ_38_KEY: |-
   Should I use encrypted DNS with a VPN?
 
-The_answer_to_this_question_is_also_not_very_helpful_strongit_dependsstrongP_Your_VPN_provider_may_have_their_own_DNS_servers_but_if_they_dont_584_KEY: |-
+The_answer_to_this_question_is_also_not_very_helpful_strongit_dependsstrongP_Your_VPN_provider_may_have_their_own_DNS_servers_but_if_they_dont_583_KEY: |-
   The answer to this question is also not very helpful: <strong>it depends</strong>. Your VPN provider may have their own DNS servers, but if they don't, the traffic between your VPN provider and the DNS server isn't encrypted. You need to trust the <a href="{{ '/providers/dns/#icanndns' | translate_page }}">encrypted DNS provider</a> in addition to the VPN provider and unless your client and target server support <a href="https://www.eff.org/deeplinks/2018/09/esni-privacy-protecting-upgrade-https">encrypted SNI</a>, the VPN provider can still see which domains you are visiting.
 
-However_strongyou_shouldnt_use_encrypted_DNS_with_TorstrongP_This_would_direct_all_of_your_DNS_requests_through_a_single_circuit_and_would_allow_199_KEY: |-
+However_strongyou_shouldnt_use_encrypted_DNS_with_TorstrongP_This_would_direct_all_of_your_DNS_requests_through_a_single_circuit_and_would_allow_198_KEY: |-
   However <strong>you shouldn't use encrypted DNS with Tor</strong>. This would direct all of your DNS requests through a single circuit, and would allow the encrypted DNS provider to deanonymize you.
 
-What_if_I_need_anonymityQ_26_KEY: |-
+What_if_I_need_anonymityQ_25_KEY: |-
   What if I need anonymity?
 
-VPNs_cannot_provide_strong_anonymityP_Your_VPN_provider_will_still_see_your_real_IP_address_and_often_has_a_money_trail_that_can_be_linked_directly_ba_225_KEY: |-
+VPNs_cannot_provide_strong_anonymityP_Your_VPN_provider_will_still_see_your_real_IP_address_and_often_has_a_money_trail_that_can_be_linked_directly_ba_224_KEY: |-
   VPNs cannot provide strong anonymity. Your VPN provider will still see your real IP address, and often has a money trail that can be linked directly back to you. You cannot rely on "no logging" policies to protect your data.
 
-Shouldnt_I_hide_my_IP_addressQ_32_KEY: |-
+Shouldnt_I_hide_my_IP_addressQ_31_KEY: |-
   Shouldn't I hide my IP address?
 
-The_idea_that_your_IP_address_is_sensitive_information_or_that_your_location_is_given_away_with_all_your_internet_traffic_is_strongfearmongeringst_628_KEY: |-
+The_idea_that_your_IP_address_is_sensitive_information_or_that_your_location_is_given_away_with_all_your_internet_traffic_is_strongfearmongeringst_627_KEY: |-
   The idea that your IP address is sensitive information, or that your location is given away with all your internet traffic is <strong>fearmongering</strong> on the part of VPN providers and their marketing. Your IP address is an insignificant amount of personal data tracking companies use to identify you, because many users' IP addresses change very frequently (Dynamic IP addresses, switching networks, switching devices, etc.). Your IP address also does not give away more than the very generalized location of your Internet Service Provider. It does not give away your home address, for example, despite common perception.
 
-Should_I_use_Tor_emandem_a_VPNQ_37_KEY: |-
+Should_I_use_Tor_emandem_a_VPNQ_36_KEY: |-
   Should I use Tor <em>and</em> a VPN?
 
-By_using_a_VPN_with_Tor_youre_creating_essentially_a_permanent_entry_node_often_with_a_money_trail_attachedP_This_provides_0_additional_benefit_to_y_531_KEY: |-
+By_using_a_VPN_with_Tor_youre_creating_essentially_a_permanent_entry_node_often_with_a_money_trail_attachedP_This_provides_0_additional_benefit_to_y_530_KEY: |-
   By using a VPN with Tor, you're creating essentially a permanent entry node, often with a money trail attached. This provides 0 additional benefit to you, while increasing the attack surface of your connection dramatically. If you wish to hide your Tor usage from your ISP or your government, Tor has a built-in solution for that: Tor bridges. <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-2-onion-recipes-vpn-not-required">Read more about Tor bridges and why using a VPN is not necessary</a>.
 
-Are_VPNs_ever_usefulQ_22_KEY: |-
+Are_VPNs_ever_usefulQ_21_KEY: |-
   Are VPNs ever useful?
 
-A_VPN_may_still_be_useful_to_you_in_a_variety_of_scenarios_such_as_69_KEY: |-
+A_VPN_may_still_be_useful_to_you_in_a_variety_of_scenarios_such_as_68_KEY: |-
   A VPN may still be useful to you in a variety of scenarios, such as:
 
-Hiding_your_traffic_from_strongonlystrong_your_Internet_Service_ProviderP_79_KEY: |-
+Hiding_your_traffic_from_strongonlystrong_your_Internet_Service_ProviderP_78_KEY: |-
   Hiding your traffic from <strong>only</strong> your Internet Service Provider.
 
-Hiding_your_downloads_such_as_torrents_from_your_ISP_and_antipiracy_organizationsP_86_KEY: |-
+Hiding_your_downloads_such_as_torrents_from_your_ISP_and_antipiracy_organizationsP_85_KEY: |-
   Hiding your downloads (such as torrents) from your ISP and anti-piracy organizations.
 
-For_use_cases_like_these_or_if_you_have_another_compelling_reason_the_VPN_providers_we_listed_above_are_who_we_think_are_the_most_trustworthyP_Howeve_334_KEY: |-
+For_use_cases_like_these_or_if_you_have_another_compelling_reason_the_VPN_providers_we_listed_above_are_who_we_think_are_the_most_trustworthyP_Howeve_333_KEY: |-
   For use cases like these, or if you have another compelling reason, the VPN providers we listed above are who we think are the most trustworthy. However, using a VPN provider still means you're <em>trusting</em> the provider. In pretty much any other scenario you should be using a secure<strong>-by-design</strong> tool such as Tor.
 
-Sources_and_Further_Reading_28_KEY: |-
+Sources_and_Further_Reading_27_KEY: |-
   Sources and Further Reading
 
-a_href_httpsschubPioblog20190408veryprecariousnarrativePhtml_VPN__a_Very_Precarious_Narrativea_by_Dennis_Schubert_133_KEY: |-
+a_href_httpsschubPioblog20190408veryprecariousnarrativePhtml_VPN__a_Very_Precarious_Narrativea_by_Dennis_Schubert_132_KEY: |-
   <a href=" https://schub.io/blog/2019/04/08/very-precarious-narrative.html ">VPN - a Very Precarious Narrative</a> by Dennis Schubert
 
-a_hrefhttpsgistPgithubPcomjoepie915a9909939e6ce7d09e29Dont_use_VPN_servicesa_by_Sven_Slootweg_108_KEY: |-
+a_hrefhttpsgistPgithubPcomjoepie915a9909939e6ce7d09e29Dont_use_VPN_servicesa_by_Sven_Slootweg_107_KEY: |-
   <a href="https://gist.github.com/joepie91/5a9909939e6ce7d09e29">Don't use VPN services</a> by Sven Slootweg
 
-a_href_softwarenetworks__translate_page_The_selfcontained_networksa_recommended_by_PrivacyTools_are_able_to_replace_a_VPN_that_allow_194_KEY: |-
+a_href_softwarenetworks__translate_page_The_selfcontained_networksa_recommended_by_PrivacyTools_are_able_to_replace_a_VPN_that_allow_193_KEY: |-
   <a href='{{ "/software/networks/" | translate_page }}'>The self-contained networks</a> recommended by PrivacyTools are able to replace a VPN that allows access to services on local area network
 
-a_hrefhttpswritePprivacytoolsPiomythoughtsonsecurityslicingonionspart1mythbustingtorSlicing_Onions_Part_1__Mythbusting_Tora_by_166_KEY: |-
+a_hrefhttpswritePprivacytoolsPiomythoughtsonsecurityslicingonionspart1mythbustingtorSlicing_Onions_Part_1__Mythbusting_Tora_by_165_KEY: |-
   <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-1-myth-busting-tor">Slicing Onions: Part 1 – Myth-busting Tor</a> by blacklight447
 
-a_hrefhttpswritePprivacytoolsPiomythoughtsonsecurityslicingonionspart2onionrecipesvpnnotrequiredSlicing_Onions_Part_2__Onion_rec_195_KEY: |-
+a_hrefhttpswritePprivacytoolsPiomythoughtsonsecurityslicingonionspart2onionrecipesvpnnotrequiredSlicing_Onions_Part_2__Onion_rec_194_KEY: |-
   <a href="https://write.privacytools.io/my-thoughts-on-security/slicing-onions-part-2-onion-recipes-vpn-not-required">Slicing Onions: Part 2 – Onion recipes; VPN not required</a> by blacklight447
 
-More_VPN_Providers_19_KEY: |-
+More_VPN_Providers_18_KEY: |-
   More VPN Providers
 
-httpsthatoneprivacysitePnetvpncomparisonchart_53_KEY: |-
+httpsthatoneprivacysitePnetvpncomparisonchart_52_KEY: |-
   https://thatoneprivacysite.net/vpn-comparison-chart/
 
-Spreadsheet_with_unbiased_independently_verifiable_data_on_over_100_VPN_servicesP_83_KEY: |-
+Spreadsheet_with_unbiased_independently_verifiable_data_on_over_100_VPN_servicesP_82_KEY: |-
   Spreadsheet with unbiased, independently verifiable data on over 100 VPN services.
 
-httpsthewirecutterPcomreviewsbestvpnservice_52_KEY: |-
+httpsthewirecutterPcomreviewsbestvpnservice_51_KEY: |-
   https://thewirecutter.com/reviews/best-vpn-service/
 
-Indepth_research_on_53_popular_VPN_providersP_47_KEY: |-
+Indepth_research_on_53_popular_VPN_providersP_46_KEY: |-
   In-depth research on 53 popular VPN providers.
 
-Related_VPN_information_24_KEY: |-
+Related_VPN_information_23_KEY: |-
   Related VPN information
 
-httpsvikingvpnPcomblogsofftopicbewareofvpnmarketingandaffiliateprograms_85_KEY: |-
+httpsvikingvpnPcomblogsofftopicbewareofvpnmarketingandaffiliateprograms_84_KEY: |-
   https://vikingvpn.com/blogs/off-topic/beware-of-vpn-marketing-and-affiliate-programs
 
-Beware_of_False_Reviews__VPN_Marketing_and_Affiliate_Programs_63_KEY: |-
+Beware_of_False_Reviews__VPN_Marketing_and_Affiliate_Programs_62_KEY: |-
   Beware of False Reviews - VPN Marketing and Affiliate Programs
 
-httpswwwPgoldenfrogPcomtakebackyourinternetarticles7mythsaboutvpnloggingandanonymity_100_KEY: |-
+httpswwwPgoldenfrogPcomtakebackyourinternetarticles7mythsaboutvpnloggingandanonymity_99_KEY: |-
   https://www.goldenfrog.com/take-back-your-internet/articles/7-myths-about-vpn-logging-and-anonymity
 
-I_am_Anonymous_When_I_Use_a_VPN__7_Myths_Debunked_51_KEY: |-
+I_am_Anonymous_When_I_Use_a_VPN__7_Myths_Debunked_50_KEY: |-
   I am Anonymous When I Use a VPN - 7 Myths Debunked
 
-Note_6_KEY: |-
+Note_5_KEY: |-
   Note:
 
-While_this_is_a_good_read_they_also_use_the_article_for_selfpromotion_72_KEY: |-
+While_this_is_a_good_read_they_also_use_the_article_for_selfpromotion_71_KEY: |-
   While this is a good read, they also use the article for self-promotion
 
-httpstorrentfreakPcomproxyshvpnprovidermonitoredtraffictocatchhacker130930_89_KEY: |-
+httpstorrentfreakPcomproxyshvpnprovidermonitoredtraffictocatchhacker130930_88_KEY: |-
   https://torrentfreak.com/proxy-sh-vpn-provider-monitored-traffic-to-catch-hacker-130930/
 
-ProxyPsh_VPN_Provider_Sniffed_Server_Traffic_to_Catch_Hacker_61_KEY: |-
+ProxyPsh_VPN_Provider_Sniffed_Server_Traffic_to_Catch_Hacker_60_KEY: |-
   Proxy.sh VPN Provider Sniffed Server Traffic to Catch Hacker
 
-httpsproxyPshpanelknowledgebasePphpQactiondisplayarticleid5_68_KEY: |-
+httpsproxyPshpanelknowledgebasePphpQactiondisplayarticleid5_67_KEY: |-
   https://proxy.sh/panel/knowledgebase.php?action=displayarticle&id=5
 
-Ethical_policy__All_of_the_reasons_why_ProxyPsh_might_enable_logging_70_KEY: |-
+Ethical_policy__All_of_the_reasons_why_ProxyPsh_might_enable_logging_69_KEY: |-
   Ethical policy - All of the reasons why Proxy.sh might enable logging
 
-httpswwwPivpnPnetprivacy_29_KEY: |-
+httpswwwPivpnPnetprivacy_28_KEY: |-
   https://www.ivpn.net/privacy
 
-IVPNPnet_will_collect_your_email_and_IP_address_after_sign_up_62_KEY: |-
+IVPNPnet_will_collect_your_email_and_IP_address_after_sign_up_61_KEY: |-
   IVPN.net will collect your email and IP address after sign up
 
 Read_the_a_datatoggletooltip_dataplacementtop_dataoriginaltitleThe_IP_collected_at_signup_is_only_used_for_a_few_seconds_by_our_fraud_modu_383_KEY: |-
   Read the <a data-toggle="tooltip" data-placement="top" data-original-title="The IP collected at signup is only used for a few seconds by our fraud module and then discarded, it is not stored. Storing them would significantly increase our own liability and certainly would not be in our interest. You're absolutely welcome to signup using Tor or a VPN.">Email statement</a> from IVPN.
 
-httpsmediumPcomblackVPNnologs6d65d95a3016_50_KEY: |-
+httpsmediumPcomblackVPNnologs6d65d95a3016_49_KEY: |-
   https://medium.com/@blackVPN/no-logs-6d65d95a3016
 
-blackVPN_announced_to_delete_connection_logs_after_disconnection_65_KEY: |-
+blackVPN_announced_to_delete_connection_logs_after_disconnection_64_KEY: |-
   blackVPN announced to delete connection logs after disconnection
 
-httpsgistPgithubPcomkennwhite1f3bc4d889b02b35d8aa_55_KEY: |-
+httpsgistPgithubPcomkennwhite1f3bc4d889b02b35d8aa_54_KEY: |-
   https://gist.github.com/kennwhite/1f3bc4d889b02b35d8aa
 
-Dont_use_LT2P_IPSec_use_other_protocolsP_43_KEY: |-
+Dont_use_LT2P_IPSec_use_other_protocolsP_42_KEY: |-
   Don't use LT2P IPSec, use other protocols.
 


### PR DESCRIPTION
This PR modifies weblate-source-file.yml

There's a bug in the current code that introduced cases where there were two strings with the same source but different keys.
https://github.com/privacytoolsIO/privacytools.io/blob/9c0fcec3305c6adb65c5fb6bf924dda1b8cc2a90/weblate-source-file.yml#L2330-L2331
https://github.com/privacytoolsIO/privacytools.io/blob/9c0fcec3305c6adb65c5fb6bf924dda1b8cc2a90/weblate-source-file.yml#L4160-L4161

From a grepping of the files, it became apparent that the extra length was from how the keys were inconsistently keyed:

```
{% t Cryptomator's mobile apps are not open-source.%}
{% t Cryptomator's mobile apps are not open-source. %}
```

A solution is to modify the ID code to base the length of the source string after stripping.