### PR TITLE
Add link to CoC and correct Mastodon link on Participate section

### DIFF
--- a/_includes/sections/participate.html
+++ b/_includes/sections/participate.html
@@ -2,7 +2,7 @@
   <h1 id="participate" class="anchor"><a href="#participate"><i class="fas fa-link anchor-icon"></i></a> Participate with suggestions and constructive criticism</h1>
 </div>
 
-<p>It's important for a website like {{ site.name }} to stay up-to-date. Keep an eye on software updates for the applications listed on our site. Follow recent news about providers that we recommend. We try our best to keep up, but we're not perfect and the internet is changing fast. If you find an error, or you think a provider should not be listed here, or a qualified service provider is missing, or a browser plugin is not the best choice anymore, or anything else... <strong>Talk to us please.</strong> You can also find us on <a rel="me" href="https://social.privacytools.io/@privacytools">our own Mastodon instance</a> or on <a href="https://chat.privacytools.io">Matrix</a> at <code class="highlighter-rouge">#general:privacytools.io</code>.</p>
+<p>It's important for a website like {{ site.name }} to stay up-to-date. Keep an eye on software updates for the applications listed on our site. Follow recent news about providers that we recommend. We try our best to keep up, but we're not perfect and the internet is changing fast. If you find an error, or you think a provider should not be listed here, or a qualified service provider is missing, or a browser plugin is not the best choice anymore, or anything else... <strong>Talk to us please.</strong> You can also find us on <a href="https://chat.privacytools.io">Matrix</a> at <code class="highlighter-rouge">#general:privacytools.io</code>. When using our services, users should follow our <a href="https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct">Code of Conduct</a>.</p>
 
 <div class="row">
 
@@ -18,7 +18,7 @@
   {% include card.html color="primary"
   title="Follow on Mastodon & Twitter"
   image="/assets/img/svg/3rd-party/mastodon.svg"
-  url="https://social.privacytools.io/"
+  url="https://social.privacytools.io/@privacytools"
   website="Mastodon"
   extra_button='<a class="btn btn-primary mb-1" href="https://twitter.com/privacytoolsIO">Twitter</a>'
   description="Get the latest privacy-related updates from our Mastodon Feed. Follow us today!"


### PR DESCRIPTION
## Description

The link to Mastodon was pointing to the instance itself and not @privacytools. Users looking for our instance can find it on https://www.privacytools.io/services/. Removed the link for Mastodon that was in the paragraph above the button as it was a duplicate.

Resolves: #1371 

* Netlify preview for the mainly edited page: https://deploy-preview-1776--privacytools-io.netlify.com/index.html#participate