### PR TITLE
Rearrange some sections and correct grammatical errors

### DIFF
--- a/_includes/sections/android-addons.html
+++ b/_includes/sections/android-addons.html
@@ -1,9 +1,5 @@
 <h1 id="aaddons" class="anchor"><a href="#aaddons"><i class="fas fa-link anchor-icon"></i></a> Android Privacy Add-ons</h1>
 
-<div class="alert alert-success" role="alert">
-  <strong>Improve your privacy with these add-ons for Android.</strong>
-</div>
-
 <div class="container-fluid">
 
   <div class="row mb-2">
@@ -12,7 +8,7 @@
     </div>
     <div class="col">
     <h3>Control your traffic with <a href="https://www.netguard.me/">NetGuard</a></h3>
-    <p><strong>NetGuard</strong> provides simple and advanced ways to block certain apps' access to the internet without the help of root privileges. Applications and addresses can individually be allowed or denied access to your Wi-Fi and/or mobile connection, allowing you to control which apps are able to call home or not.
+    <p><strong>NetGuard</strong> provides simple and advanced methods to block certain apps from accessing the internet, without requiring root privileges. Applications and addresses can be individually allowed or denied access to your Wi-Fi and/or mobile connections, allowing you to control exactly which apps are able to phone home or not.</p>
     </div>
   </div>
 
@@ -22,7 +18,7 @@
     </div>
     <div class="col">
     <h3>Tor for Android with <a href="https://guardianproject.info/apps/orbot/">Orbot</a></h3>
-    <p><strong>Orbot</strong> is a free proxy app that empowers other apps to use the internet more securely. Orbot uses Tor to encrypt your Internet traffic and then hides it by bouncing through a series of computers around the world. <strong>Root Mode:</strong> Orbot can be configured to transparently proxy all of your Internet traffic through Tor. You can also choose which specific apps you want to use through Tor.
+    <p><strong>Orbot</strong> is a free proxy app that empowers other apps to use the internet more securely. Orbot uses Tor to encrypt your Internet traffic and then hides it by bouncing through a series of computers around the world. <strong>Root Mode:</strong> Orbot can be configured to transparently proxy all of your Internet traffic through Tor. You can also choose which specific apps you wish to use through Tor.</p>
     </div>
   </div>
 
@@ -32,6 +28,6 @@
 
 <ul>
   <li>
-    <a href="/providers/dns#clients">Our DNS page</a> which also has information on encrypting DNS on Android.
+    <a href="/providers/dns#clients">Our DNS client recommendations</a>, which have information on enabling encrypted DNS on Android.
   </li>
 </ul>

