### PR TITLE
Remove Sparkleshare from File Sync

### DIFF
--- a/_includes/sections/file-sync.html
+++ b/_includes/sections/file-sync.html
@@ -20,18 +20,6 @@
   googleplay="https://play.google.com/store/apps/details?id=com.github.catfriend1.syncthingandroid"
 %}
 
-{%
-  include cardv2.html
-  title="SparkleShare"
-  image="/assets/img/svg/3rd-party/sparkleshare.svg"
-  description="<strong>SparkleShare</strong> creates a special folder on your computer. You can add remotely hosted folders (or \"projects\") to this folder. These projects will be automatically kept in sync with both the host and all of your peers when someone adds, removes, or edits a file."
-  website="https://sparkleshare.org/"
-  forum="https://forum.privacytools.io/t/discussion-sparkleshare/1626"
-  github="https://github.com/hbons/SparkleShare"
-  linux="https://www.sparkleshare.org/"
-  mac="https://github.com/hbons/SparkleShare/releases/"
-%}
-
 <h3>Worth Mentioning</h3>
 
 <ul>


### PR DESCRIPTION
## Description

Resolves: #1309 

It seems that the project maintainer has moved onto working on FigmaSharp. There have only been 16 commits to Sparkleshare since the start of 2019: 3 in Jan19, 3 in May19, 4 in Jan20 and 6 in Feb20. Most of these commits are trivial changes (12 commits with under 10 changes each) to README or bumping version numbers. The "activity" at the start of this year was merging a pull request for Libravatar support. The Windows version is severely outdated and he doesn't care about maintaining it, [saying that the outdated version will be the last one](https://github.com/hbons/SparkleShare/issues/1909#issuecomment-526943216).

I think it is safe to say that this project is not maintained anymore. The question is whether that really matters. If the project was "feature-complete" as @dawidpotocki mentioned perhaps it wouldn't matter much, but as Windows users' only option is to use version 1.4, and **there have been ~5000 commits to master since then**, I wouldn't feel good about recommend Sparkleshare to users.

- Netlify preview for the mainly edited page: https://deploy-preview-1771--privacytools-io.netlify.com/software/file-sync/