### PR TITLE
Remove wirecutter, affiliate driven site, talks about VPNs we don't recommend anyway

### DIFF
--- a/pages/providers/vpn.html
+++ b/pages/providers/vpn.html
@@ -219,7 +219,6 @@ breadcrumb: "VPN"
         <h3>More VPN Providers</h3>
         <ul>
           <li><a href="https://thatoneprivacysite.net/vpn-comparison-chart/">Spreadsheet with unbiased, independently verifiable data on over 100 VPN services.</a></li>
-          <li><a href="https://thewirecutter.com/reviews/best-vpn-service/">In-depth research on 53 popular VPN providers.</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
Uses affiliate links, we don't want to be driving traffic there. Recommends VPNs that do not fit our criteria.