### PR TITLE
Add privacy policy links for OS pages

### DIFF
--- a/_includes/sections/mobile-operating-systems.html
+++ b/_includes/sections/mobile-operating-systems.html
@@ -22,6 +22,7 @@ description='LineageOS is a free and open-source operating system for smartphone
 badges="info:AOSP"
 labels="warning:contrib:This software may depend on or recommend non-free software."
 website="https://www.lineageos.org/"
+privacy-policy="https://www.lineageos.org/legal/"
 github="https://github.com/LineageOS"
 %}
 
@@ -32,6 +33,7 @@ description="Ubuntu Touch is a free and open-source operating system for smartph
 badges="info:GNU/Linux"
 labels="warning:contrib:This software may depend on or recommend non-free software."
 website="https://ubuntu-touch.io/"
+privacy-policy="https://ubports.com/privacy"
 github="https://github.com/ubports"
 %}
 

--- a/_includes/sections/operating-systems.html
+++ b/_includes/sections/operating-systems.html
@@ -11,6 +11,7 @@ description='Qubes is an open-source operating system designed to provide strong
 badges="info:Xen"
 labels="warning:contrib:This software may depend on or recommend non-free software."
 website="https://www.qubes-os.org/"
+privacy-policy="https://www.qubes-os.org/privacy/"
 github="https://github.com/QubesOS"
 tor="http://qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion/"
 %}
@@ -22,6 +23,7 @@ description='Fedora is a Linux distribution developed by the Fedora Project and 
 badges="info:GNU/Linux"
 labels="warning:contrib:This software may depend on or recommend non-free software."
 website="https://getfedora.org/"
+privacy-policy="https://fedoraproject.org/wiki/Legal:PrivacyPolicy?rd=Legal/PrivacyPolicy"
 git="https://src.fedoraproject.org/"
 %}
 
@@ -31,6 +33,7 @@ image="/assets/img/svg/3rd-party/debian.svg"
 description='Debian is a Unix-like computer operating system and a Linux distribution that is composed entirely of free and open-source software, most of which is under the GNU General Public License, and packaged by a group of individuals known as the Debian project.'
 badges="info:GNU/Linux"
 website="https://www.debian.org/"
+privacy-policy="https://www.debian.org/legal/privacy"
 tor="http://sejnfjrq6szgca7v.onion"
 gitlab="https://salsa.debian.org/qa/debsources"
 %}

--- a/_includes/sections/router-firmware.html
+++ b/_includes/sections/router-firmware.html
@@ -19,6 +19,7 @@ description="pfSense is an open source firewall/router computer software distrib
 badges="info:BSD"
 labels="warning:contrib:This software may depend on or recommend non-free software."
 website="https://www.pfsense.org/"
+privacy-policy="https://www.pfsense.org/privacy.html"
 github="https://github.com/pfsense/"
 %}
 


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytoolsIO/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Adds links to available privacy policies in the OS pages.

* Netlify preview for the mainly edited page: <!-- link or Non Applicable? Edit this in afterwards --> https://deploy-preview-1862--privacytools-io.netlify.app/operating-systems/#os