### PR TITLE
remove bad vpn link

### DIFF
--- a/pages/providers/vpn.html
+++ b/pages/providers/vpn.html
@@ -230,7 +230,6 @@ breadcrumb: "VPN"
 
         <ul>
           <li><a href="https://vikingvpn.com/blogs/off-topic/beware-of-vpn-marketing-and-affiliate-programs">Beware of False Reviews - VPN Marketing and Affiliate Programs</a></li>
-          <li><a href="https://www.goldenfrog.com/take-back-your-internet/articles/7-myths-about-vpn-logging-and-anonymity">I am Anonymous When I Use a VPN - 7 Myths Debunked</a><br />(<strong>Note:</strong> While this is a good read, they also use the article for self-promotion)</li>
           <li><a href="https://torrentfreak.com/proxy-sh-vpn-provider-monitored-traffic-to-catch-hacker-130930/">Proxy.sh VPN Provider Sniffed Server Traffic to Catch Hacker</a></li>
           <li><a href="https://proxy.sh/panel/knowledgebase.php?action=displayarticle&id=5">Ethical policy - All of the reasons why Proxy.sh might enable logging</a></li>
           <li><a href="https://www.ivpn.net/privacy">IVPN.net will collect your email and IP address after sign up</a><br />Read the <a data-toggle="tooltip" data-placement="top" data-original-title="The IP collected at signup is only used for a few seconds by our fraud module and then discarded, it is not stored. Storing them would significantly increase our own liability and certainly would not be in our interest. You're absolutely welcome to signup using Tor or a VPN.">Email statement</a> from IVPN.</li>


### PR DESCRIPTION
removes a link on the vpn page which spread miss information about Tor.

<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #none <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->


* Netlify preview for the mainly edited page: https://deploy-preview-1798--privacytools-io.netlify.com/providers/vpn/


