### PR TITLE
Remove star and update link for key disclosure laws for Belgium

### DIFF
--- a/_includes/sections/key-disclosure-law.html
+++ b/_includes/sections/key-disclosure-law.html
@@ -28,7 +28,7 @@
   title="Key disclosure laws may apply"
   body='
   <ol class="card-ol">
-    <li><a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Belgium">Belgium *</a> <div class="float-right"><span class="flag-icon flag-icon-be"></span></div></li>
+    <li><a href="https://tweakers.net/nieuws/163116/belgische-rechter-verdachte-mag-verplicht-worden-code-smartphone-af-te-staan.html">Belgium</a> <div class="float-right"><span class="flag-icon flag-icon-be"></span></div></li>
     <li><a href="https://www.riigiteataja.ee/akt/106012016019">Estonia</a> <div class="float-right"><span class="flag-icon flag-icon-ee"></span></div></li>
     <li><a href="https://en.wikipedia.org/wiki/Key_disclosure_law#Finland">Finland *</a> <div class="float-right"><span class="flag-icon flag-icon-fi"></span></div></li>
     <li><a href="https://en.wikipedia.org/wiki/Key_disclosure_law#New_Zealand">New Zealand</a> (unclear) <div class="float-right"><span class="flag-icon flag-icon-nz"></span></div></li>


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #1696

* Change link from https://en.wikipedia.org/wiki/Key_disclosure_law#Belgium to https://tweakers.net/nieuws/163116/belgische-rechter-verdachte-mag-verplicht-worden-code-smartphone-af-te-staan.html (the judgment supercedes the old law).
* Remove the star.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

* Netlify preview for the mainly edited page: https://deploy-preview-1700--privacytools-io.netlify.com/providers/#kdl
