### PR TITLE
add partial centralization warning for Jami

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -164,7 +164,7 @@
   title="Jami"
   image="/assets/img/svg/3rd-party/jami.svg"
   description="Encrypted instant messaging and video calling software. Uses <a href=//jami.net/improving-performance-and-security-with-tls-1-3/>TLS 1.3</a> for encryption."
-  labels="success:VoIP"
+  labels="warning:<a href=//git.jami.net/savoirfairelinux/ring-project/issues/765>Warning</a>:This software is partially centralized but can be self-hosted.|success:VoIP"
   website="https://jami.net/"
   forum="https://forum.privacytools.io/t/discussion-jami/2116"
   gitlab="https://git.jami.net/savoirfairelinux"

--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -163,7 +163,7 @@
   include cardv2.html
   title="Jami"
   image="/assets/img/svg/3rd-party/jami.svg"
-  description="Encrypted instant messaging and video calling software. All communications are fully end-to-end encrypted using <a href=//jami.net/improving-performance-and-security-with-tls-1-3/>TLS 1.3</a> and never stored elsewhere than on user's devices, even when <a href=//jami.net/why-is-jami-truly-distributed/>TURN servers are used</a>."
+  description="Encrypted instant messaging and video calling software. All communications are E2EE using <a href=//jami.net/improving-performance-and-security-with-tls-1-3/>TLS 1.3</a> and never stored elsewhere than on user's devices, even when <a href=//jami.net/why-is-jami-truly-distributed/>TURN servers are used</a>."
   labels="warning:<a href=//git.jami.net/savoirfairelinux/ring-project/issues/765>Warning</a>:This software is partially centralized but can be self-hosted.|success:VoIP"
   website="https://jami.net/"
   forum="https://forum.privacytools.io/t/discussion-jami/2116"

--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -163,7 +163,7 @@
   include cardv2.html
   title="Jami"
   image="/assets/img/svg/3rd-party/jami.svg"
-  description="Encrypted instant messaging and video calling software. Uses <a href=//jami.net/improving-performance-and-security-with-tls-1-3/>TLS 1.3</a> for encryption."
+  description="Encrypted instant messaging and video calling software. All communications are fully end-to-end encrypted using <a href=//jami.net/improving-performance-and-security-with-tls-1-3/>TLS 1.3</a> and never stored elsewhere than on user's devices, even when <a href=//jami.net/why-is-jami-truly-distributed/>TURN servers are used</a>."
   labels="warning:<a href=//git.jami.net/savoirfairelinux/ring-project/issues/765>Warning</a>:This software is partially centralized but can be self-hosted.|success:VoIP"
   website="https://jami.net/"
   forum="https://forum.privacytools.io/t/discussion-jami/2116"


### PR DESCRIPTION
#### Description

Resolves: #1727 <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->

Changes:
* Add label warning that Jami is partially centralized
* Extend description to mention all communications are end-to-end encrypted, including through TURN servers if used.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: https://deploy-preview-1752--privacytools-io.netlify.com/software/real-time-communication/#peer-to-peer
