### PR TITLE
Source code for IVPN now available

### DIFF
--- a/_includes/sections/vpn.html
+++ b/_includes/sections/vpn.html
@@ -83,8 +83,8 @@
     <p>We also think it's better for the security of the VPN provider's private keys if they use <a href="https://en.wikipedia.org/wiki/Dedicated_hosting_service">dedicated servers</a>, instead of cheaper shared solutions (with other customers) such as <a href="https://en.wikipedia.org/wiki/Virtual_private_server">virtual private servers</a>.</p>
     <h5><span class="badge badge-success">Independently Audited</span></h5>
     <p>IVPN has undergone a <a href="https://cure53.de/audit-report_ivpn.pdf">no-logging audit from Cure53</a> which concluded in agreement with IVPN's no-logging claim. IVPN has also completed a <a href="https://cure53.de/summary-report_ivpn_2019.pdf">comprehensive pentest report Cure53</a> in January 2020. IVPN has also said they plan to have <a href="https://www.ivpn.net/blog/independent-security-audit-concluded">annual reports</a> in the future.</p>
-    <h5><span class="badge badge-warning">Closed Source Clients</span></h5>
-    <p>The source code for the Windows, MacOS, iOS and Android apps is not available. Open source software would allow the community to verify the intended purpose.</p>
+    <h5><span class="badge badge-success">Open Source Clients</span></h5>
+    <p>As of Feburary 2020 <a href="https://www.ivpn.net/blog/ivpn-applications-are-now-open-source">IVPN applications are now open source</a>. Source code can be obtained from their <a href="https://github.com/ivpn">GitHub organization</a>.</p>
     <h5><span class="badge badge-success">Accepts Bitcoin</span></h5>
     <p>In addition to accepting credit/debit cards and PayPal, IVPN accepts <strong>Bitcoin</strong> and <strong>cash/local currency</strong> (on annual plans) as anonymous forms of payment.</p>
     <h5><span class="badge badge-success">Remote Port Forwarding</span></h5>

--- a/pages/providers/vpn.html
+++ b/pages/providers/vpn.html
@@ -55,6 +55,7 @@ breadcrumb: "VPN"
       <ul>
         <li>OpenVPN support.</li>
         <li>Killswitch built in to clients.</li>
+        <li>If VPN cients are provided, they should be <a href="https://en.wikipedia.org/wiki/Open_source">open source</a>, like the VPN software they generally have built into them. We believe that <a href="https://en.wikipedia.org/wiki/Source_code">source code</a> availability provides greater transparency to the user about what their device is actually doing. Ideally we like to see these applications <a href="https://www.f-droid.org/en/2019/05/05/trust-privacy-and-free-software.html">available in F-Droid</a>.</li>
       </ul>
     </div>
     <div class="col-md-6">
@@ -63,7 +64,6 @@ breadcrumb: "VPN"
         <li>OpenVPN and WireGuard support.</li>
         <li>Killswitch with highly configurable options (enable/disable on certain networks, on boot, etc.)</li>
         <li>Easy-to-use VPN clients</li>
-        <li>Clients are <a href="https://en.wikipedia.org/wiki/Open_source">open source</a>. We believe that <a href="https://en.wikipedia.org/wiki/Source_code">source code</a> availability provides greater transparency to the user about what their device is actually doing. Ideally we like to see these applications <a href="https://www.f-droid.org/en/2019/05/05/trust-privacy-and-free-software.html">available in F-Droid</a>.</li>
         <li>Supports <a href="https://en.wikipedia.org/wiki/IPv6">IPv6</a>. We expect that servers will allow incoming connections via IPv6 and allow users to access services hosted on IPv6 addresses.</li>
         <li>Capability of <a href="https://en.wikipedia.org/wiki/Port_forwarding#Remote_port_forwarding">remote port forwarding</a> assists in creating connections when using P2P (<a href="https://en.wikipedia.org/wiki/Peer-to-peer">Peer-to-Peer</a>) filesharing software, Freenet, or hosting a server (e.g., Mumble).</li>
       </ul>


### PR DESCRIPTION
https://deploy-preview-1705--privacytools-io.netlify.com/providers/vpn/

I've also updated the criteria to now require open source clients. These really are just wrappers around a VPN client which is already open source so there's no reason providers in the future that are added can't make sure they are open source.