### PR TITLE
fixed missing link code

### DIFF
--- a/_includes/sections/browser-fingerprint.html
+++ b/_includes/sections/browser-fingerprint.html
@@ -4,10 +4,10 @@
   Your Browser sends information that makes you unique amongst millions of users and therefore easy to identify.
 </div>
 
-<p>When you visit a web page, your browser voluntarily sends information about its configuration, such as available fonts, browser type, and add-ons. If this combination of information is unique, it may be possible to identify and track you without using cookies. EFF created a Tool called <a href="https://panopticlick.eff.org/">Panopticlick</a> to test your browser to see how unique it is.</p>
+<p>When you visit a web page, your browser voluntarily sends information about its configuration, such as available fonts, browser type, and add-ons. If this combination of information is unique, it may be possible to identify and track you without using cookies. EFF created a Tool called <a href="https://panopticlick.eff.org/" target="_blank">Panopticlick</a> to test your browser to see how unique it is.</p>
 
 <p>
-<a class="btn btn-warning" href="https://panopticlick.eff.org/">
+<a class="btn btn-warning" target="_blank" href="https://panopticlick.eff.org/">
   Test your Browser now
 </a>
 </p>


### PR DESCRIPTION
closes #1899 

Adds target="_blank" to the panopticlick.eff.org links.