### PR TITLE
Add privacy policy links to Social News Aggregator cards

### DIFF
--- a/_includes/cardv2.html
+++ b/_includes/cardv2.html
@@ -69,6 +69,15 @@
           <i class="fas fa-external-link-alt fa-fw"></i>
           Website
         </a>
+        {% if include.privacy-policy %}
+        <a
+          href="{{include.privacy-policy}}"
+          rel="noopener"
+          class="btn btn-warning mt-1 mr-1">
+          <i class="fas fa-book fa-fw"></i>
+          Privacy Policy
+        </a>
+        {% endif %}
         {% if include.forum %}
           <a
             href="{{include.forum}}"

--- a/_includes/sections/social-news-aggregator.html
+++ b/_includes/sections/social-news-aggregator.html
@@ -1,48 +1,48 @@
 <h1 id="obb" class="anchor"><a href="#social-news-aggregator"><i class="fas fa-link anchor-icon"></i></a> Social News Aggregators</h1>
 
 <div class="alert alert-warning" role="alert">
-	<strong>If you are currently using a online bulletin board like Reddit, you should pick an alternative here.</strong>
+  <strong>If you are currently using a online bulletin board like Reddit, you should pick an alternative here.</strong>
 </div>
 
 {% include cardv2.html
-	title="Aether"
-	image="/assets/img/svg/3rd-party/aether.svg"
-	description='<a href="https://github.com/nehbit/aether/blob/master/LICENSE.md">Aether is a free and open-source</a> decentralized social news aggregator with a built-in voting system.'
-	website="https://getaether.net/"
-	privacy-policy="https://getaether.net/privacypolicy/"
-	forum="https://forum.privacytools.io/t/discussion-aether/1256"
-	github="https://github.com/nehbit/aether"
-	windows="https://getaether.net/download/"
-	mac="https://getaether.net/download/"
-	linux="https://getaether.net/download/"
+title="Aether"
+image="/assets/img/svg/3rd-party/aether.svg"
+description='<a href="https://github.com/nehbit/aether/blob/master/LICENSE.md">Aether is a free and open-source</a> decentralized social news aggregator with a built-in voting system.'
+website="https://getaether.net/"
+privacy-policy="https://getaether.net/privacypolicy/"
+forum="https://forum.privacytools.io/t/discussion-aether/1256"
+github="https://github.com/nehbit/aether"
+windows="https://getaether.net/download/"
+mac="https://getaether.net/download/"
+linux="https://getaether.net/download/"
 %}
 
 {% include cardv2.html
-	title="Tildes"
-	image="/assets/img/svg/3rd-party/tildes.svg"
-	description='Tildes is a web-based self-hostable online bulletin board. It is licensed under <a href="https://gitlab.com/tildes/tildes/blob/master/LICENSE">GPL 3.0</a>.'
-	website="https://tildes.net"
-	privacy-policy="https://docs.tildes.net/policies/privacy-policy"
-	forum="https://forum.privacytools.io/t/discussion-tildes/1257"
-	gitlab="https://gitlab.com/tildes/tildes"
-	web="https://tildes.net"
+title="Tildes"
+image="/assets/img/svg/3rd-party/tildes.svg"
+description='Tildes is a web-based self-hostable online bulletin board. It is licensed under <a href="https://gitlab.com/tildes/tildes/blob/master/LICENSE">GPL 3.0</a>.'
+website="https://tildes.net"
+privacy-policy="https://docs.tildes.net/policies/privacy-policy"
+forum="https://forum.privacytools.io/t/discussion-tildes/1257"
+gitlab="https://gitlab.com/tildes/tildes"
+web="https://tildes.net"
 %}
 
 {% include cardv2.html
-	title="Raddle"
-	image="/assets/img/png/3rd-party/raddle.png"
-	description="Raddle is a public Postmill instance focused on privacy and anti-censorship."
-	website="https://raddle.me"
-	privacy-policy="https://raddle.me/wiki/privacy_policy"
-	forum="https://forum.privacytools.io/t/discussion-raddle/1258"
-	gitlab="https://gitlab.com/postmill/"
-	web="https://raddle.me"
+title="Raddle"
+image="/assets/img/png/3rd-party/raddle.png"
+description="Raddle is a public Postmill instance focused on privacy and anti-censorship."
+website="https://raddle.me"
+privacy-policy="https://raddle.me/wiki/privacy_policy"
+forum="https://forum.privacytools.io/t/discussion-raddle/1258"
+gitlab="https://gitlab.com/postmill/"
+web="https://raddle.me"
 %}
 
 <h3>Worth Mentioning</h3>
 
 <ul>
