### PR TITLE
Make breadcrumbs nicer looking

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -8,7 +8,8 @@
     {% if forloop.last %}
     <li class="breadcrumb-item active" aria-current="page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
       <link href="{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' | replace:'without-plugin/','without-plugins/' }}{% endfor %}" itemprop="item"  />
-      <span itemprop="name">{{ crumb | replace:'-',' ' | remove:'.html' | capitalize }}</span>
+      <span itemprop="name">{% if page.breadcrumb %}{{ page.breadcrumb }}{% else %}{% assign words = crumb | replace:'-',' ' | remove:'.html' | split: ' ' %}{% capture titlecase %}{% for word in words %}{{ word | capitalize }} {% endfor %}{% endcapture %}{{ titlecase }}{% endif %}
+      </span>
       <meta itemprop="position" content="{{ forloop.index }}" />
     </li>
     {% else %}

--- a/pages/providers/dns.html
+++ b/pages/providers/dns.html
@@ -3,6 +3,7 @@ layout: page
 permalink: /providers/dns/
 title: "Encrypted DNS Resolvers"
 description: "Don't let Google see all your DNS traffic. Discover privacy-centric alternatives to the traditional DNS providers."
+breadcrumb: "DNS"
 ---
 
 {% include sections/dns.html %}

--- a/pages/providers/vpn.html
+++ b/pages/providers/vpn.html
@@ -3,6 +3,7 @@ layout: page
 permalink: /providers/vpn/
 title: "VPN Services"
 description: "Find a no-logging VPN operator who isn't out to sell or read your web traffic."
+breadcrumb: "VPN"
 ---
 
 <div class="card border-danger">

--- a/pages/software/cal-card.html
+++ b/pages/software/cal-card.html
@@ -1,8 +1,9 @@
 ---
 layout: page
 permalink: /software/calendar-contacts/
-title: "Calendar/Contacts Sync Tools"
+title: "Calendar and Contact Sync Tools"
 description: "Discover free, open-source, and secure ways to sync your contacts and calendars across your devices."
+breadcrumb: "Calendar and Contacts"
 ---
 
 {% include sections/calendar-contacts-sync.html %}


### PR DESCRIPTION
- Adds breadcrumb attribute to YAML front-matter for pages where we would like to define a particular breadcrumb name rather than the auto-generated one.
  - Example: https://deploy-preview-1555--privacytools-io.netlify.com/providers/dns/
- Capitalizes every word of the breadcrumb name rather than only the first.
  - Example: https://deploy-preview-1555--privacytools-io.netlify.com/providers/social-news-aggregator/

Resolves: #1551