### PR TITLE
Change a warning of Firefox about:config entering

### DIFF
--- a/_includes/sections/browser-tweaks.html
+++ b/_includes/sections/browser-tweaks.html
@@ -6,7 +6,7 @@
 
 <ol>
   <li>Enter "about:config" in the firefox address bar and press enter.</li>
-  <li>Press the button "Accept the Risk and Continue"</li>
+  <li>Press the button "I'll be careful, I promise!" or "Accept the Risk and Continue"</li>
   <li>Follow the instructions below...</li>
 </ol>
 

--- a/_includes/sections/browser-tweaks.html
+++ b/_includes/sections/browser-tweaks.html
@@ -6,7 +6,7 @@
 
 <ol>
   <li>Enter "about:config" in the firefox address bar and press enter.</li>
-  <li>Press the button "I'll be careful, I promise!"</li>
+  <li>Press the button "Accept the Risk and Continue"</li>
   <li>Follow the instructions below...</li>
 </ol>
 

--- a/_includes/sections/browser-tweaks.html
+++ b/_includes/sections/browser-tweaks.html
@@ -6,7 +6,7 @@
 
 <ol>
   <li>Enter "about:config" in the firefox address bar and press enter.</li>
-  <li>Press the button "I'll be careful, I promise!" or "Accept the Risk and Continue"</li>
+  <li>Press the button "Accept the Risk and Continue" [FF71+] or "I accept the risk".</li>
   <li>Follow the instructions below...</li>
 </ol>
 


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Button had been changed to "Accept the Risk and Continue" so I've updated that. More information at #1602

Resolves: https://github.com/privacytoolsIO/privacytools.io/issues/1532

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software