### PR TITLE
Change wording to be closer to Bromite's own description

### DIFF
--- a/_includes/sections/browser-recommendation.html
+++ b/_includes/sections/browser-recommendation.html
@@ -66,7 +66,7 @@ googleplay="https://play.google.com/store/apps/details?id=org.torproject.torbrow
 {% include cardv2.html
 title="Bromite"
 image="/assets/img/svg/3rd-party/bromite.svg"
-description='Bromite is a Chromium-based browser with privacy and security enhancements, built-in adblocking, DNS over HTTPS support; it includes patches from ungoogled-chromium and other privacy-focused projects. More info can be found <a href="https://www.bromite.org/#main-features">on the official website</a>.'
+description='Bromite is a Chromium-based browser with privacy and security enhancements, built-in adblocking and DNS over HTTPS support; it includes patches from ungoogled-chromium and other privacy-focused projects. More info can be found <a href="https://www.bromite.org/#main-features">on the official website</a>.'
 website="https://www.bromite.org/"
 forum="https://forum.privacytools.io/t/discussion-bromite-browsers/1521"
 github="https://github.com/bromite/bromite"

--- a/_includes/sections/browser-recommendation.html
+++ b/_includes/sections/browser-recommendation.html
@@ -66,7 +66,7 @@ googleplay="https://play.google.com/store/apps/details?id=org.torproject.torbrow
 {% include cardv2.html
 title="Bromite"
 image="/assets/img/svg/3rd-party/bromite.svg"
-description='Bromite is a Chromium-based browser with security enhancement patches from GrapheneOS and other security-focused projects, built-in adblocking, and DNS over HTTPS support. More info can be found <a href="https://www.bromite.org/#main-features">on their website</a>.'
+description='Bromite is a Chromium-based browser with privacy and security enhancements, built-in adblocking, DNS over HTTPS support; it includes patches from ungoogled-chromium and other privacy-focused projects. More info can be found <a href="https://www.bromite.org/#main-features">on the official website</a>.'
 website="https://www.bromite.org/"
 forum="https://forum.privacytools.io/t/discussion-bromite-browsers/1521"
 github="https://github.com/bromite/bromite"


### PR DESCRIPTION
This PR changes the wording to be closer to Bromite's own description and mentions ungoogled-chromium instead of GrapheneOS.

## Description

Resolves: #1588

#### Check List

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: <!-- link or Non Applicable? Edit this in afterwards -->