### PR TITLE
notebooks: link to Notable's homepage instead of GitHub

### DIFF
--- a/_includes/sections/notebooks.html
+++ b/_includes/sections/notebooks.html
@@ -60,7 +60,7 @@ chrome="https://chrome.google.com/webstore/detail/turtl/dgcojenhfdjhieoglmiaheih
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://github.com/notable/notable">Notable</a> - The markdown-based note-taking app that doesn't suck.</li>
+  <li><a href="https://notable.md/">Notable</a> - The markdown-based note-taking app that doesn't suck.</li>
   <li><a href="https://paperwork.cloud/">Paperwork</a> - An open-source and self-hosted solution. For PHP / MySQL servers.</li>
   <li><a href="https://orgmode.org">Org-mode</a> - A major mode for GNU Emacs. Org-mode is for keeping notes, maintaining TODO lists, planning projects, and authoring documents with a fast and effective plain-text system. </li>
 </ul>


### PR DESCRIPTION
## Description

I am looking for some sort of a todo list and happened to notice that we are linking to Notable's GitHub while they have a homepage.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

* Netlify preview for the mainly edited page: https://deploy-preview-1633--privacytools-io.netlify.com/software/notebooks/#notebook