-	<li><a href="https://beta.akasha.world/">Akasha</a> - A decentralized online bulletin board using <a href="https://www.wikipedia.org/wiki/InterPlanetary_File_System">IPFS</a> and <a href="https://www.wikipedia.org/wiki/Ethereum">Ethereum</a>.</li>
-	<li><a href="https://dev.lemmy.ml/">Lemmy</a> - An <a href="https://github.com/dessalines/lemmy/blob/master/LICENSE">AGPL</a>-licensed self-hostable link aggregator intended to work in the <a href="https://www.wikipedia.org/wiki/Fediverse">Fediverse</a>.</li>
-	<li><a href="https://notabug.io/">notabug.io</a> - A <a href="https://github.com/notabugio/notabug/blob/master/LICENSE.md">free and open-source</a> P2P link aggregator with a strong resemblance to old.reddit.com (not to be confused with <a href="https://notabug.org/">NotABug.org</a>).</li>
+  <li><a href="https://beta.akasha.world/">Akasha</a> - A decentralized online bulletin board using <a href="https://www.wikipedia.org/wiki/InterPlanetary_File_System">IPFS</a> and <a href="https://www.wikipedia.org/wiki/Ethereum">Ethereum</a>.</li>
+  <li><a href="https://dev.lemmy.ml/">Lemmy</a> - An <a href="https://github.com/dessalines/lemmy/blob/master/LICENSE">AGPL</a>-licensed self-hostable link aggregator intended to work in the <a href="https://www.wikipedia.org/wiki/Fediverse">Fediverse</a>.</li>
+  <li><a href="https://notabug.io/">notabug.io</a> - A <a href="https://github.com/notabugio/notabug/blob/master/LICENSE.md">free and open-source</a> P2P link aggregator with a strong resemblance to old.reddit.com (not to be confused with <a href="https://notabug.org/">NotABug.org</a>).</li>
 </ul>

--- a/_includes/sections/social-news-aggregator.html
+++ b/_includes/sections/social-news-aggregator.html
@@ -1,45 +1,48 @@
 <h1 id="obb" class="anchor"><a href="#social-news-aggregator"><i class="fas fa-link anchor-icon"></i></a> Social News Aggregators</h1>
 
 <div class="alert alert-warning" role="alert">
