### PR TITLE
Updated VSCodium description to remove mention of fork

### DIFF
--- a/_includes/sections/productivity-tools.html
+++ b/_includes/sections/productivity-tools.html
@@ -56,7 +56,7 @@
   <li><a href="https://dudle.inf.tu-dresden.de/anonymous/">dudle</a> - An online scheduling application, free and open-source. Schedule meetings or make small online polls. No email collection or the need of registration.</li>
   <li><a href="https://framadate.org/">Framadate</a> - A free and open-source online service for planning an appointment or making a decision quickly and easily. No registration is required.</li>
   <li><a href="https://www.libreoffice.org/">LibreOffice</a> - Free and open-source office suite.</li>
-  <li><a href="https://vscodium.com/">VSCodium</a> - Fork of Microsoft's Visual Studio Code editor without branding or telemetry.</li>
+  <li><a href="https://vscodium.com/">VSCodium</a> - Scripts to automatically build Microsoft's Visual Studio Code editor without branding or telemetry.</li>
 </ul>
 
 <h1 id="metadata-removal-tools" class="anchor">


### PR DESCRIPTION
Reworded the worth mentioning recommendation of VSCodium to remove calling it a fork. The VSCodium GitHub site clearly states "this is not a fork."

Resolves: #1845 

https://deploy-preview-1855--privacytools-io.netlify.app/software/productivity/