### PR TITLE
Add privacy policy links to Search Engine cards

### DIFF
--- a/_includes/cardv2.html
+++ b/_includes/cardv2.html
@@ -69,6 +69,15 @@
           <i class="fas fa-external-link-alt fa-fw"></i>
           Website
         </a>
+        {% if include.privacy-policy %}
+        <a
+          href="{{include.privacy-policy}}"
+          rel="noopener"
+          class="btn btn-warning mt-1 mr-1">
+          <i class="fas fa-book fa-fw"></i>
+          Privacy Policy
+        </a>
+        {% endif %}
         {% if include.forum %}
           <a
             href="{{include.forum}}"

--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -1,7 +1,7 @@
 <h1 id="search" class="anchor"><a href="#search"><i class="fas fa-link anchor-icon"></i></a> Privacy Respecting Search Engines</h1>
 
 <div class="alert alert-warning" role="alert">
-  <strong> If you are currently using search engines like Google, Bing, or Yahoo, you should pick an alternative here.</strong>
+	<strong>If you are currently using search engines like Google, Bing, or Yahoo, you should pick an alternative here.</strong>
 </div>
 
 {%

--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -1,52 +1,45 @@
 <h1 id="search" class="anchor"><a href="#search"><i class="fas fa-link anchor-icon"></i></a> Privacy Respecting Search Engines</h1>
 
 <div class="alert alert-warning" role="alert">
-  <strong> If you are currently using search engines like Google, Bing, or Yahoo, you should pick an alternative here. </strong>
+  <strong> If you are currently using search engines like Google, Bing, or Yahoo, you should pick an alternative here.</strong>
 </div>
 
-{% include cardv2.html
-title="searx - Decentral"
-image="/assets/img/svg/3rd-party/searx.svg"
-description='searx is an <a href="https://github.com/asciimoo/searx">open-source</a> metasearch engine, aggregating the results of other search engines while not storing information about its users. No logs, no ads and no tracking. There is a <a href="https://searx.space/">list of public instances</a> or you can try the <a href="https://search.privacytools.io/">PrivacyTools instance</a>.'
-website="https://searx.me/"
-tor="http://ulrn6sryqaifefld.onion"
-forum="https://forum.privacytools.io/t/discussion-searx/283"
-github="https://github.com/asciimoo/searx"
+{%
+	include cardv2.html
+	title="Searx"
+	image="/assets/img/svg/3rd-party/searx.svg"
+	description='Searx is an <a href="https://github.com/asciimoo/searx">open-source</a>, self-hostable, metasearch engine, aggregating the results of other search engines while not storing information about its users. There is a <a href="https://searx.space/">list of public instances</a> or you can try the <a href="https://search.privacytools.io/">PrivacyTools instance</a>.'
+	website="https://searx.me/"
+	tor="http://ulrn6sryqaifefld.onion"
+	forum="https://forum.privacytools.io/t/discussion-searx/283"
+	github="https://github.com/asciimoo/searx"
 %}
 
-{% include cardv2.html
-title="DuckDuckGo - USA"
-image="/assets/img/svg/3rd-party/duckduckgo.svg"
-description='DuckDuckGo is a "search engine that doesn\'t track you." Some of DuckDuckGo\'s code is free software hosted at GitHub, but the core is proprietary. <span class="flag-icon flag-icon-us"></span> <a href="../../providers/#ukusa">The company is based in the USA.</a>'
-website="https://duckduckgo.com/"
-tor="http://3g2upl4pq6kufc4m.onion"
-forum="https://forum.privacytools.io/t/discussion-duckduckgo/285"
-github="https://github.com/duckduckgo"
+{%
+	include cardv2.html
+	title="DuckDuckGo"
+	image="/assets/img/svg/3rd-party/duckduckgo.svg"
+	description='DuckDuckGo is a "search engine that doesn\'t track you." Some of DuckDuckGo\'s code is free software hosted at GitHub, but the core is proprietary. <span class="flag-icon flag-icon-us"></span> <a href="../../providers/#ukusa">The company is based in the USA.</a>'
+	website="https://duckduckgo.com/"
+	tor="http://3g2upl4pq6kufc4m.onion"
+	forum="https://forum.privacytools.io/t/discussion-duckduckgo/285"
+	github="https://github.com/duckduckgo"
 %}
 
-{% include cardv2.html
-title="Qwant - France"
-image="/assets/img/svg/3rd-party/qwant.svg"
-description='Qwant is a search engine with its philosophy based on two principles: no user tracking and no filter bubble. Qwant was launched in France in February 2013.'
-website="https://www.qwant.com/"
-forum="https://forum.privacytools.io/t/discussion-qwant/286"
-github="https://github.com/Qwant/"
+{%
+	include cardv2.html
+	title="Qwant"
+	image="/assets/img/svg/3rd-party/qwant.svg"
+	description='Qwant is a search engine with its philosophy based on two principles: no user tracking and no filter bubble. <span class="flag-icon flag-icon-fr"></span> <a href="../../providers/#ukusa">The company is based in France.</a>'
+	website="https://www.qwant.com/"
+	forum="https://forum.privacytools.io/t/discussion-qwant/286"
+	github="https://github.com/Qwant/"
 %}
-
-
-<h3>Firefox Addon</h3>
-
-<ul>
-  <li>
-    <a href="https://addons.mozilla.org/firefox/addon/google-search-link-fix/">Google search link fix</a> - Firefox extension that prevents Google and Yandex search pages from modifying search result links when you click them. This is useful when
-    copying links but it also helps privacy by preventing the search engines from recording your clicks. (<a href="https://github.com/palant/searchlinkfix">Open Source</a>)
-  </li>
-</ul>
 
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://yacy.net/">YaCy</a> - A free-software P2P search engine powered by its users.</li>
-  <li><a href="https://metager.de/en/">MetaGer</a> - An open-source metasearch engine, which is based in Germany. It focuses on protecting the user's privacy.</li>
-  <li><a href="https://www.mojeek.com/">Mojeek</a> - Independent and unbiased search results with no user tracking.</li>
+	<li><a href="https://metager.org/">MetaGer</a> - An <a href="https://gitlab.metager.de/open-source/MetaGer">open-source</a> metasearch engine run as a non-profit based in Germany.</li>
+	<li><a href="https://www.mojeek.com/">Mojeek</a> - An independent search engine based in the UK and the <a href="https://blog.mojeek.com/2018/10/search-that-does-not-follow-you-around.html">first search engine to have a policy of not tracking its users.</a></li>
+	<li><a href="https://yacy.net/">YaCy</a> - A free-software P2P search engine powered by its users.</li>
 </ul>

--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -21,6 +21,7 @@
 	image="/assets/img/svg/3rd-party/duckduckgo.svg"
 	description='DuckDuckGo is a "search engine that doesn\'t track you." Some of DuckDuckGo\'s code is free software hosted at GitHub, but the core is proprietary. <span class="flag-icon flag-icon-us"></span> <a href="../../providers/#ukusa">The company is based in the USA.</a>'
 	website="https://duckduckgo.com/"
+	privacy-policy="https://duckduckgo.com/privacy"
 	tor="http://3g2upl4pq6kufc4m.onion"
 	forum="https://forum.privacytools.io/t/discussion-duckduckgo/285"
 	github="https://github.com/duckduckgo"
@@ -32,6 +33,7 @@
 	image="/assets/img/svg/3rd-party/qwant.svg"
 	description='Qwant is a search engine with its philosophy based on two principles: no user tracking and no filter bubble. <span class="flag-icon flag-icon-fr"></span> <a href="../../providers/#ukusa">The company is based in France.</a>'
 	website="https://www.qwant.com/"
+	privacy-policy="https://about.qwant.com/legal/privacy/"
 	forum="https://forum.privacytools.io/t/discussion-qwant/286"
 	github="https://github.com/Qwant/"
 %}

--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -1,47 +1,47 @@
 <h1 id="search" class="anchor"><a href="#search"><i class="fas fa-link anchor-icon"></i></a> Privacy Respecting Search Engines</h1>
 
 <div class="alert alert-warning" role="alert">
-	<strong>If you are currently using search engines like Google, Bing, or Yahoo, you should pick an alternative here.</strong>
+  <strong>If you are currently using search engines like Google, Bing, or Yahoo, you should pick an alternative here.</strong>
 </div>
 
 {%
-	include cardv2.html
-	title="Searx"
-	image="/assets/img/svg/3rd-party/searx.svg"
-	description='Searx is an <a href="https://github.com/asciimoo/searx">open-source</a>, self-hostable, metasearch engine, aggregating the results of other search engines while not storing information about its users. There is a <a href="https://searx.space/">list of public instances</a> or you can try the <a href="https://search.privacytools.io/">PrivacyTools instance</a>.'
-	website="https://searx.me/"
-	tor="http://ulrn6sryqaifefld.onion"
-	forum="https://forum.privacytools.io/t/discussion-searx/283"
-	github="https://github.com/asciimoo/searx"
+include cardv2.html
+title="Searx"
+image="/assets/img/svg/3rd-party/searx.svg"
+description='Searx is an <a href="https://github.com/asciimoo/searx">open-source</a>, self-hostable, metasearch engine, aggregating the results of other search engines while not storing information about its users. There is a <a href="https://searx.space/">list of public instances</a> or you can try the <a href="https://search.privacytools.io/">PrivacyTools instance</a>.'
+website="https://searx.me/"
+tor="http://ulrn6sryqaifefld.onion"
+forum="https://forum.privacytools.io/t/discussion-searx/283"
+github="https://github.com/asciimoo/searx"
 %}
 
 {%
-	include cardv2.html
-	title="DuckDuckGo"
-	image="/assets/img/svg/3rd-party/duckduckgo.svg"
-	description='DuckDuckGo is a "search engine that doesn\'t track you." Some of DuckDuckGo\'s code is free software hosted at GitHub, but the core is proprietary. <span class="flag-icon flag-icon-us"></span> <a href="../../providers/#ukusa">The company is based in the USA.</a>'
-	website="https://duckduckgo.com/"
-	privacy-policy="https://duckduckgo.com/privacy"
-	tor="http://3g2upl4pq6kufc4m.onion"
-	forum="https://forum.privacytools.io/t/discussion-duckduckgo/285"
-	github="https://github.com/duckduckgo"
+include cardv2.html
+title="DuckDuckGo"
+image="/assets/img/svg/3rd-party/duckduckgo.svg"
+description='DuckDuckGo is a "search engine that doesn\'t track you." Some of DuckDuckGo\'s code is free software hosted at GitHub, but the core is proprietary. <span class="flag-icon flag-icon-us"></span> <a href="../../providers/#ukusa">The company is based in the USA.</a>'
+website="https://duckduckgo.com/"
+privacy-policy="https://duckduckgo.com/privacy"
+tor="http://3g2upl4pq6kufc4m.onion"
+forum="https://forum.privacytools.io/t/discussion-duckduckgo/285"
+github="https://github.com/duckduckgo"
 %}
 
 {%
-	include cardv2.html
-	title="Qwant"
-	image="/assets/img/svg/3rd-party/qwant.svg"
-	description='Qwant is a search engine with its philosophy based on two principles: no user tracking and no filter bubble. <span class="flag-icon flag-icon-fr"></span> <a href="../../providers/#ukusa">The company is based in France.</a>'
-	website="https://www.qwant.com/"
-	privacy-policy="https://about.qwant.com/legal/privacy/"
-	forum="https://forum.privacytools.io/t/discussion-qwant/286"
-	github="https://github.com/Qwant/"
+include cardv2.html
+title="Qwant"
+image="/assets/img/svg/3rd-party/qwant.svg"
+description='Qwant is a search engine with its philosophy based on two principles: no user tracking and no filter bubble. <span class="flag-icon flag-icon-fr"></span> <a href="../../providers/#ukusa">The company is based in France.</a>'
+website="https://www.qwant.com/"
+privacy-policy="https://about.qwant.com/legal/privacy/"
+forum="https://forum.privacytools.io/t/discussion-qwant/286"
+github="https://github.com/Qwant/"
 %}
 
 <h3>Worth Mentioning</h3>
 
 <ul>
-	<li><a href="https://metager.org/">MetaGer</a> - An <a href="https://gitlab.metager.de/open-source/MetaGer">open-source</a>, metasearch engine run as a non-profit based in Germany.</li>
-	<li><a href="https://www.mojeek.com/">Mojeek</a> - An independent search engine based in the UK, and the <a href="https://blog.mojeek.com/2018/10/search-that-does-not-follow-you-around.html">first search engine to have a policy of not tracking its users.</a></li>
-	<li><a href="https://yacy.net/">YaCy</a> - An <a href="https://github.com/yacy/yacy_search_server">open-source</a>, peer-to-peer search engine powered by its users.</li>
+  <li><a href="https://metager.org/">MetaGer</a> - An <a href="https://gitlab.metager.de/open-source/MetaGer">open-source</a>, metasearch engine run as a non-profit based in Germany.</li>
+  <li><a href="https://www.mojeek.com/">Mojeek</a> - An independent search engine based in the UK, and the <a href="https://blog.mojeek.com/2018/10/search-that-does-not-follow-you-around.html">first search engine to have a policy of not tracking its users.</a></li>
+  <li><a href="https://yacy.net/">YaCy</a> - An <a href="https://github.com/yacy/yacy_search_server">open-source</a>, peer-to-peer search engine powered by its users.</li>
 </ul>

--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -41,7 +41,7 @@
 <h3>Worth Mentioning</h3>
 
 <ul>
-	<li><a href="https://metager.org/">MetaGer</a> - An <a href="https://gitlab.metager.de/open-source/MetaGer">open-source</a> metasearch engine run as a non-profit based in Germany.</li>
-	<li><a href="https://www.mojeek.com/">Mojeek</a> - An independent search engine based in the UK and the <a href="https://blog.mojeek.com/2018/10/search-that-does-not-follow-you-around.html">first search engine to have a policy of not tracking its users.</a></li>
-	<li><a href="https://yacy.net/">YaCy</a> - A free-software P2P search engine powered by its users.</li>
+	<li><a href="https://metager.org/">MetaGer</a> - An <a href="https://gitlab.metager.de/open-source/MetaGer">open-source</a>, metasearch engine run as a non-profit based in Germany.</li>
+	<li><a href="https://www.mojeek.com/">Mojeek</a> - An independent search engine based in the UK, and the <a href="https://blog.mojeek.com/2018/10/search-that-does-not-follow-you-around.html">first search engine to have a policy of not tracking its users.</a></li>
+	<li><a href="https://yacy.net/">YaCy</a> - An <a href="https://github.com/yacy/yacy_search_server">open-source</a>, peer-to-peer search engine powered by its users.</li>
 </ul>

--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -41,7 +41,7 @@ github="https://github.com/Qwant/"
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://metager.org/">MetaGer</a> - An <a href="https://gitlab.metager.de/open-source/MetaGer">open-source</a>, metasearch engine run as a non-profit based in Germany.</li>
-  <li><a href="https://www.mojeek.com/">Mojeek</a> - An independent search engine based in the UK, and the <a href="https://blog.mojeek.com/2018/10/search-that-does-not-follow-you-around.html">first search engine to have a policy of not tracking its users.</a></li>
+  <li><a href="https://metager.org/">MetaGer</a> - An <a href="https://gitlab.metager.de/open-source/MetaGer">open-source</a>, metasearch engine run as a non-profit based in Germany. (<a href="https://metager.org/datenschutz">Privacy Policy</a>)</li>
+  <li><a href="https://www.mojeek.com/">Mojeek</a> - An independent search engine based in the UK, and the <a href="https://blog.mojeek.com/2018/10/search-that-does-not-follow-you-around.html">first search engine to have a policy of not tracking its users.</a> (<a href="https://www.mojeek.com/about/privacy/">Privacy Policy</a>)</li>
   <li><a href="https://yacy.net/">YaCy</a> - An <a href="https://github.com/yacy/yacy_search_server">open-source</a>, peer-to-peer search engine powered by its users.</li>
 </ul>


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

This MR cleans up the search engine page a bit by updating some descriptions for clarity and consistency along with adding a new Cardv2 link for a privacy policy button to add to the DuckDuckGo and Qwant cards.

The Google Search WebExtension for Firefox has also been removed since usage of Google conflicts with our warning banner to avoid using Google/Bing/Yahoo.

* Netlify preview for the mainly edited page: https://deploy-preview-1844--privacytools-io.netlify.app/providers/search-engines/#search

Dependent PR:
- [x] https://github.com/privacytoolsIO/privacytools.io/pull/1849