### PR TITLE
Fix collapsing navbar dropdown when clicking another element

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -25,7 +25,11 @@ function navSectionsToggle() {
 
 function navSectionsClose(event) {
   // Hide all dropdowns when clicking in different place
-  if (event.target.matches(".nav-summary")) return;
+  if (
+    event.target.matches(".nav-summary") ||
+    event.target.parentNode.matches(".nav-summary")
+  )
+    return;
   navSections.forEach(navSection => {
     navSection.open = !open;
   });


### PR DESCRIPTION
JavaScript was checking if element clicked is exactly `.nav-summary`,
which isn't a problem when just clicking text inside it, but if we try
to click another element inside like `<span>`, it won't work, since now
this span is clicked, not `.nav-summary`.

Closes #1549