### PR TITLE
Fixed PR template broken link to CoC

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- PLEASE READ OUR CODE OF CONDUCT (https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->
+<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->
 
 ## Description
 


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

The link was broken since it was pointing to https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md instead of https://github.com/privacytoolsIO/.github/blob/master/CODE_OF_CONDUCT.md but on that version it explicitly says "_Please refer to the full text on our wiki when referencing this document._" so I changed the link to point to the CoC on the wiki instead.