-  <strong>If you are currently using a online bulletin board like Reddit, you should pick an alternative here.</strong>
+	<strong>If you are currently using a online bulletin board like Reddit, you should pick an alternative here.</strong>
 </div>
 
 {% include cardv2.html
-title="Aether"
-image="/assets/img/svg/3rd-party/aether.svg"
-description='<a href="https://github.com/nehbit/aether/blob/master/LICENSE.md">Aether is a free and open-source</a> decentralized social news aggregator with a built-in voting system.'
-website="https://getaether.net/"
-forum="https://forum.privacytools.io/t/discussion-aether/1256"
-github="https://github.com/nehbit/aether"
-windows="https://getaether.net/download/"
-mac="https://getaether.net/download/"
-linux="https://getaether.net/download/"
+	title="Aether"
+	image="/assets/img/svg/3rd-party/aether.svg"
+	description='<a href="https://github.com/nehbit/aether/blob/master/LICENSE.md">Aether is a free and open-source</a> decentralized social news aggregator with a built-in voting system.'
+	website="https://getaether.net/"
+	privacy-policy="https://getaether.net/privacypolicy/"
+	forum="https://forum.privacytools.io/t/discussion-aether/1256"
+	github="https://github.com/nehbit/aether"
+	windows="https://getaether.net/download/"
+	mac="https://getaether.net/download/"
+	linux="https://getaether.net/download/"
 %}
 
 {% include cardv2.html
-title="Tildes"
-image="/assets/img/svg/3rd-party/tildes.svg"
-description='Tildes is a web-based self-hostable online bulletin board. It is licensed under <a href="https://gitlab.com/tildes/tildes/blob/master/LICENSE">GPL 3.0</a>.'
-website="https://tildes.net"
-forum="https://forum.privacytools.io/t/discussion-tildes/1257"
-gitlab="https://gitlab.com/tildes/tildes"
-web="https://tildes.net"
+	title="Tildes"
+	image="/assets/img/svg/3rd-party/tildes.svg"
+	description='Tildes is a web-based self-hostable online bulletin board. It is licensed under <a href="https://gitlab.com/tildes/tildes/blob/master/LICENSE">GPL 3.0</a>.'
+	website="https://tildes.net"
+	privacy-policy="https://docs.tildes.net/policies/privacy-policy"
+	forum="https://forum.privacytools.io/t/discussion-tildes/1257"
+	gitlab="https://gitlab.com/tildes/tildes"
+	web="https://tildes.net"
 %}
 
 {% include cardv2.html
-title="Raddle"
-image="/assets/img/png/3rd-party/raddle.png"
-description="Raddle is a public Postmill instance focused on privacy and anti-censorship."
-website="https://raddle.me"
-forum="https://forum.privacytools.io/t/discussion-raddle/1258"
-gitlab="https://gitlab.com/postmill/"
-web="https://raddle.me"
+	title="Raddle"
+	image="/assets/img/png/3rd-party/raddle.png"
+	description="Raddle is a public Postmill instance focused on privacy and anti-censorship."
+	website="https://raddle.me"
+	privacy-policy="https://raddle.me/wiki/privacy_policy"
+	forum="https://forum.privacytools.io/t/discussion-raddle/1258"
+	gitlab="https://gitlab.com/postmill/"
+	web="https://raddle.me"
 %}
 
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://beta.akasha.world/">Akasha</a> - A decentralized online bulletin board using <a href="https://www.wikipedia.org/wiki/InterPlanetary_File_System">IPFS</a> and <a href="https://www.wikipedia.org/wiki/Ethereum">Ethereum</a>.</li>
-  <li><a href="https://dev.lemmy.ml/">Lemmy</a> - An <a href="https://github.com/dessalines/lemmy/blob/master/LICENSE">AGPL</a>-licensed self-hostable link aggregator intended to work in the <a href="https://www.wikipedia.org/wiki/Fediverse">Fediverse</a>.</li>
-  <li><a href="https://notabug.io/">notabug.io</a> - A <a href="https://github.com/notabugio/notabug/blob/master/LICENSE.md">free and open-source</a> P2P link aggregator with a strong resemblance to old.reddit.com (not to be confused with <a href="https://notabug.org/">NotABug.org</a>).</li>
+	<li><a href="https://beta.akasha.world/">Akasha</a> - A decentralized online bulletin board using <a href="https://www.wikipedia.org/wiki/InterPlanetary_File_System">IPFS</a> and <a href="https://www.wikipedia.org/wiki/Ethereum">Ethereum</a>.</li>
+	<li><a href="https://dev.lemmy.ml/">Lemmy</a> - An <a href="https://github.com/dessalines/lemmy/blob/master/LICENSE">AGPL</a>-licensed self-hostable link aggregator intended to work in the <a href="https://www.wikipedia.org/wiki/Fediverse">Fediverse</a>.</li>
+	<li><a href="https://notabug.io/">notabug.io</a> - A <a href="https://github.com/notabugio/notabug/blob/master/LICENSE.md">free and open-source</a> P2P link aggregator with a strong resemblance to old.reddit.com (not to be confused with <a href="https://notabug.org/">NotABug.org</a>).</li>
 </ul>


### PR DESCRIPTION
This MR adds privacy policy links to the Social News Aggregator cards for easier reference.

Netlify preview for the mainly edited page: https://deploy-preview-1857--privacytools-io.netlify.app/providers/social-news-aggregator/
