### PR TITLE
Update Startpage.com Listing

### DIFF
--- a/_includes/sections/search-engines.html
+++ b/_includes/sections/search-engines.html
@@ -27,16 +27,6 @@ forum="https://forum.privacytools.io/t/discussion-duckduckgo/285"
 github="https://github.com/duckduckgo"
 %}
 
-{% include cardv2.html
-title="StartPage"
-image="/assets/img/svg/3rd-party/startpage.svg"
-description='StartPage is a search engine that provides Google search results with complete privacy protection. <span class="flag-icon flag-icon-nl"></span> Behind StartPage is a European company based in the Netherlands that has been obsessive about privacy since 2006.'
-labels="warning:<a href=//support.startpage.com/index.php?/Knowledgebase/Article/View/1277/0/startpage-ceo-robert-beens-discusses-the-investment-from-privacy-one--system1>Warning</a>:StartPage was recently acquired by an advertising company."
-website="https://www.startpage.com/"
-privacy-policy="https://www.startpage.com/en/privacy-policy/"
-forum="https://forum.privacytools.io/t/delisted-discussion-startpage/284"
-%}
-
 {%
 include cardv2.html
 title="Qwant"
@@ -46,6 +36,16 @@ website="https://www.qwant.com/"
 privacy-policy="https://about.qwant.com/legal/privacy/"
 forum="https://forum.privacytools.io/t/discussion-qwant/286"
 github="https://github.com/Qwant/"
+%}
+
+{% include cardv2.html
+title="Startpage.com"
+image="/assets/img/svg/3rd-party/startpage.svg"
+description='Startpage.com is a search engine that provides Google search results with complete privacy protection. <span class="flag-icon flag-icon-nl"></span> Startpage BV is a Netherlands-based company that has been dedicated to privacy-respecting search since 2006.'
+labels="warning:<a href=//support.startpage.com/index.php?/Knowledgebase/Article/View/1277/0/startpage-ceo-robert-beens-discusses-the-investment-from-privacy-one--system1>Warning</a>:Startpage.com was recently acquired by United States-based System1."
+website="https://www.startpage.com/"
+privacy-policy="https://www.startpage.com/en/privacy-policy/"
+forum="https://forum.privacytools.io/t/delisted-discussion-startpage/284"
 %}
 
 <h3>Worth Mentioning</h3>


### PR DESCRIPTION
Startpage listing cleanup:

- Use correct branding (**Startpage.com** vs StartPage)
- Alphabetizes listings (besides Searx, a metasearch software platform rather than a provider)
- Changes "obsessive" description to a more neutral tone: `Startpage BV is a Netherlands-based company that has been dedicated to privacy-respecting search since 2006.`