### PR TITLE
Add security warning to email lists

### DIFF
--- a/pages/providers/email.html
+++ b/pages/providers/email.html
@@ -5,4 +5,13 @@ title: "Best Secure Email Providers for Privacy"
 description: "Find a secure email provider that will keep your privacy in mind. Don't settle for ad-supported platforms. Never trust any company with your privacy, always encrypt."
 ---
 
+<div class="card border-danger">
+  <div class="card-header text-danger"><i class="fas fa-exclamation-circle fa-fw"></i> Warning</div>
+  <div class="card-body">
+    <p class="card-text text-danger">Even when using end-to-end encryption technology like GPG, email is inherently insecure and should not be trusted for sensitive communications. Metadata is always communicated in plaintext, and even when encryption is used correctly it is very easy for either party to acidentally respond to or forward a previously encrypted message in plaintext in many clients. GPG also does not easily support modern crypto functionality such as key rotation and forward secrecy.</p>
+    <p class="card-text text-secondary">We recommend the following email providers for routine notifications and messages from other services that require an email address. For communications that <strong>need</strong> to be safe and secure, you should use a dedicated instant messaging tool, such as Signal.</p>
+    <a href="/software/real-time-communication/" class="btn btn-outline-secondary">Recommended Instant Messengers</a>
+  </div>
+</div>
+
 {% include sections/email-providers.html %}

--- a/pages/software/email.html
+++ b/pages/software/email.html
@@ -5,6 +5,15 @@ title: "Email Clients"
 description: "Discover free, open-source, and secure email clients, along with some email alternatives you may not have considered."
 ---
 
+<div class="card border-danger">
+  <div class="card-header text-danger"><i class="fas fa-exclamation-circle fa-fw"></i> Warning</div>
+  <div class="card-body">
+    <p class="card-text text-danger">Even when using end-to-end encryption technology like GPG, email is inherently insecure and should not be trusted for sensitive communications. Metadata is always communicated in plaintext, and even when encryption is used correctly it is very easy for either party to acidentally respond to or forward a previously encrypted message in plaintext in many clients. GPG also does not easily support modern crypto functionality such as key rotation and forward secrecy.</p>
+    <p class="card-text text-secondary">We recommend the following email providers for routine notifications and messages from other services that require an email address. For communications that <strong>need</strong> to be safe and secure, you should use a dedicated instant messaging tool, such as Signal.</p>
+    <a href="/software/real-time-communication/" class="btn btn-outline-secondary">Recommended Instant Messengers</a>
+  </div>
+</div>
+
 {% include sections/email-clients.html %}
 
 {% include sections/email-alternatives.html %}


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

This adds a warning to the email lists that (even with GPG) email is insecure for many reasons and should not be entrusted with sensitive communications. It recommends using a IM platform like Signal for that kind of thing.

Related: #1542 

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: https://deploy-preview-1543--privacytools-io.netlify.com/providers/email/