--- a/_includes/sections/browser-addons.html
+++ b/_includes/sections/browser-addons.html
@@ -20,7 +20,7 @@ edge="https://www.microsoft.com/en-us/p/ublock-origin/9nblggh444l4"
 {% include cardv2.html
 title="HTTPS Everywhere: Secure Connections"
 image="/assets/img/addons/https-everywhere.png"
-description="<strong>HTTPS Everywhere</strong> enables encryption of your connecitons to many major websites, making your browsing more secure. It is a collaboration between The Tor Project and the Electronic Frontier Foundation."
+description="<strong>HTTPS Everywhere</strong> enables encryption of your connections to many major websites, making your browsing more secure. It is a collaboration between The Tor Project and the Electronic Frontier Foundation."
 website="https://www.eff.org/https-everywhere"
 forum="https://forum.privacytools.io/t/discussion-https-everywhere/268"
 github="https://github.com/EFForg/https-everywhere"

--- a/_includes/sections/browser-addons.html
+++ b/_includes/sections/browser-addons.html
@@ -1,13 +1,13 @@
 <h1 id="addons" class="anchor"><a href="#addons"><i class="fas fa-link anchor-icon"></i></a> Recommended Browser Add-ons</h1>
 
-<div class="alert alert-primary" role="alert">
-  <strong>Improve your privacy with these browser add-ons.</strong>
+<div class="alert alert-secondary" role="alert">
+  Not all of these add-ons are necessary, and many provide redundant functionality. Choose the ones you need, and <a class="alert-link" href="https://blog.privacytools.io/firefox-privacy-an-introduction-to-safe/">learn more with our guide to Firefox Privacy</a>.
 </div>
 
 {% include cardv2.html
 title="uBlock Origin: Block Ads and Trackers"
 image="/assets/img/addons/ublock-origin.png"
-description="<strong>uBlock Origin</strong> is an efficient <a href=https://github.com/gorhill/uBlock/wiki/Blocking-mode>wide-spectrum blocker</a> that's easy on memory, and yet can load and enforce thousands more filters than other popular blockers out there. It has no monetization strategy and is completely open source."
+description="<strong>uBlock Origin</strong> is an efficient <a href=https://github.com/gorhill/uBlock/wiki/Blocking-mode>wide-spectrum blocker</a> that is easy on memory, and yet can load and enforce thousands more filters than other popular blockers out there. It has no monetization strategy and is completely open source."
 website="https://addons.mozilla.org/firefox/addon/ublock-origin/"
 forum="https://forum.privacytools.io/t/discussion-ublock-origin/266"
 github="https://github.com/gorhill/uBlock/"
@@ -18,20 +18,9 @@ edge="https://www.microsoft.com/en-us/p/ublock-origin/9nblggh444l4"
 %}
 
 {% include cardv2.html
-title="Cookie AutoDelete: Automatically Delete Cookies"
-image="/assets/img/addons/cookie-autodelete.png"
-description="<strong>Cookie AutoDelete</strong> automatically removes cookies when they are no longer used by open browser tabs. With the cookies, lingering sessions, as well as information used to spy on you, will be expunged."
-website="https://addons.mozilla.org/firefox/addon/cookie-autodelete/"
-forum="https://forum.privacytools.io/t/discussion-cookie-autodelete/267"
-github="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete"
-firefox="https://addons.mozilla.org/en-US/firefox/addon/cookie-autodelete"
-chrome="https://chrome.google.com/webstore/detail/cookie-autodelete/fhcgjolkccmbidfldomjliifgaodjagh"
-%}
-
-{% include cardv2.html
 title="HTTPS Everywhere: Secure Connections"
 image="/assets/img/addons/https-everywhere.png"
-description="<strong>HTTPS Everywhere</strong> encrypts your communications with many major websites, making your browsing more secure. A collaboration between The Tor Project and the Electronic Frontier Foundation."
+description="<strong>HTTPS Everywhere</strong> enables encryption of your connecitons to many major websites, making your browsing more secure. It is a collaboration between The Tor Project and the Electronic Frontier Foundation."
 website="https://www.eff.org/https-everywhere"
 forum="https://forum.privacytools.io/t/discussion-https-everywhere/268"
 github="https://github.com/EFForg/https-everywhere"
@@ -43,7 +32,7 @@ opera="https://addons.opera.com/en/extensions/details/https-everywhere"
 {% include cardv2.html
 title="Decentraleyes: Block Content Delivery Networks"
 image="/assets/img/addons/decentraleyes.png"
-description="<strong>Decentraleyes</strong> emulates Content Delivery Networks locally by intercepting requests, finding the required resource, and injecting it into the environment. This all happens instantaneously, automatically, and no prior configuration is required."
+description="<strong>Decentraleyes</strong> emulates Content Delivery Networks locally by intercepting requests, finding the required resource locally, and injecting it into the environment. This all happens instantaneously and automatically, with no configuration required."
 website="https://decentraleyes.org/"
 forum="https://forum.privacytools.io/t/discussion-decentraleyes/269"
 gitlab="https://git.synz.io/Synzvato/decentraleyes"
@@ -53,9 +42,20 @@ opera="https://addons.opera.com/en/extensions/details/decentraleyes"
 %}
 
 {% include cardv2.html
+title="Cookie AutoDelete: Automatically Delete Cookies"
+image="/assets/img/addons/cookie-autodelete.png"
+description="<strong>Cookie AutoDelete</strong> automatically removes cookies, lingering sessions, and other information that can be used to spy on you when they are no longer used by open browser tabs."
+website="https://addons.mozilla.org/firefox/addon/cookie-autodelete/"
+forum="https://forum.privacytools.io/t/discussion-cookie-autodelete/267"
+github="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete"
+firefox="https://addons.mozilla.org/en-US/firefox/addon/cookie-autodelete"
+chrome="https://chrome.google.com/webstore/detail/cookie-autodelete/fhcgjolkccmbidfldomjliifgaodjagh"
+%}
+
+{% include cardv2.html
 title="Terms of Service; Didn’t Read: Be Informed"
 image="/assets/img/addons/tosdr.png"
-description="<strong>Terms of Service; Didn’t Read</strong> is an addon that aims to fix how “I have read and agree to the Terms” is the biggest lie on the web by grading websites based on their terms of service agreements and privacy policies. It also gives short summaries of those agreements. The analysis and ratings are done transparently by a community of reviewers."
+description="<strong>Terms of Service; Didn’t Read</strong> is an addon that believes “I have read and agree to the Terms of Service” is the biggest lie on the web, and wants to fix it by grading websites based on their terms of service agreements and privacy policies. It also gives short summaries of those agreements. The analysis and ratings are published transparently by a community of reviewers."
 website="https://tosdr.org/"
 forum="https://forum.privacytools.io/t/discussion-terms-of-service-didn-t-read/270"
 github="https://github.com/tosdr/"
@@ -90,7 +90,7 @@ opera="https://addons.opera.com/en/extensions/details/privacy-badger/"
 <h2>For Power Users Only</h2>
 
 <div class="alert alert-warning" role="alert">
-  <strong>These addons require quite a lot of interaction from the user. Some sites will not work properly until you have configured the add-ons.</strong>
+  <strong>These addons require quite a lot of interaction from the user. Some sites may not work properly without careful configuration.</strong>
 </div>
 
 {% include cardv2.html

--- a/_includes/sections/browser-recommendation.html
+++ b/_includes/sections/browser-recommendation.html
@@ -7,7 +7,7 @@
 title="Firefox"
 image="/assets/img/tools/Firefox.png"
 description='Firefox is fast, reliable, open-source, and respects your privacy. Don\'t forget to adjust the settings according to our
-recommendations: <a href="#webrtc"><i class="fas fa-link"></i> WebRTC</a> and <a href="#about_config"><i class="fas fa-link"></i> about:config</a> and get the <a href="#addons"><i class="fas fa-link"></i> privacy add-ons</a>.'
+recommendations: <a href="#addons"><i class="fas fa-link"></i> Privacy Add-ons</a> <a href="#webrtc"><i class="fas fa-link"></i> WebRTC</a> <a href="#about_config"><i class="fas fa-link"></i> about:config tweaks</a>.'
 website="https://firefox.com"
 forum="https://forum.privacytools.io/t/discussion-firefox/279"
 source="https://hg.mozilla.org/mozilla-central/"
@@ -41,7 +41,7 @@ linux="https://www.torproject.org/download/"
 title="Firefox"
 image="/assets/img/tools/Firefox.png"
 description='Firefox is fast, reliable, open-source, and respects your privacy. Don\'t forget to adjust the settings according to our
-recommendations: <a href="#webrtc"><i class="fas fa-link"></i> WebRTC</a> and <a href="#about_config"><i class="fas fa-link"></i> about:config</a> and get the <a href="#addons"><i class="fas fa-link"></i> privacy add-ons</a>.'
+recommendations: <a href="#addons"><i class="fas fa-link"></i> Privacy Add-ons</a> <a href="#webrtc"><i class="fas fa-link"></i> WebRTC</a> <a href="#about_config"><i class="fas fa-link"></i> about:config tweaks</a>.'
 website="https://www.mozilla.org/en-US/firefox/mobile/"
 forum="https://forum.privacytools.io/t/discussion-firefox/279"
 source="https://github.com/mozilla-mobile"
@@ -66,7 +66,7 @@ googleplay="https://play.google.com/store/apps/details?id=org.torproject.torbrow
 {% include cardv2.html
 title="Bromite"
 image="/assets/img/tools/bromite.png"
-description='Bromite is a Chromium-based browser with security enhancement patches from GrapheneOS and built-in adblocking and DNS over HTTPS support. More info can be found <a href="https://www.bromite.org/#main-features">here</a>.'
+description='Bromite is a Chromium-based browser with security enhancement patches from GrapheneOS and other security-focused projects, built-in adblocking, and DNS over HTTPS support. More info can be found <a href="https://www.bromite.org/#main-features">on their website</a>.'
 website="https://www.bromite.org/"
 forum="https://forum.privacytools.io/t/discussion-bromite-browsers/1521"
 github="https://github.com/bromite/bromite"

--- a/_includes/sections/calendar-contacts-sync.html
+++ b/_includes/sections/calendar-contacts-sync.html
@@ -24,14 +24,6 @@
 
 {%
   include cardv2.html
-  title="Email Providers"
-  image="/assets/img/misc/email.png"
-  description='Many email providers also offer calendar and or contacts sync services. Refer to the <a href="/providers/email">Email Providers section</a> to choose an email provider and check if they also offer calendar and/or contacts sync.'
-  website="/providers/email"
-%}
-
-{%
-  include cardv2.html
   title="EteSync"
   image="/assets/img/provider/etesync.png"
   description="<strong>EteSync</strong> is a secure, end-to-end encrypted, and privacy-respecting cloud backup and synchronization software for your personal information (e.g. contacts and calendars). There are native clients for Android, iOS, and the web, and an adapter layer for most desktop clients. It costs $24 per year to use, or you can host the server yourself for free."
@@ -50,6 +42,14 @@
   ios="https://www.etesync.com/install/ios/"
 %}
 
+{%
+  include cardv2.html
+  title="Email Providers"
+  image="/assets/img/misc/email.png"
+  description='Many email providers also offer calendar and or contacts sync services. Refer to our <a href="/providers/email">Email Provider recommendations</a> to choose an email provider and see if they also offer calendar and/or contacts sync.'
+  website="/providers/email"
+%}
+
 <h3>Worth Mentioning</h3>
 
 <ul>
@@ -58,9 +58,9 @@
   </li>
 
   <li>
-    <a href="../cloud">cloud backups</a> - Consider regularly exporting your calendar and or contacts and backing them up on a separate storage drive or uploading them to cloud storage (ideally after <a href="../encryption-tools/">encrypting</a> them).
+    <a href="../cloud">Cloud backups</a> - Consider regularly exporting your calendar and or contacts and backing them up on a separate storage drive or uploading them to cloud storage (ideally after <a href="../encryption-tools/">encrypting</a> them).
   </li>
-  
+
   <li>
     <a href="https://github.com/39aldo39/DecSync">DecSync</a> - DecSync can be used to synchronize RSS, contacts, and calendars without a server by using file synchronization software such as <a href="https://syncthing.net/">Syncthing</a>.
   </li>

--- a/_includes/sections/cloud-storage.html
+++ b/_includes/sections/cloud-storage.html
@@ -7,7 +7,7 @@
 {% include cardv2.html
 title="Nextcloud - Choose your hoster"
 image="/assets/img/provider/Nextcloud.png"
-description="Nextcloud is similar in functionality to the widely-used Dropbox, with the difference being that Nextcloud is free and open-source, thereby allowing anyone to install and operate it without charge on a private server, with no limits on storage space or the number of connected clients."
+description="<strong>Nextcloud</strong> is a suite of client-server software for creating your own file hosting services on a private server you control. Nextcloud is free and open-source, and supports end-to-end encryption with many of its clients. The only limits on storage and bandwidth are the limits on the <a href=\"/providers/hosting\">server provider</a> you choose."
 website="https://nextcloud.com/"
 forum="https://forum.privacytools.io/t/discussion-nextcloud/287"
 github="https://github.com/nextcloud"

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -1,7 +1,7 @@
 <h1 id="dns" class="anchor"><a href="#dns"><i class="fas fa-link anchor-icon"></i></a> Encrypted Domain Name System (DNS) Resolvers</h1>
 
 <div class="alert alert-warning" role="alert">
-  <strong>Note: Using an encrypted DNS resolver will not make you anonymous, nor hide your internet traffic from your Internet Service Provider. But it will prevent DNS hijacking, and make your DNS requests harder for third parties to eavesdrop on and tamper with. If you are currently using Google's DNS resolver, you should pick an alternative here.</strong>
+  <strong>Note: Using an encrypted DNS resolver will not make you anonymous, nor hide your internet traffic from your Internet Service Provider. But, it will prevent DNS hijacking, and make your DNS requests harder for third parties to eavesdrop on and tamper with. If you are currently using Google's DNS resolver, you should pick an alternative here.</strong>
 </div>
 
 <div class="table-responsive">
@@ -512,82 +512,3 @@
     </tbody>
   </table>
 </div>
-
-<h4>Terms</h4>
-
-<ul>
-  <li>DNS-over-TLS (DoT) - A security protocol for encrypted DNS on a dedicated port 853. Some providers support port 443 which generally works everywhere while port 853 is often blocked by restrictive firewalls. DoT has two modes:</li>
-    <ul>
-        <li>Oppurtunistic mode: the client attempts to form a DNS-over-TLS connection to the server on port 853 without performing certificate validation. If it fails, it will use unencrypted DNS. <span class="badge badge-warning" data-toggle="tooltip" data-original-title="In other words automatic mode leaves your DNS traffic vulnerable to SSL strip and MITM attacks"><i class="fas fa-exclamation-triangle"></i></span></li>
-        <li>Strict mode: the client connects to a specific hostname and performs certificate validation for it. If it fails, no DNS queries are made until it succeeds.</li>
-    </ul>
-  <li>DNS-over-HTTPS (DoH) - Similar to DoT, but uses HTTPS instead, being indistinguishable from "normal" HTTPS traffic on port 443. <span class="badge badge-warning" data-toggle="tooltip" data-original-title="DoH contains metadata such as user-agent (which may include system information) that is sent to the DNS server."><a href="https://tools.ietf.org/html/rfc8484#section-8.2"><i class="fas fa-exclamation-triangle"></i></a></span></li>
-  <li>DNSCrypt - An older yet robust method of encrypting DNS.</li>
-</ul>
-
-<h4>How to verify DNS is encrypted</h4>
-
-<ul>
-  <li>DoH / DoT
-    <ul>
-      <li>Check <a href="https://www.dnsleaktest.com/">DNSLeakTest.com</a>. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title="Your DNS provider may not appear with their own name, so compare the responses to what you know or can find about your DNS provider. Just ensure you don't see your ISP or old unencrypted DNS provider."><i class="fas fa-exclamation-triangle"></i></span></li>
-      <li>Check the website of your DNS provider. They may have a page for telling "you are using our DNS." Examples include <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a> and <a href="https://1.1.1.1/help">Cloudflare</a>.</li>
-      <li>If using Firefox's trusted recursive resolver (TRR), navigate to <code>about:networking#dns</code>. If the TRR column says "true" for some fields, you are using DoH. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title='Some fields will say "false" depending on the the value of network.trr.mode in about:config'><a href="https://wiki.mozilla.org/Trusted_Recursive_Resolver"><i class="fas fa-exclamation-triangle"></i></a></span></li>
-    </ul>
-  </li>
-  <li>dnscrypt-proxy - Check <a href="https://github.com/jedisct1/dnscrypt-proxy/wiki/Checking">dnscrypt-proxy's wiki on how to verify that your DNS is encrypted</a>.</li>
-  <li>DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">DNSSEC Resolver Test by Matthäus Wander</a>.</li>
-  <li>QNAME Minimization - Run <code>dig +short txt qnamemintest.internet.nl</code> from the command-line (taken from <a href="https://nlnetlabs.nl/downloads/presentations/unbound_qnamemin_oarc24.pdf">this NLnet Labs presentation</a>). If you are on Windows 10, run <code>Resolve-DnsName -Type TXT -Name qnamemintest.internet.nl</code> from the PowerShell. You should see this display: <code>"HOORAY - QNAME minimisation is enabled on your resolver :)!"</code></li>
-</ul>
-
-<h3 id="clients">Software suggestions and Additional Information</h3>
-
-<ul>
-  <li><strong>Encrypted DNS clients for desktop:</strong>
-    <ul>
-      <li><em>Firefox</em> comes with built-in DoH support with Cloudflare set as the default resolver, but can be configured to use any DoH resolver. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title='"Cloudflare has agreed to collect only a limited amount of data about the DNS requests that are sent to the Cloudflare Resolver for Firefox via the Firefox browser."'><a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/firefox/"><i class="fas fa-exclamation-triangle"></i></a></span> Currently Mozilla is <a href="https://blog.mozilla.org/futurereleases/2019/07/31/dns-over-https-doh-update-detecting-managed-networks-and-user-choice/">conducting studies</a> before enabling DoH by default for all US-based Firefox users.</li>
-          <ul>
-              <li>DNS over HTTPS can be enabled in Menu -> Preferences (<code>about:preferences</code>) -> Network Settings -> Enable DNS over HTTPS. Set "Use Provider" to "Custom", and enter your DoH provider's address.</li>
-              <li>Advanced users may enable it in <code>about:config</code> by setting <code>network.trr.custom_uri</code> and <code>network.trr.uri</code> as the address you find from the documentation of your DoH provider and <code>network.trr.mode</code> as <code>2</code>. It may also be desirable to set <code>network.security.esni.enabled</code> to <code>True</code> in order to enable encrypted SNI and make sites supporting ESNI a bit more difficult to track.</li>
-          </ul>
-    </ul>
-  </li>
-  <li><strong>Encrypted DNS clients for mobile:</strong>
-    <ul>
-      <li><em>Android 9</em> comes with a DoT client by <a href="https://support.google.com/android/answer/9089903">default</a>. <span class="badge badge-warning" data-toggle="tooltip" data-original-title="...but with some caveats"><a href="https://www.quad9.net/private-dns-quad9-android9/"><i class="fas fa-exclamation-triangle"></i></a></span></li>
-        <ul>
-          <li>We recommend selecting <em>Private DNS provider hostname</em> and entering the DoT address from documentation of your DoT provider to enable strict mode (see Terms above). <span class="badge badge-warning" data-toggle="tooltip" data-original-title="If you are on a network blocking access to port 853, Android will error about the network not having internet connectivity."><i class="fas fa-exclamation-triangle"></i></span></li>
-        </ul>
-      <li><em><a href="https://apps.apple.com/app/id1452162351">DNSCloak</a></em> - An <a href="https://github.com/s-s/dnscloak">open-source</a> DNSCrypt and DoH client for iOS by <td><a data-toggle="tooltip" data-placement="bottom" data-original-title='"A charitable non-profit host organization for international Free Software projects."' href="https://techcultivation.org/">the Center for the Cultivation of Technology gemeinnuetzige GmbH</a>.</li>
-      <li><em><a href="https://git.frostnerd.com/PublicAndroidApps/smokescreen/blob/master/README.md">Nebulo</a></em> - An open-source application for Android supporting DoH and DoT. It also supports caching DNS responses and locally logging DNS queries.</li>
-    </ul>
-  </li>
-  <li><strong>Local DNS servers:</strong>
-    <ul>
-      <li><em><a href="https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby">Stubby</a></em> - An open-source application for Linux, macOS, and Windows that acts as a local DNS Privacy stub resolver using DoT.</li>
-      <li><em><a href="https://nlnetlabs.nl/projects/unbound/about/">Unbound</a></em> - a validating, recursive, caching DNS resolver. It can also be ran network-wide and has supported DNS-over-TLS since version 1.7.3.</li>
-      <ul>
-          <li>See also <a href="https://www.ctrl.blog/entry/unbound-tls-forwarding.html">Actually secure DNS over TLS in Unbound on ctrl.blog</a>.</li>
-      </ul>
-    </ul>
-  </li>
-  <li><strong>Network wide DNS servers:</strong>
-    <ul>
-      <li><em><a href="https://pi-hole.net/">Pi-hole</a></em> - A network-wide DNS server mainly for the Raspberry Pi. Blocks ads, tracking, and malicious domains for all devices on your network.</li>
-      <li><em><a href="https://gitlab.com/quidsup/notrack">NoTrack</a></em> - A network-wide DNS server like Pi-hole for blocking ads, tracking, and malicious domains.</li>
-    </ul>
-  </li>
-  <li><strong>Further reading:</strong>
-    <ul>
-      <li>On Firefox, DoH and ESNI</li>
-          <ul>
-              <li><a href="https://wiki.mozilla.org/Trusted_Recursive_Resolver">Trusted Recursive Resolver (DoH) on MozillaWiki</a></li>
-              <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1500289">Firefox bug report requesting the ability to use ESNI without DoH</a></li>
-              <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1542754">Firefox bug report requesting the ability to use Android 9+'s Private DNS (DoT) and benefit from encrypted SNI without having to enable DoH</a></li>
-              <li><a href="https://blog.cloudflare.com/encrypted-sni/">Encrypt it or lose it: how encrypted SNI works on Cloudflare blog</a></li>
-          </ul>
-      <li><a href="https://www.isc.org/blogs/qname-minimization-and-privacy/">QNAME Minimization and Your Privacy</a> by the Internet Systems Consortium (ISC)</li>
-      <li><a href="https://www.isc.org/dnssec/">DNSSEC and BIND 9</a> by the ISC</li>
-    </ul>
-  </li>
-</ul>

--- a/_includes/sections/email-clients.html
+++ b/_includes/sections/email-clients.html
@@ -3,7 +3,7 @@
 {% include cardv2.html
 title="Thunderbird"
 image="/assets/img/tools/Thunderbird.png"
-description="Thunderbird is a free, open source, cross-platform email, newsgroup, news feed, and chat (XMPP, IRC, Twitter) client developed by community, previously by the Mozilla Foundation."
+description="Thunderbird is a free, open source, cross-platform email, newsgroup, news feed, and chat (XMPP, IRC, Twitter) client developed by the Thunderbird community, and previously by the Mozilla Foundation."
 website="https://www.thunderbird.net/"
 forum="https://forum.privacytools.io/t/discussion-thunderbird/659"
 source="https://hg.mozilla.org/comm-central/"

--- a/_includes/sections/email-providers.html
+++ b/_includes/sections/email-providers.html
@@ -258,13 +258,3 @@
 <a href="https://mailinabox.email/"><img src="/assets/img/provider/Mail-in-a-Box.png" width="200" height="70" class="img-fluid float-left mr-3" alt="Mail-in-a-Box"></a>
 <p>Take it a step further and get control of your email with this easy-to-deploy mail server in a box. Mail-in-a-Box lets you become your own mail service provider in a few easy steps. It's sort of like making your own Gmail, but one you control from top
 to bottom. Technically, Mail-in-a-Box turns a fresh cloud computer into a working mail server. But you don't need to be a technology expert to set it up. <strong>More: <a href="https://mailinabox.email/">https://mailinabox.email/</a></strong></p>
-
-<h3>Related Information</h3>
-
-<ul>
-  <li><a href="https://www.wired.com/2011/10/ecpa-turns-twenty-five/">Aging 'Privacy' Law Leaves Cloud E-Mail Open to Cops</a> - Data stored in the cloud for longer than 6 months is considered abandoned and may be accessed by intelligence agencies without
-    a warrant. Learning: Use an external email client like Thunderbird or Enigmail, download your emails and store them locally. Never leave them on the server.</li>
-  <li><a href="https://www.eff.org/deeplinks/2012/04/may-firstriseup-server-seizure-fbi-overreaches-yet-again">With May First/Riseup Server Seizure, FBI Overreaches Yet Again</a></li>
-  <li><a href="https://www.autistici.org/ai/crackdown/">Autistici/Inventati server compromised</a> - The cryptographic services offered by the Autistici/Inventati server have been compromised on 15th June 2004. It was discovered on 21st June 2005. One year
-    later. During an enquiry on a single mailbox, the Postal Police may have tapped for a whole year every user's private communication going through the server autistici.org/inventati.org.</li>
-</ul>

--- a/_includes/sections/file-encryption.html
+++ b/_includes/sections/file-encryption.html
@@ -53,8 +53,8 @@
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration. <span class="badge badge-warning" data-toggle="tooltip" title="Cryptomator's mobile apps are not open-source."><a href="https://github.com/cryptomator/cryptomator-android/issues/1#issuecomment-257979375"><i class="fas fa-exclamation-triangle"></i></a></span></li></li>
+  <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration. <span class="badge badge-warning" data-toggle="tooltip" title="Cryptomator's mobile apps are not open-source."><a href="https://github.com/cryptomator/cryptomator-android/issues/1#issuecomment-257979375"><i class="fas fa-exclamation-triangle"></i></a></span></li>
   <li><a href="https://gitlab.com/cryptsetup/cryptsetup/">Linux Unified Key Setup (LUKS)</a> - A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.</li>
-  <li><a href="https://hat.sh/">Hat.sh</a> - A cross-platform, serverless JavaScript web application that provides secure file encryption using the AES-256-GCM algorithm in your browser. It can also be downloaded and run offline.</a></li>
+  <li><a href="https://hat.sh/">Hat.sh</a> - A cross-platform, serverless JavaScript web application that provides secure file encryption using the AES-256-GCM algorithm in your browser. It can also be downloaded and run offline.</li>
   <li><a href="https://www.keka.io/">Keka</a> - A macOS-only, open-source file archiver with the ability to encrypt files.</li>
 </ul>

--- a/_includes/sections/file-sharing.html
+++ b/_includes/sections/file-sharing.html
@@ -4,7 +4,7 @@
 title="Firefox Send"
 image="/assets/img/tools/Firefox-Send.png"
 website="https://send.firefox.com/"
-description="Firefox Send uses end-to-end encryption to keep your data secure from the moment you share to the moment your file is opened. It also offers security controls that you can set. You can choose when your file link expires, the number of downloads, and whether to add an optional password for an extra layer of security."
+description="Firefox Send uses end-to-end encryption to keep your data secure from the moment you share to the moment your file is opened. It also offers security controls that you can set. You can choose when your file link expires, the number of downloads, and whether you would like to add a password for an extra layer of security."
 forum="https://forum.privacytools.io/t/discussion-firefox-send/755"
 github="https://github.com/mozilla/send"
 web="https://send.firefox.com/"

--- a/_includes/sections/file-sync.html
+++ b/_includes/sections/file-sync.html
@@ -9,7 +9,7 @@
   include cardv2.html
   title="Syncthing"
   image="/assets/img/tools/Syncthing.png"
-  description="<strong>Syncthing</strong> replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third-party and how it's transmitted over the Internet."
+  description="<strong>Syncthing</strong> replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third-party, and how it is transmitted over the Internet."
   website="https://syncthing.net/"
   forum="https://forum.privacytools.io/t/discussion-syncthing/1627/2"
   github="https://github.com/syncthing?type=source"
@@ -24,7 +24,7 @@
   include cardv2.html
   title="SparkleShare"
   image="/assets/img/tools/SparkleShare.png"
-  description="<strong>SparkleShare</strong> creates a special folder on your computer. You can add remotely hosted folders (or \"projects\") to this folder. These projects will be automatically kept in sync with both the host and all of your peers when someone adds, removes or edits a file."
+  description="<strong>SparkleShare</strong> creates a special folder on your computer. You can add remotely hosted folders (or \"projects\") to this folder. These projects will be automatically kept in sync with both the host and all of your peers when someone adds, removes, or edits a file."
   website="https://sparkleshare.org/"
   forum="https://forum.privacytools.io/t/discussion-sparkleshare/1626"
   github="https://github.com/hbons/SparkleShare"
@@ -36,7 +36,6 @@
 
 <ul>
   <li>
-    <a href="https://git-annex.branchable.com/">git-annex</a> - Allows managing files with git, without checking the file contents into git. While that may seem paradoxical, it is useful when dealing with files larger than git can currently easily handle,
-    whether due to limitations in memory, time, or disk space.
+    <a href="https://git-annex.branchable.com/">git-annex</a> - Allows managing files with git, without checking the file contents into git. While that may seem paradoxical, it is useful when dealing with files larger than git can currently easily handle, whether due to limitations in memory, time, or disk space.
   </li>
 </ul>

--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -1,33 +1,31 @@
-<h1 id="im" class="anchor"><a href="#im"><i class="fas fa-link anchor-icon"></i></a> Encrypted Instant Messenger</h1>
+<h1 id="im" class="anchor"><a href="#im"><i class="fas fa-link anchor-icon"></i></a> Encrypted Instant Messengers</h1>
 
-<div>
-    <p>We only recommend instant messenger programs or apps that support <a href="https://en.wikipedia.org/wiki/End-to-end_encryption">end-to-end encryption (E2EE)</a>. When E2EE is used, all transmissions (messages, voice, video, etc.) are encrypted <strong>before</strong> they are sent from your device. E2EE protects both the authenticity and confidentiality of the transmission as they pass through any part of the network (servers, etc.).</p>
+<p>We only recommend instant messenger programs or apps that support <a href="https://en.wikipedia.org/wiki/End-to-end_encryption">end-to-end encryption (E2EE)</a>. When E2EE is used, all transmissions (messages, voice, video, etc.) are encrypted <strong>before</strong> they are sent from your device. E2EE protects both the authenticity and confidentiality of the transmission as they pass through any part of the network (servers, etc.).</p>
 
-    <p>All the client programs/apps we chose are <a href="https://en.wikipedia.org/wiki/Free_and_open-source_software">free and open-source software</a> unless otherwise mentioned. This to ensure that the code can be independently verified by experts now and in the future.</p>
+<p>All the client programs/apps we chose are <a href="https://en.wikipedia.org/wiki/Free_and_open-source_software">free and open-source software</a> unless otherwise mentioned. This to ensure that the code can be independently verified by experts now and in the future.</p>
 
-    <p>We have described the three main types of messaging programs that exist: Centralized, Federated and Peer-to-Peer (P2P), with the advantages and disadvantages of each.</p>
+<p>We have described the three main types of messaging programs that exist: Centralized, Federated and Peer-to-Peer (P2P), with the advantages and disadvantages of each.</p>
 
-    <h2 id="centralized" class="anchor"><a href="#centralized"><i class="fas fa-link anchor-icon"></i></a> Centralized</h2>
+<h2 id="centralized" class="anchor"><a href="#centralized"><i class="fas fa-link anchor-icon"></i></a> Centralized</h2>
 
-    <p>Centralized messengers are those where every participant is on the same server or network of servers controlled by the same organization.</p>
+<p>Centralized messengers are those where every participant is on the same server or network of servers controlled by the same organization.</p>
 
-    <h3>Advantages</h3>
+<h3>Advantages</h3>
+<ul>
+    <li>New features and changes can be implemented more quickly.</li>
+    <li>Easier to get started with and to find contacts.</li>
+</ul>
+
+<h3>Disadvantages</h3>
+<ul>
+    <li>Centralized services could be more susceptible to <a href="#exploiting-centralized-networks">legislation requiring backdoor access</a>.</li>
+    <li>Can include <a href="https://drewdevault.com/2018/08/08/Signal.html">restricted control or access</a>. This can include things like:</li>
     <ul>
-        <li>New features and changes can be implemented more quickly.</li>
-        <li>Easier to get started with and to find contacts.</li>
+        <li>Being <a href="https://github.com/LibreSignal/LibreSignal/issues/37#issuecomment-217211165">forbidden from connecting third-party clients</a> to the centralized network that might provide for greater customization or better user experience. Often defined in Terms and Conditions of usage.</li>
+        <li>Poor or no documentation for third-party developers.</li>
     </ul>
-
-    <h3>Disadvantages</h3>
-    <ul>
-        <li>Centralized services could be more susceptible to <a href="#exploiting-centralized-networks">legislation requiring backdoor access</a>.</li>
-        <li>Can include <a href="https://drewdevault.com/2018/08/08/Signal.html">restricted control or access</a>. This can include things like:</li>
-        <ul>
-            <li>Being <a href="https://github.com/LibreSignal/LibreSignal/issues/37#issuecomment-217211165">forbidden from connecting third-party clients</a> to the centralized network that might provide for greater customization or better user experience. Often defined in Terms and Conditions of usage.</li>
-            <li>Poor or no documentation for third-party developers.</li>
-        </ul>
-        <li>The <a href="https://blog.privacytools.io/delisting-wire">ownership</a>, privacy policy, and operations of the service can change easily when a single entity controls it, potentially compromising the service later on.</li>
-    </ul>
-</div>
+    <li>The <a href="https://blog.privacytools.io/delisting-wire">ownership</a>, privacy policy, and operations of the service can change easily when a single entity controls it, potentially compromising the service later on.</li>
+</ul>
 
 <div class="alert alert-warning" role="alert">
   <strong>If you are currently using an Instant Messenger like Telegram, LINE, Viber, <a href="https://www.eff.org/deeplinks/2016/10/where-whatsapp-went-wrong-effs-four-biggest-security-concerns">WhatsApp</a>, or plain SMS, you should pick an alternative here.</strong></div>
@@ -125,7 +123,6 @@
             <li>Other <a href="https://omemo.top">OMEMO</a> capable clients for XMPP.</li>
         </ul>
         <li><a href="https://www.kontalk.org">Kontalk</a> is a community-driven instant messaging network based on XMPP.</li>
-        </ul>
     </ul>
 
     <h2 id="peer-to-peer" class="anchor"><a href="#peer-to-peer"><i class="fas fa-link anchor-icon"></i></a> Peer to Peer (P2P)</h2>
@@ -194,71 +191,9 @@
   linux="https://tox.chat/download.html#oses"
 %}
 
-<div>
-    <h4>Worth Mentioning</h4>
+<h4>Worth Mentioning</h4>
 
-    <ul>
-        <li><a href="https://status.im">Status.im</a> - Encrypted instant messenger with an integrated <a href="https://en.wikipedia.org/wiki/Ethereum">Ethereum</a> wallet (cryptocurrency) that also includes support for <a href="https://our.status.im/tag/dapps">DApps (decentralized apps)</a> (web apps in a curated store). Uses the <a href="https://blog.enuma.io/update/2018/08/08/decentralized-application-messaging-with-whisper.html">Whisper protocol</a> for P2P communication. <span class="badge badge-warning">Experimental</span></li>
-        <li><a href="https://retroshare.cc">Retroshare</a> - Encrypted instant messaging and voice/video call client. RetroShare supports both <a href="https://www.torproject.org/">Tor</a> and <a href="https://geti2p.net">I2P</a>.</li>
-    </ul>
-
-    <h3 id="exploiting-centralized-networks" class="anchor">
-        <a href="#exploiting-centralized-networks">
-            <i class="fas fa-link anchor-icon"></i>
-    </a>
-        Recent news about breaking E2EE on centralized instant messengers
-    </h3>
-
-    <h5>November 2019</h5>
-    <ul>
-        <li><a href="https://www.reuters.com/article/us-interpol-encryption-exclusive-idUSKBN1XR0S7">Exclusive: Interpol plans to condemn encryption spread, citing predators, sources say (Reuters)</a></li>
-        <li><a href="https://arstechnica.com/tech-policy/2019/11/think-of-the-children-fbi-sought-interpol-statement-against-end-to-end-crypto/">Think of the children: FBI sought Interpol statement against end-to-end crypto (ArsTechnica)</a></li>
-    </ul>
-
-    <h5>October 2019</h5>
-    <ul>
-        <li><a href="https://www.eff.org/deeplinks/2019/10/open-letter-governments-us-uk-and-australia-facebook-all-out-attack-encryption">The Open Letter from the Governments of US, UK, and Australia to Facebook is An All-Out Attack on Encryption (EFF)</a></li>
-        <li><a href="https://arstechnica.com/tech-policy/2019/10/the-broken-record-why-barrs-call-against-end-to-end-encryption-is-nuts/">The broken record: Why Barr’s call against end-to-end encryption is nuts (ArsTechnica)</a></li>
-        <li><a href="https://arstechnica.com/information-technology/2019/10/ag-barr-is-pushing-facebook-to-backdoor-whatsapp-and-halt-encryption-plans">US wants Facebook to backdoor WhatsApp and halt encryption plans (ArsTechnica)</a></li>
-    </ul>
-
-    <h5>August 2019</h5>
-    <ul>
-        <li><a href="https://arstechnica.com/tech-policy/2019/08/post-snowden-tech-became-more-secure-but-is-govt-really-at-risk-of-going-dark">Post Snowden tech became more secure, but is government really at risk of going dark? (ArsTechnica)</a></li>
-    </ul>
-
-    <h5>July 2019</h5>
-    <ul>
-        <li><a href="https://techcrunch.com/2019/07/23/william-barr-consumers-security-risks-backdoors/">US attorney general William Barr says Americans should accept security risks of encryption backdoors (TechCrunch)</a></li>
-        <li><a href="https://www.theregister.co.uk/2019/07/23/us_encryption_backdoor/">Low Barr: Don't give me that crap about security, just put the backdoors in the encryption, roars US Attorney General (The Register)</a></li>
-    </ul>
-
-    <h5>May 2019</h5>
-    <ul>
-        <li><a href="https://www.theguardian.com/uk-news/2019/may/30/apple-and-whatsapp-condemn-gchq-plans-to-eavesdrop-on-encrypted-chats">Apple and WhatsApp condemn GCHQ plans to eavesdrop on encrypted chats (The Guardian)</a></li>
-    </ul>
-
-    <h5>January 2019</h5>
-    <ul>
-        <li><a href="https://www.justsecurity.org/62114/give-ghost-backdoor/">Give Up the Ghost: A Backdoor by Another Name (Just Security)</a></li>
-    </ul>
-
-    <h5>December 2018</h5>
-    <ul>
-        <li><a href="https://www.zdnet.com/article/whats-actually-in-australias-encryption-laws-everything-you-need-to-know/">What's actually in Australia's encryption laws? Everything you need to know (ZDnet)</a></li>
-    </ul>
-
-    <h3>Complete Comparison</h3>
-    <ul>
-        <li><a href="https://securechatguide.org/effguide.html">securechatguide.org</a> - Guide to Choosing a Messenger.</li>
-        <li><a href="https://www.securemessagingapps.com/">securemessagingapps.com</a> - Secure Messaging Apps Comparison.</li>
-    </ul>
-
-    <h3 id="#rtc-independent-security-audits">Independent security audits</h3>
-    <ul>
-        <li><a href="https://eprint.iacr.org/2016/1013.pdf">A Formal Security Analysis of the Signal Messaging Protocol (2019)</a> by Katriel Cohn-Gordon, Cas Cremers, Benjamin Dowling, Luke Garratt and Douglas Stebila</li>
-        <li><a href="https://keybase.io/docs-assets/blog/NCC_Group_Keybase_KB2018_Public_Report_2019-02-27_v1.3.pdf">Keybase's Protocol Security Review (2019)</a> by <a href="https://www.nccgroup.trust/">NCC Group</a></li>
-        <li><a href="https://www.nccgroup.trust/us/our-research/matrix-olm-cryptographic-review/">Matrix Olm Cryptographic Review</a></li>
-        <li><a href="https://briarproject.org/news/2017-beta-released-security-audit">Briar - Darknet Messenger Releases Beta, Passes Security Audit</a></li>
-    </ul>
-</div>
+<ul>
+    <li><a href="https://status.im">Status.im</a> - Encrypted instant messenger with an integrated <a href="https://en.wikipedia.org/wiki/Ethereum">Ethereum</a> wallet (cryptocurrency) that also includes support for <a href="https://our.status.im/tag/dapps">DApps (decentralized apps)</a> (web apps in a curated store). Uses the <a href="https://blog.enuma.io/update/2018/08/08/decentralized-application-messaging-with-whisper.html">Whisper protocol</a> for P2P communication. <span class="badge badge-warning">Experimental</span></li>
+    <li><a href="https://retroshare.cc">Retroshare</a> - Encrypted instant messaging and voice/video call client. RetroShare supports both <a href="https://www.torproject.org/">Tor</a> and <a href="https://geti2p.net">I2P</a>.</li>
+</ul>

--- a/_includes/sections/live-operating-systems.html
+++ b/_includes/sections/live-operating-systems.html
@@ -3,7 +3,7 @@
 {% include cardv2.html
 title="Tails"
 image="/assets/img/tools/Tails.png"
-description='Tails is a live operating system that starts on almost any computer from a DVD, USB stick, or SD card. It aims at preserving privacy and anonymity, and circumventing censorship by forcing Internet connections through the Tor network; leaving no trace on the computer; and using state-of-the-art cryptographic tools to encrypt files, emails, and instant messages.'
+description='Tails is a live operating system that can boot on almost any computer from a DVD, USB stick, or SD card you control. It aims at preserving privacy and anonymity, and circumventing censorship by forcing Internet connections through the Tor network; leaving no trace on the computer; and using state-of-the-art cryptographic tools to encrypt files, emails, and instant messages.'
 badges="info:GNU/Linux"
 labels="warning:contrib:This software may depend on or recommend non-free software."
 website="https://tails.boum.org/"

--- a/_includes/sections/mobile-operating-systems.html
+++ b/_includes/sections/mobile-operating-systems.html
@@ -1,7 +1,7 @@
 <h1 id="mobile_os" class="anchor"><a href="#mobile_os"><i class="fas fa-link anchor-icon"></i></a> Mobile Operating Systems</h1>
 
 <div class="alert alert-warning" role="alert">
-  <strong>Even though the source code of the following OS is provided, installing Google Apps may compromise your setup.</strong>
+  <strong>Even though the source code of the following operating systems is provided, installing Google Apps may compromise your setup.</strong>
 </div>
 
 {% include cardv2.html

--- a/_includes/sections/notebooks.html
+++ b/_includes/sections/notebooks.html
@@ -24,7 +24,7 @@ chrome="https://chrome.google.com/webstore/detail/joplin-web-clipper/alofnhikmmk
 {% include cardv2.html
 title="Standard Notes"
 image="/assets/img/tools/StandardNotes.png"
-description='Standard Notes is a simple and private notes app that makes your notes easy and available everywhere you are. Features end-to-end encryption on every platform, and a powerful desktop experience with themes and custom editors. It has also been <a href="https://s3.amazonaws.com/standard-notes/security/Report-SN-Audit.pdf">independently audited (PDF)</a>.'
+description='Standard Notes is a simple and private notes app that makes your notes easy and available everywhere you are. It features end-to-end encryption on every platform, and a powerful desktop experience with themes and custom editors. It has also been <a href="https://s3.amazonaws.com/standard-notes/security/Report-SN-Audit.pdf">independently audited (PDF)</a>.'
 website="https://standardnotes.org/"
 github="https://github.com/standardnotes"
 windows="https://standardnotes.org/#get-started"

--- a/_includes/sections/operating-systems.html
+++ b/_includes/sections/operating-systems.html
@@ -45,38 +45,3 @@ gitlab="https://salsa.debian.org/qa/debsources"
   <li><a href="https://www.whonix.org/">Whonix</a> <span class="badge badge-info">GNU/Linux</span> - A Debian-based security-focused Linux distribution. It aims to provide privacy, security and anonymity on the internet. The operating system consists of two virtual machines, a "Workstation"
     and a Tor "Gateway". All communication are forced through the Tor network to accomplish this.</li>
 </ul>
-
-<h3>Warning</h3>
-
-<ul>
-  <li><a href="#win10"><i class="fas fa-link"></i> Don't use Windows 10 - It's a privacy nightmare</a></li>
-</ul>
-
-<h4 id="cpuvulns">Remember to check CPU vulnerability mitigations</h4>
-
-<p><em><a href="https://support.microsoft.com/en-us/help/4073757/protect-windows-devices-from-speculative-execution-side-channel-attack">This also affects Windows 10</a>, but it doesn't expose this information or mitigation instructions as easily. MacOS users check <a href="https://support.apple.com/en-us/HT210108">How to enable full mitigation for Microarchitectural Data Sampling (MDS) vulnerabilities on Apple Support</a>.</em></p>
-
-<p>When running a recent enough Linux kernel, you can check the CPU vulnerabilities it detects by <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code>. By using <code>tail -n +1</code> instead of <code>cat</code>, the file names are also visible.</p>
-
-<p>
-    In case you have an Intel CPU, you may notice "SMT vulnerable" display after running the <code>tail</code> command. To mitigate this, disable <a href="https://en.wikipedia.org/wiki/Hyper-threading">hyper-threading</a> from the UEFI/BIOS. You can also take the following mitigation steps below if your system/distribution uses GRUB and supports <code>/etc/default/grub.d/</code>:
-</p>
-
-<ol>
-  <li><code>sudo mkdir /etc/default/grub.d/</code> to create a directory for additional grub configuration</li>
-  <li><code>echo GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT l1tf=full,force mds=full,nosmt mitigations=auto,nosmt nosmt=force" | sudo tee /etc/default/grub.d/mitigations.cfg</code> to create a new grub config file source with the echoed content</li>
-  <li><code>sudo grub-mkconfig -o /boot/grub/grub.cfg</code> to generate a new grub config file including these new kernel boot flags</li>
-  <li><code>sudo reboot</code> to reboot</li>
-  <li>after the reboot, check <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code> again to see that everything referring to SMT now says "SMT disabled."</li>
-</ol>
-
-<h5>Further reading</h5>
-
-<ul>
-  <li><a href="https://cpu.fail/">CPU.fail</a></li>
-  <li><a href="https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/">Hardware vulnerabilities index on The Linux kernel user's and administrator's guide</a></li>
-  <li><a href="https://www.cyberciti.biz/faq/install-update-intel-microcode-firmware-linux/">How to install/update CPU microcode firmware on Linux</a> - Regardless of your CPU manufacturer, you should always install the latest microcode packages available to be protected from CPU vulnerabilities, especially if the command above reports <strong>no microcode</strong> in its output.</li>
-  <li><a href="https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html">MDS - Microarchitectural Data Sampling on The Linux kernel user's and administrator's guide</a></li>
-  <li><a href="https://mdsattacks.com/">RIDL and Fallout: MDS attacks on mdsattacks.com</a></li>
-  <li><a href="https://en.wikipedia.org/wiki/Simultaneous_multithreading">Simultaneous multithreading on Wikipedia</a></li>
-</ul>

--- a/_includes/sections/password-managers.html
+++ b/_includes/sections/password-managers.html
@@ -82,9 +82,3 @@
     <a href="https://pwsafe.org/">Password Safe</a> - Whether the answer is one or hundreds, Password Safe allows you to safely and easily create a secured and encrypted username/password list. With Password Safe all you have to do is create and remember a single "Master Password" of your choice in order to unlock and access your entire username/password list.
   </li>
 </ul>
-
-<h3>Related Information</h3>
-
-<ul>
-  <li><a href="https://peertube.mastodon.host/videos/watch/4cdedd90-a5b4-4022-b93d-828e85ed58cd">Edward Snowden on Passwords on Peertube</a></li>
-</ul>

--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -46,8 +46,8 @@ github="https://github.com/Qwant/"
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://yacy.net/">YaCy</a> - A free-software P2P search engine powered by its users.</a></li>
-  <li><a href="https://jivesearch.com/">Jive Search</a> - A free-software search engine with a similar look and feel to Google.</a></li>
+  <li><a href="https://yacy.net/">YaCy</a> - A free-software P2P search engine powered by its users.</li>
+  <li><a href="https://jivesearch.com/">Jive Search</a> - A free-software search engine with a similar look and feel to Google.</li>
   <li><a href="https://metager.de/en/">MetaGer</a> - An open-source metasearch engine, which is based in Germany. It focuses on protecting the user's privacy.</li>
   <li><a href="https://www.mojeek.com/">Mojeek</a> - Independent and unbiased search results with no user tracking.</li>
 </ul>

--- a/_includes/sections/self-contained-networks.html
+++ b/_includes/sections/self-contained-networks.html
@@ -58,12 +58,6 @@ netbsd="https://freenetproject.org/pages/download.html#gnulinux-posix"
 github="https://github.com/freenet/"
 %}
 
-<h3>Related Information</h3>
-
-<ul>
-  <li><a href="https://darknetdiaries.com/">darknetdiaries.com</a> - True stories from the dark side of the Internet.</li>
-</ul>
-
 <h3>Worth Mentioning</h3>
 
 <ul>

--- a/_includes/sections/selfhosted-cloud.html
+++ b/_includes/sections/selfhosted-cloud.html
@@ -7,7 +7,7 @@
 {% include cardv2.html
 title="Nextcloud"
 image="/assets/img/provider/Nextcloud.png"
-description="Nextcloud is similar in functionality to the widely used Dropbox, with the difference being that Nextcloud is free and open-source, thereby allowing anyone to install and operate it without charge on a private server with no limits on storage space or the number of connected clients."
+description="<strong>Nextcloud</strong> is a suite of client-server software for creating your own file hosting services on a private server you control. Nextcloud is free and open-source, and supports end-to-end encryption with many of its clients. The only limits on storage and bandwidth are the limits on the <a href=\"/providers/hosting\">server provider</a> you choose."
 website="https://nextcloud.com/"
 forum="https://forum.privacytools.io/t/discussion-nextcloud/287"
 windows="https://nextcloud.com/install/#install-clients"

--- a/_includes/sections/social-networks.html
+++ b/_includes/sections/social-networks.html
@@ -1,13 +1,13 @@
 <h1 id="social" class="anchor"><a href="#social"><i class="fas fa-link anchor-icon"></i></a> Decentralized Social Networks</h1>
 
 <div class="alert alert-warning" role="alert">
-  <strong> If you are currently using Social Networks like Facebook or Twitter, you should pick an alternative here. </strong>
+  <strong> If you are currently using Social Networks like Facebook or Twitter, you should pick an alternative here.</strong>
 </div>
 
 {% include cardv2.html
 title="Mastodon - Twitter Alternative"
 image="/assets/img/tools/Mastodon.png"
-description='Mastodon is a social network based on open web protocols and free, open-source software. It is decentralized like email. It also has the most users, and the most diverse (in terms of interests) users; looks good; and is easy to setup. Feel welcome to join our hosted instance: <a href="https://social.privacytools.io/">social.privacytools.io</a>'
+description='Mastodon is a social network based on open web protocols and free, open-source software. It is decentralized like email, users can exist on different servers or even different platforms but still communicate with each other. It also has the most users, and the most diverse (in terms of interests) users, it looks good, and it is easy to setup yourself. If you are looking for a server to join, you are welcome to join our hosted instance: <a href="https://social.privacytools.io/">social.privacytools.io</a>'
 website="https://joinmastodon.org/"
 forum="https://forum.privacytools.io/t/discussion-mastodon/289"
 github="https://github.com/tootsuite/mastodon"
@@ -26,7 +26,7 @@ web="https://joinmastodon.org/#getting-started"
 {% include cardv2.html
 title="diaspora* - Google+ Alternative"
 image="/assets/img/tools/diaspora.png"
-description="diaspora* is based on three key philosophies: Decentralization, freedom and privacy. It is intended to address privacy concerns related to centralized social networks by allowing users set up their own server (or \"pod\") to host content; pods can then interact to share status updates, photographs, and other social data."
+description="diaspora* is based on three key philosophies: Decentralization, Freedom, and Privacy. It is intended to address privacy concerns related to centralized social networks by allowing users set up their own server (or \"pod\") to host content. Pods can then interact to share status updates, photographs, and other social data."
 website="https://diasporafoundation.org/"
 forum="https://forum.privacytools.io/t/discussion-diaspora/290"
 github="https://github.com/diaspora/diaspora"
@@ -51,7 +51,7 @@ web="https://friendi.ca/"
 {% include cardv2.html
 title="PixelFed - Instagram Alternative"
 image="/assets/img/provider/pixelfed.png"
-description='PixelFed is a free and ethical photo sharing platform, powered by ActivityPub federation. Pixelfed is an open-source, federated platform. You can run your own instance or <a href="https://fediverse.party/en/pixelfed/">join one.</a>'
+description='PixelFed is a free and ethical photo sharing platform, powered by ActivityPub federation. Pixelfed is an open-source, federated platform. You can run your own instance or <a href="https://fediverse.party/en/pixelfed/">join an existing one.</a>'
 website="https://pixelfed.org/"
 forum="https://forum.privacytools.io/t/discussion-pixelfed/293"
 github="https://github.com/pixelfed"
@@ -72,19 +72,4 @@ web="https://gnu.io/social/"
 <ul>
   <li><a href="https://www.minds.com/">Minds</a> - An <a href="https://gitlab.com/minds">open-source</a> and distributed social networking service, integrating the blockchain to reward the community.</li>
   <li><a href="https://movim.eu/">Movim</a> - A federated social platform that relies on the XMPP standard and therefore allows you to exchange with many other clients on all devices.</li>
-</ul>
-
-<h3>Related Information</h3>
-<ul>
-  <li><a href="https://addons.mozilla.org/firefox/addon/mastodon-simplified-federation/">Mastodon: Simplified Federation</a> - Firefox Extension to improve usability for remote Mastodon instances.</li>
-  <li><a href="https://justdeleteme.xyz/">JustDeleteMe</a> - A directory of direct links to delete your account from web services.</li>
-  <li><a href="https://forget.codl.fr/">Forget</a> - A service that automatically deletes your old posts on Twitter and Mastodon that everyone has forgotten about.</li>
-</ul>
-
-<h3>Facebook Related</h3>
-<ul>
-  <li><a href="https://www.facebook.com/help/delete_account">Delete your Facebook account</a> - Direct link to delete your Facebook account without being able to reactivate it again.</li>
-  <li><a href="https://deletefacebook.com/">How To Permanently Delete A Facebook Account</a> - This guide will take you through a smooth and successful Facebook account deletion.</li>
-  <li><a href="https://addons.mozilla.org/firefox/addon/facebook-container/">Facebook Container by Mozilla</a> - Prevent Facebook from tracking you around the web.</li>
-  <li><a href="https://www.stopusingfacebook.co/">Stop using Facebook</a> - A curated list of reasons to stop using Facebook and how to do it.</li>
 </ul>

--- a/pages/os.html
+++ b/pages/os.html
@@ -7,6 +7,41 @@ description: "Even your own computer could be compromising your privacy. Discove
 
 {% include sections/operating-systems.html %}
 
+<h3>Warning</h3>
+
+<ul>
+  <li><a href="#win10"><i class="fas fa-link"></i> Don't use Windows 10 - It's a privacy nightmare</a></li>
+</ul>
+
+<h4 id="cpuvulns">Remember to check CPU vulnerability mitigations</h4>
+
+<p><em><a href="https://support.microsoft.com/en-us/help/4073757/protect-windows-devices-from-speculative-execution-side-channel-attack">This also affects Windows 10</a>, but it doesn't expose this information or mitigation instructions as easily. MacOS users check <a href="https://support.apple.com/en-us/HT210108">How to enable full mitigation for Microarchitectural Data Sampling (MDS) vulnerabilities on Apple Support</a>.</em></p>
+
+<p>When running a recent enough Linux kernel, you can check the CPU vulnerabilities it detects by <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code>. By using <code>tail -n +1</code> instead of <code>cat</code>, the file names are also visible.</p>
+
+<p>
+    In case you have an Intel CPU, you may notice "SMT vulnerable" display after running the <code>tail</code> command. To mitigate this, disable <a href="https://en.wikipedia.org/wiki/Hyper-threading">hyper-threading</a> from the UEFI/BIOS. You can also take the following mitigation steps below if your system/distribution uses GRUB and supports <code>/etc/default/grub.d/</code>:
+</p>
+
+<ol>
+  <li><code>sudo mkdir /etc/default/grub.d/</code> to create a directory for additional grub configuration</li>
+  <li><code>echo GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT l1tf=full,force mds=full,nosmt mitigations=auto,nosmt nosmt=force" | sudo tee /etc/default/grub.d/mitigations.cfg</code> to create a new grub config file source with the echoed content</li>
+  <li><code>sudo grub-mkconfig -o /boot/grub/grub.cfg</code> to generate a new grub config file including these new kernel boot flags</li>
+  <li><code>sudo reboot</code> to reboot</li>
+  <li>after the reboot, check <code>tail -n +1 /sys/devices/system/cpu/vulnerabilities/*</code> again to see that everything referring to SMT now says "SMT disabled."</li>
+</ol>
+
+<h5>Further reading</h5>
+
+<ul>
+  <li><a href="https://cpu.fail/">CPU.fail</a></li>
+  <li><a href="https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/">Hardware vulnerabilities index on The Linux kernel user's and administrator's guide</a></li>
+  <li><a href="https://www.cyberciti.biz/faq/install-update-intel-microcode-firmware-linux/">How to install/update CPU microcode firmware on Linux</a> - Regardless of your CPU manufacturer, you should always install the latest microcode packages available to be protected from CPU vulnerabilities, especially if the command above reports <strong>no microcode</strong> in its output.</li>
+  <li><a href="https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html">MDS - Microarchitectural Data Sampling on The Linux kernel user's and administrator's guide</a></li>
+  <li><a href="https://mdsattacks.com/">RIDL and Fallout: MDS attacks on mdsattacks.com</a></li>
+  <li><a href="https://en.wikipedia.org/wiki/Simultaneous_multithreading">Simultaneous multithreading on Wikipedia</a></li>
+</ul>
+
 {% include sections/live-operating-systems.html %}
 
 {% include sections/mobile-operating-systems.html %}

--- a/pages/providers/dns.html
+++ b/pages/providers/dns.html
@@ -6,3 +6,82 @@ description: "Don't let Google see all your DNS traffic. Discover privacy-centri
 ---
 
 {% include sections/dns.html %}
+
+<h4>Terms</h4>
+
+<ul>
+  <li>DNS-over-TLS (DoT) - A security protocol for encrypted DNS on a dedicated port 853. Some providers support port 443 which generally works everywhere while port 853 is often blocked by restrictive firewalls. DoT has two modes:</li>
+    <ul>
+        <li>Oppurtunistic mode: the client attempts to form a DNS-over-TLS connection to the server on port 853 without performing certificate validation. If it fails, it will use unencrypted DNS. <span class="badge badge-warning" data-toggle="tooltip" data-original-title="In other words automatic mode leaves your DNS traffic vulnerable to SSL strip and MITM attacks"><i class="fas fa-exclamation-triangle"></i></span></li>
+        <li>Strict mode: the client connects to a specific hostname and performs certificate validation for it. If it fails, no DNS queries are made until it succeeds.</li>
+    </ul>
+  <li>DNS-over-HTTPS (DoH) - Similar to DoT, but uses HTTPS instead, being indistinguishable from "normal" HTTPS traffic on port 443. <span class="badge badge-warning" data-toggle="tooltip" data-original-title="DoH contains metadata such as user-agent (which may include system information) that is sent to the DNS server."><a href="https://tools.ietf.org/html/rfc8484#section-8.2"><i class="fas fa-exclamation-triangle"></i></a></span></li>
+  <li>DNSCrypt - An older yet robust method of encrypting DNS.</li>
+</ul>
+
+<h4>How to verify DNS is encrypted</h4>
+
+<ul>
+  <li>DoH / DoT
+    <ul>
+      <li>Check <a href="https://www.dnsleaktest.com/">DNSLeakTest.com</a>. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title="Your DNS provider may not appear with their own name, so compare the responses to what you know or can find about your DNS provider. Just ensure you don't see your ISP or old unencrypted DNS provider."><i class="fas fa-exclamation-triangle"></i></span></li>
+      <li>Check the website of your DNS provider. They may have a page for telling "you are using our DNS." Examples include <a href="https://adguard.com/en/adguard-dns/overview.html">AdGuard</a> and <a href="https://1.1.1.1/help">Cloudflare</a>.</li>
+      <li>If using Firefox's trusted recursive resolver (TRR), navigate to <code>about:networking#dns</code>. If the TRR column says "true" for some fields, you are using DoH. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title='Some fields will say "false" depending on the the value of network.trr.mode in about:config'><a href="https://wiki.mozilla.org/Trusted_Recursive_Resolver"><i class="fas fa-exclamation-triangle"></i></a></span></li>
+    </ul>
+  </li>
+  <li>dnscrypt-proxy - Check <a href="https://github.com/jedisct1/dnscrypt-proxy/wiki/Checking">dnscrypt-proxy's wiki on how to verify that your DNS is encrypted</a>.</li>
+  <li>DNSSEC - Check <a href="https://dnssec.vs.uni-due.de/">DNSSEC Resolver Test by Matthäus Wander</a>.</li>
+  <li>QNAME Minimization - Run <code>dig +short txt qnamemintest.internet.nl</code> from the command-line (taken from <a href="https://nlnetlabs.nl/downloads/presentations/unbound_qnamemin_oarc24.pdf">this NLnet Labs presentation</a>). If you are on Windows 10, run <code>Resolve-DnsName -Type TXT -Name qnamemintest.internet.nl</code> from the PowerShell. You should see this display: <code>"HOORAY - QNAME minimisation is enabled on your resolver :)!"</code></li>
+</ul>
+
+<h3 id="clients">Software suggestions and Additional Information</h3>
+
+<ul>
+  <li><strong>Encrypted DNS clients for desktop:</strong>
+    <ul>
+      <li><em>Firefox</em> comes with built-in DoH support with Cloudflare set as the default resolver, but can be configured to use any DoH resolver. <span class="badge badge-warning" data-toggle="tooltip" data-placement="bottom" data-original-title='"Cloudflare has agreed to collect only a limited amount of data about the DNS requests that are sent to the Cloudflare Resolver for Firefox via the Firefox browser."'><a href="https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/firefox/"><i class="fas fa-exclamation-triangle"></i></a></span> Currently Mozilla is <a href="https://blog.mozilla.org/futurereleases/2019/07/31/dns-over-https-doh-update-detecting-managed-networks-and-user-choice/">conducting studies</a> before enabling DoH by default for all US-based Firefox users.</li>
+          <ul>
+              <li>DNS over HTTPS can be enabled in Menu -> Preferences (<code>about:preferences</code>) -> Network Settings -> Enable DNS over HTTPS. Set "Use Provider" to "Custom", and enter your DoH provider's address.</li>
+              <li>Advanced users may enable it in <code>about:config</code> by setting <code>network.trr.custom_uri</code> and <code>network.trr.uri</code> as the address you find from the documentation of your DoH provider and <code>network.trr.mode</code> as <code>2</code>. It may also be desirable to set <code>network.security.esni.enabled</code> to <code>True</code> in order to enable encrypted SNI and make sites supporting ESNI a bit more difficult to track.</li>
+          </ul>
+    </ul>
+  </li>
+  <li><strong>Encrypted DNS clients for mobile:</strong>
+    <ul>
+      <li><em>Android 9</em> comes with a DoT client by <a href="https://support.google.com/android/answer/9089903">default</a>. <span class="badge badge-warning" data-toggle="tooltip" data-original-title="...but with some caveats"><a href="https://www.quad9.net/private-dns-quad9-android9/"><i class="fas fa-exclamation-triangle"></i></a></span></li>
+        <ul>
+          <li>We recommend selecting <em>Private DNS provider hostname</em> and entering the DoT address from documentation of your DoT provider to enable strict mode (see Terms above). <span class="badge badge-warning" data-toggle="tooltip" data-original-title="If you are on a network blocking access to port 853, Android will error about the network not having internet connectivity."><i class="fas fa-exclamation-triangle"></i></span></li>
+        </ul>
+      <li><em><a href="https://apps.apple.com/app/id1452162351">DNSCloak</a></em> - An <a href="https://github.com/s-s/dnscloak">open-source</a> DNSCrypt and DoH client for iOS by <td><a data-toggle="tooltip" data-placement="bottom" data-original-title='"A charitable non-profit host organization for international Free Software projects."' href="https://techcultivation.org/">the Center for the Cultivation of Technology gemeinnuetzige GmbH</a>.</li>
+      <li><em><a href="https://git.frostnerd.com/PublicAndroidApps/smokescreen/blob/master/README.md">Nebulo</a></em> - An open-source application for Android supporting DoH and DoT. It also supports caching DNS responses and locally logging DNS queries.</li>
+    </ul>
+  </li>
+  <li><strong>Local DNS servers:</strong>
+    <ul>
+      <li><em><a href="https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby">Stubby</a></em> - An open-source application for Linux, macOS, and Windows that acts as a local DNS Privacy stub resolver using DoT.</li>
+      <li><em><a href="https://nlnetlabs.nl/projects/unbound/about/">Unbound</a></em> - a validating, recursive, caching DNS resolver. It can also be ran network-wide and has supported DNS-over-TLS since version 1.7.3.</li>
+      <ul>
+          <li>See also <a href="https://www.ctrl.blog/entry/unbound-tls-forwarding.html">Actually secure DNS over TLS in Unbound on ctrl.blog</a>.</li>
+      </ul>
+    </ul>
+  </li>
+  <li><strong>Network wide DNS servers:</strong>
+    <ul>
+      <li><em><a href="https://pi-hole.net/">Pi-hole</a></em> - A network-wide DNS server mainly for the Raspberry Pi. Blocks ads, tracking, and malicious domains for all devices on your network.</li>
+      <li><em><a href="https://gitlab.com/quidsup/notrack">NoTrack</a></em> - A network-wide DNS server like Pi-hole for blocking ads, tracking, and malicious domains.</li>
+    </ul>
+  </li>
+  <li><strong>Further reading:</strong>
+    <ul>
+      <li>On Firefox, DoH and ESNI</li>
+          <ul>
+              <li><a href="https://wiki.mozilla.org/Trusted_Recursive_Resolver">Trusted Recursive Resolver (DoH) on MozillaWiki</a></li>
+              <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1500289">Firefox bug report requesting the ability to use ESNI without DoH</a></li>
+              <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1542754">Firefox bug report requesting the ability to use Android 9+'s Private DNS (DoT) and benefit from encrypted SNI without having to enable DoH</a></li>
+              <li><a href="https://blog.cloudflare.com/encrypted-sni/">Encrypt it or lose it: how encrypted SNI works on Cloudflare blog</a></li>
+          </ul>
+      <li><a href="https://www.isc.org/blogs/qname-minimization-and-privacy/">QNAME Minimization and Your Privacy</a> by the Internet Systems Consortium (ISC)</li>
+      <li><a href="https://www.isc.org/dnssec/">DNSSEC and BIND 9</a> by the ISC</li>
+    </ul>
+  </li>
+</ul>

--- a/pages/providers/email.html
+++ b/pages/providers/email.html
@@ -15,3 +15,13 @@ description: "Find a secure email provider that will keep your privacy in mind. 
 </div>
 
 {% include sections/email-providers.html %}
+
+<h3>Related Information</h3>
+
+<ul>
+  <li><a href="https://www.wired.com/2011/10/ecpa-turns-twenty-five/">Aging 'Privacy' Law Leaves Cloud E-Mail Open to Cops</a> - Data stored in the cloud for longer than 6 months is considered abandoned and may be accessed by intelligence agencies without
+    a warrant. Learning: Use an external email client like Thunderbird or Enigmail, download your emails and store them locally. Never leave them on the server.</li>
+  <li><a href="https://www.eff.org/deeplinks/2012/04/may-firstriseup-server-seizure-fbi-overreaches-yet-again">With May First/Riseup Server Seizure, FBI Overreaches Yet Again</a></li>
+  <li><a href="https://www.autistici.org/ai/crackdown/">Autistici/Inventati server compromised</a> - The cryptographic services offered by the Autistici/Inventati server have been compromised on 15th June 2004. It was discovered on 21st June 2005. One year
+    later. During an enquiry on a single mailbox, the Postal Police may have tapped for a whole year every user's private communication going through the server autistici.org/inventati.org.</li>
+</ul>

--- a/pages/providers/social-networks.html
+++ b/pages/providers/social-networks.html
@@ -6,3 +6,18 @@ description: "Find a social network that doesn't pry into your data or monetize 
 ---
 
 {% include sections/social-networks.html %}
+
+<h3>Related Information</h3>
+<ul>
+  <li><a href="https://addons.mozilla.org/firefox/addon/mastodon-simplified-federation/">Mastodon: Simplified Federation</a> - Firefox Extension to improve usability for remote Mastodon instances.</li>
+  <li><a href="https://justdeleteme.xyz/">JustDeleteMe</a> - A directory of direct links to delete your account from web services.</li>
+  <li><a href="https://forget.codl.fr/">Forget</a> - A service that automatically deletes your old posts on Twitter and Mastodon that everyone has forgotten about.</li>
+</ul>
+
+<h3>Facebook Related</h3>
+<ul>
+  <li><a href="https://www.facebook.com/help/delete_account">Delete your Facebook account</a> - Direct link to delete your Facebook account without being able to reactivate it again.</li>
+  <li><a href="https://deletefacebook.com/">How To Permanently Delete A Facebook Account</a> - This guide will take you through a smooth and successful Facebook account deletion.</li>
+  <li><a href="https://addons.mozilla.org/firefox/addon/facebook-container/">Facebook Container by Mozilla</a> - Prevent Facebook from tracking you around the web.</li>
+  <li><a href="https://www.stopusingfacebook.co/">Stop using Facebook</a> - A curated list of reasons to stop using Facebook and how to do it.</li>
+</ul>

--- a/pages/software/networks.html
+++ b/pages/software/networks.html
@@ -7,3 +7,9 @@ hidedesc: true
 ---
 
 {% include sections/self-contained-networks.html %}
+
+<h3>Related Information</h3>
+
+<ul>
+  <li><a href="https://darknetdiaries.com/">darknetdiaries.com</a> - True stories from the dark side of the Internet.</li>
+</ul>

--- a/pages/software/passwords.html
+++ b/pages/software/passwords.html
@@ -6,3 +6,9 @@ description: "Stay safe and secure online with an encrypted and open-source pass
 ---
 
 {% include sections/password-managers.html %}
+
+<h3>Related Information</h3>
+
+<ul>
+  <li><a href="https://peertube.mastodon.host/videos/watch/4cdedd90-a5b4-4022-b93d-828e85ed58cd">Edward Snowden on Passwords on Peertube</a></li>
+</ul>

--- a/pages/software/real-time-communication.html
+++ b/pages/software/real-time-communication.html
@@ -7,6 +7,66 @@ description: "Discover secure and private ways to communicate with others online
 
 {% include sections/instant-messenger.html %}
 
+<h3 id="exploiting-centralized-networks" class="anchor">
+    <a href="#exploiting-centralized-networks">
+        <i class="fas fa-link anchor-icon"></i>
+</a>
+    Recent news about breaking E2EE on centralized instant messengers
+</h3>
+
+<h5>November 2019</h5>
+<ul>
+    <li><a href="https://www.reuters.com/article/us-interpol-encryption-exclusive-idUSKBN1XR0S7">Exclusive: Interpol plans to condemn encryption spread, citing predators, sources say (Reuters)</a></li>
+    <li><a href="https://arstechnica.com/tech-policy/2019/11/think-of-the-children-fbi-sought-interpol-statement-against-end-to-end-crypto/">Think of the children: FBI sought Interpol statement against end-to-end crypto (ArsTechnica)</a></li>
+</ul>
+
+<h5>October 2019</h5>
+<ul>
+    <li><a href="https://www.eff.org/deeplinks/2019/10/open-letter-governments-us-uk-and-australia-facebook-all-out-attack-encryption">The Open Letter from the Governments of US, UK, and Australia to Facebook is An All-Out Attack on Encryption (EFF)</a></li>
+    <li><a href="https://arstechnica.com/tech-policy/2019/10/the-broken-record-why-barrs-call-against-end-to-end-encryption-is-nuts/">The broken record: Why Barr’s call against end-to-end encryption is nuts (ArsTechnica)</a></li>
+    <li><a href="https://arstechnica.com/information-technology/2019/10/ag-barr-is-pushing-facebook-to-backdoor-whatsapp-and-halt-encryption-plans">US wants Facebook to backdoor WhatsApp and halt encryption plans (ArsTechnica)</a></li>
+</ul>
+
+<h5>August 2019</h5>
+<ul>
+    <li><a href="https://arstechnica.com/tech-policy/2019/08/post-snowden-tech-became-more-secure-but-is-govt-really-at-risk-of-going-dark">Post Snowden tech became more secure, but is government really at risk of going dark? (ArsTechnica)</a></li>
+</ul>
+
+<h5>July 2019</h5>
+<ul>
+    <li><a href="https://techcrunch.com/2019/07/23/william-barr-consumers-security-risks-backdoors/">US attorney general William Barr says Americans should accept security risks of encryption backdoors (TechCrunch)</a></li>
+    <li><a href="https://www.theregister.co.uk/2019/07/23/us_encryption_backdoor/">Low Barr: Don't give me that crap about security, just put the backdoors in the encryption, roars US Attorney General (The Register)</a></li>
+</ul>
+
+<h5>May 2019</h5>
+<ul>
+    <li><a href="https://www.theguardian.com/uk-news/2019/may/30/apple-and-whatsapp-condemn-gchq-plans-to-eavesdrop-on-encrypted-chats">Apple and WhatsApp condemn GCHQ plans to eavesdrop on encrypted chats (The Guardian)</a></li>
+</ul>
+
+<h5>January 2019</h5>
+<ul>
+    <li><a href="https://www.justsecurity.org/62114/give-ghost-backdoor/">Give Up the Ghost: A Backdoor by Another Name (Just Security)</a></li>
+</ul>
+
+<h5>December 2018</h5>
+<ul>
+    <li><a href="https://www.zdnet.com/article/whats-actually-in-australias-encryption-laws-everything-you-need-to-know/">What's actually in Australia's encryption laws? Everything you need to know (ZDnet)</a></li>
+</ul>
+
+<h3>Complete Comparison</h3>
+<ul>
+    <li><a href="https://securechatguide.org/effguide.html">securechatguide.org</a> - Guide to Choosing a Messenger.</li>
+    <li><a href="https://www.securemessagingapps.com/">securemessagingapps.com</a> - Secure Messaging Apps Comparison.</li>
+</ul>
+
+<h3 id="#rtc-independent-security-audits">Independent security audits</h3>
+<ul>
+    <li><a href="https://eprint.iacr.org/2016/1013.pdf">A Formal Security Analysis of the Signal Messaging Protocol (2019)</a> by Katriel Cohn-Gordon, Cas Cremers, Benjamin Dowling, Luke Garratt and Douglas Stebila</li>
+    <li><a href="https://keybase.io/docs-assets/blog/NCC_Group_Keybase_KB2018_Public_Report_2019-02-27_v1.3.pdf">Keybase's Protocol Security Review (2019)</a> by <a href="https://www.nccgroup.trust/">NCC Group</a></li>
+    <li><a href="https://www.nccgroup.trust/us/our-research/matrix-olm-cryptographic-review/">Matrix Olm Cryptographic Review</a></li>
+    <li><a href="https://briarproject.org/news/2017-beta-released-security-audit">Briar - Darknet Messenger Releases Beta, Passes Security Audit</a></li>
+</ul>
+
 <hr/>
 
 {% include sections/voice-video-messenger.html %}


### PR DESCRIPTION
This PR corrects some sentences I didn't like, and rearranges the content of the website a bit.

Recommendations and worth mentioning products should generally go in the `_includes/sections` folder, while supplemental information (such as VPN criteria, news on E2EE, and other "further reading") should go directly on the page in `/pages`. This makes that guideline more consistently applied across the site.