### PR TITLE
Update cardv2 for mobile layouts

### DIFF
--- a/_includes/cardv2.html
+++ b/_includes/cardv2.html
@@ -61,7 +61,7 @@
       {% endif %}
     </p>
     <div class="d-flex justify-content-between flex-column flex-md-row align-items-start align-items-md-center">
-      <div class="d-flex flex-shrink-0 mr-1">
+      <div class="flow-root flex-shrink-0 mr-1">
         <a
           href="{{include.website}}"
           rel="noopener"
@@ -82,7 +82,7 @@
           <a
             href="{{include.tor}}"
             rel="noopener"
-            class="hover-text-decoration-none mt-1 mr-1"
+            class="btn icon-btn hover-text-decoration-none mt-1 mr-1"
             data-toggle="tooltip"
             data-placement="bottom"
             data-original-title="Requires specific software to access: torproject.org">
@@ -93,7 +93,7 @@
           <a
             href="{{include.i2p}}"
             rel="noopener"
-            class="hover-text-decoration-none mt-1 mr-1"
+            class="btn icon-btn hover-text-decoration-none mt-1 mr-1"
             data-toggle="tooltip"
             data-placement="bottom"
             data-original-title="Requires specific software to access: geti2p.net">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -219,7 +219,13 @@ h2, h3:not(.h5), h4, h5 {
   background: darken($tor, 5%);
 }
 
+.icon-btn {
+  padding: 0px;
+}
 
+.flow-root {
+  display: flow-root;
+}
 
 /*
  * Bootstrap 4.2+ features


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

This MR attempts to update v2 cards to be more mobile friendly; specifically letting the card buttons flex. Also will allow more buttons to fit in the future (for example, the Qwant card below adds a "Privacy Policy" button).

Netlify: https://deploy-preview-1849--privacytools-io.netlify.app/

Resolves: #none <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->

### Example 1

![change-1](https://user-images.githubusercontent.com/1514352/79936588-60374200-8447-11ea-8c19-5cb3c2787b99.png)

#### Before

![before-3](https://user-images.githubusercontent.com/1514352/79936605-6af1d700-8447-11ea-8b7b-e409ada2249e.png)

#### After

![change-3](https://user-images.githubusercontent.com/1514352/79936621-747b3f00-8447-11ea-82a6-1741f84e4943.png)

### Example 2

![q-before-1](https://user-images.githubusercontent.com/1514352/79936692-9d033900-8447-11ea-8097-68c72245c57e.png)

#### Before

![q-before-2](https://user-images.githubusercontent.com/1514352/79936705-a2608380-8447-11ea-9d9a-86468b4db9b9.png)

![q-before-3](https://user-images.githubusercontent.com/1514352/79936717-a7253780-8447-11ea-913a-9d3979ac70d3.png)

#### After

![q-after-2](https://user-images.githubusercontent.com/1514352/79936734-af7d7280-8447-11ea-9ba9-54de68cbed07.png)

![q-after-3](https://user-images.githubusercontent.com/1514352/79936744-b2786300-8447-11ea-9db2-cc5402fb4232.png)

![q-after-4](https://user-images.githubusercontent.com/1514352/79936754-b73d1700-8447-11ea-8d62-5488d29679a7.png)