### PR TITLE
No "high priority" tag for Website Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/5_Website_Issues.md
+++ b/.github/ISSUE_TEMPLATE/5_Website_Issues.md
@@ -2,7 +2,7 @@
 name: "🌐 Website Issue"
 about: Report an issue with the website.
 title: "🌐 Website Issue | "
-labels: 🌐 website issue, high priority
+labels: 🌐 website issue
 ---
 
 ## Description


### PR DESCRIPTION
This should just be applied on a case-by-case basis rather than as a label that external contributors cannot remove when creating an issue.